### PR TITLE
GH-21 Introduce a version catalog using the Gradle toml format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,17 +4,3 @@ plugins {
 
 group = "energy.eddie"
 version = "0.0.0"
-
-allprojects {
-    ext {
-        set("junitVersion", "5.9.2")
-    }
-    repositories {
-        mavenCentral()
-    }
-}
-
-
-
-
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+# See: https://docs.gradle.org/current/userguide/platforms.html#sub:conventional-dependencies-toml
+[versions]
+junit = "5.9.2"
+
+[libraries]
+# Aggregator artifact of junit5
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit"}
+
+[bundles]
+
+[plugins]


### PR DESCRIPTION
There are multiple ways to create a versions catalog.
I decided to use the TOML approach as it's the easiest way.
For all different approaches see [this](https://proandroiddev.com/gradle-version-catalogs-for-an-awesome-dependency-management-f2ba700ff894).
