### PR TITLE
NOISSUE Allow merge commit messages

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -10,5 +10,5 @@ jobs:
       - name: Check for referenced issue
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^((\#|GH\-|gh\-)[0-9]+|NOISSUE).+'
-          error: 'Commit message must reference an issue at the start or start with NOISSUE'
+          pattern: '^((\#|GH\-|gh\-)[0-9]+|NOISSUE|Merge).+'
+          error: 'Commit message must reference an issue at the start, start with NOISSUE, or start with Merge'


### PR DESCRIPTION
That's something that bothered me quiet some time.
The commit check only runs only on push, but if the latest commit is a merge commit, because a development branch was rebased from the main, the commit message check will fail.