### PR TITLE
GH-75 add EdaIdMapper interface and implement it in memory structures

### DIFF
--- a/region-connectors/region-connector-at/src/main/java/energy/eddie/regionconnector/at/eda/EdaIdMapper.java
+++ b/region-connectors/region-connector-at/src/main/java/energy/eddie/regionconnector/at/eda/EdaIdMapper.java
@@ -1,0 +1,46 @@
+package energy.eddie.regionconnector.at.eda;
+
+import jakarta.annotation.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Stores permissionId and connectionId as well as information needed to retrieve them.
+ */
+public interface EdaIdMapper {
+
+    /**
+     * Adds mapping info for the given conversationId and requestId.
+     * If the mapping info already exists, it will be overwritten.
+     * The mapping info can be retrieved by calling {@link #getMappingInfoForConversationIdOrRequestID(String, String)}.
+     * @param conversationId can be used to retrieve the mapping info as long as the messages from EDA are sent in the same process. Which should be the case for HistoricalMeteringData and MasterData but nor MeteringData.
+     * @param requestId can be used to retrieve the mapping info for all EDA messages that contain the requestId. Should only be the messages that are sent for the consent requests.
+     * @param mappingInfo the mapping info to be added
+     */
+    void addMappingInfo(String conversationId, String requestId, MappingInfo mappingInfo);
+
+    /**
+     * Adds mapping info for the given consentId.
+     * The requestId is used to look up the existing mapping info.
+     * The mapping info can be retrieved by calling {@link #getMappingInfoForConsentId(String)}.
+     * @param consentId uniquely identifies the given consent
+     * @param requestId can be used to retrieve the mapping info for all EDA messages that contain the requestId. Should only be the messages that are sent for the consent requests.
+     * @return true if the mapping was added successfully, false if no mapping for the given requestId exists
+     */
+    boolean addMappingForConsentId(String consentId,String requestId);
+
+    /**
+     * Retrieves the mapping info for the given conversationId or requestId.
+     * @param conversationId can be used to retrieve the mapping info as long as the messages from EDA are sent in the same process. Which should be the case for HistoricalMeteringData and MasterData but nor MeteringData.
+     * @param requestId can be used to retrieve the mapping info for all EDA messages that contain the requestId. Should only be the messages that are sent for the consent requests.
+     * @return the mapping info if it exists, empty otherwise
+     */
+    Optional<MappingInfo> getMappingInfoForConversationIdOrRequestID(String conversationId, @Nullable String requestId);
+
+    /**
+     * Retrieves the mapping info for the given consentId.
+     * @param consentId uniquely identifies the given consent
+     * @return the mapping info if it exists, empty otherwise
+     */
+    Optional<MappingInfo> getMappingInfoForConsentId(String consentId);
+}

--- a/region-connectors/region-connector-at/src/main/java/energy/eddie/regionconnector/at/eda/InMemoryEdaIdMapper.java
+++ b/region-connectors/region-connector-at/src/main/java/energy/eddie/regionconnector/at/eda/InMemoryEdaIdMapper.java
@@ -1,0 +1,59 @@
+package energy.eddie.regionconnector.at.eda;
+
+import jakarta.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryEdaIdMapper implements EdaIdMapper {
+
+    private final ConcurrentMap<String, MappingInfo> requestIdToMappingInfo = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, MappingInfo> consentIdToMappingInfo = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, MappingInfo> conversationIdToMappingInfo = new ConcurrentHashMap<>();
+
+
+    @Override
+    public void addMappingInfo(String conversationId, String requestId, MappingInfo mappingInfo) {
+        requireNonNull(conversationId);
+        requireNonNull(requestId);
+        requireNonNull(mappingInfo);
+
+        requestIdToMappingInfo.put(requestId, mappingInfo);
+        conversationIdToMappingInfo.put(conversationId, mappingInfo);
+    }
+
+    @Override
+    public boolean addMappingForConsentId(String consentId, String requestId) {
+        requireNonNull(consentId);
+        requireNonNull(requestId);
+
+        var mappingInfo = requestIdToMappingInfo.get(requestId);
+        if (mappingInfo == null) {
+            return false;
+        }
+
+        consentIdToMappingInfo.put(consentId, mappingInfo);
+        return true;
+    }
+
+    @Override
+    public Optional<MappingInfo> getMappingInfoForConversationIdOrRequestID(String conversationId, @Nullable String requestId) {
+        var mappingInfo = conversationIdToMappingInfo.get(conversationId);
+
+        if (mappingInfo == null && requestId != null) {
+            mappingInfo = requestIdToMappingInfo.get(requestId);
+        }
+
+        return Optional.ofNullable(mappingInfo);
+    }
+
+    @Override
+    public Optional<MappingInfo> getMappingInfoForConsentId(String consentId) {
+        requireNonNull(consentId);
+
+        return Optional.ofNullable(consentIdToMappingInfo.get(consentId));
+    }
+}

--- a/region-connectors/region-connector-at/src/main/java/energy/eddie/regionconnector/at/eda/MappingInfo.java
+++ b/region-connectors/region-connector-at/src/main/java/energy/eddie/regionconnector/at/eda/MappingInfo.java
@@ -1,0 +1,5 @@
+package energy.eddie.regionconnector.at.eda;
+
+public record MappingInfo(String permissionId, String connectionId){
+
+}

--- a/region-connectors/region-connector-at/src/test/java/energy/eddie/regionconnector/at/eda/EdaIdMapperTest.java
+++ b/region-connectors/region-connector-at/src/test/java/energy/eddie/regionconnector/at/eda/EdaIdMapperTest.java
@@ -1,0 +1,153 @@
+package energy.eddie.regionconnector.at.eda;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+abstract class EdaIdMapperTest {
+
+    EdaIdMapper edaIdMapper; // add @BeforeEach in concrete class
+
+    @AfterEach
+    void tearDown() {
+        edaIdMapper = null;
+    }
+
+    @Test
+    void addMappingInfo_throwsIfParametersAreNull() {
+        assertThrows(NullPointerException.class, () -> edaIdMapper.addMappingInfo(null, "requestId", new MappingInfo("permissionId", "connectionId")));
+        assertThrows(NullPointerException.class, () -> edaIdMapper.addMappingInfo("conversationId", null, new MappingInfo("permissionId", "connectionId")));
+        assertThrows(NullPointerException.class, () -> edaIdMapper.addMappingInfo("conversationId", "requestId", null));
+    }
+
+    @Test
+    void addMappingInfo_addsMapping() {
+        var mappingInfo = new MappingInfo("permissionId", "connectionId");
+        var conversationId = "conversationId";
+        var requestId = "requestId";
+
+        edaIdMapper.addMappingInfo(conversationId, requestId, mappingInfo);
+
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConversationIdOrRequestID(conversationId, requestId);
+        assertTrue(mappingInfoOptional.isPresent());
+        assertEquals(mappingInfo, mappingInfoOptional.orElseThrow());
+    }
+
+    @Test
+    void addMappingInfo_OverridesExistingMapping() {
+        var mappingInfo = new MappingInfo("permissionId", "connectionId");
+        var mappingInfo2 = new MappingInfo("permissionId2", "connectionId2");
+        var conversationId = "conversationId";
+        var requestId = "requestId";
+
+        edaIdMapper.addMappingInfo(conversationId, requestId, mappingInfo);
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConversationIdOrRequestID(conversationId, requestId);
+        assertTrue(mappingInfoOptional.isPresent());
+        assertEquals(mappingInfo, mappingInfoOptional.orElseThrow());
+
+        edaIdMapper.addMappingInfo(conversationId, requestId, mappingInfo2);
+        mappingInfoOptional = edaIdMapper.getMappingInfoForConversationIdOrRequestID(conversationId, requestId);
+        assertTrue(mappingInfoOptional.isPresent());
+        assertEquals(mappingInfo2, mappingInfoOptional.orElseThrow());
+    }
+
+    @Test
+    void getMappingInfoForConversationIdOrRequestID_MappingInfoDoesNotExist_ReturnsEmpty() {
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConversationIdOrRequestID("nomatch", "nomatch");
+        assertFalse(mappingInfoOptional.isPresent());
+    }
+
+    @Test
+    void getMappingInfoForConversationIdOrRequestID_MappingInfoDoesNotExistRequestIdNull_ReturnsEmpty() {
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConversationIdOrRequestID("nomatch", null);
+        assertFalse(mappingInfoOptional.isPresent());
+    }
+
+    @Test
+    void getMappingInfoForConversationIdOrRequestID_MappingInfoExists_ReturnsMappingInfo() {
+        var mappingInfo = new MappingInfo("permissionId", "connectionId");
+        var conversationId = "conversationId";
+        var requestId = "requestId";
+
+        edaIdMapper.addMappingInfo(conversationId, requestId, mappingInfo);
+
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConversationIdOrRequestID(conversationId, requestId);
+        assertTrue(mappingInfoOptional.isPresent());
+        assertEquals(mappingInfo, mappingInfoOptional.orElseThrow());
+    }
+
+    @Test
+    void getMappingInfoForConversationIdOrRequestID_MappingInfoExistsRequestIdIsNull_ReturnsMappingInfo() {
+        var mappingInfo = new MappingInfo("permissionId", "connectionId");
+        var conversationId = "conversationId";
+        var requestId = "requestId";
+
+        edaIdMapper.addMappingInfo(conversationId, requestId, mappingInfo);
+
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConversationIdOrRequestID(conversationId, null);
+        assertTrue(mappingInfoOptional.isPresent());
+        assertEquals(mappingInfo, mappingInfoOptional.orElseThrow());
+    }
+
+    @Test
+    void getMappingInfoForConversationIdOrRequestID_MappingInfoExistsConversationIdHasNoMatch_ReturnsMappingInfo() {
+        var mappingInfo = new MappingInfo("permissionId", "connectionId");
+        var conversationId = "conversationId";
+        var requestId = "requestId";
+
+        edaIdMapper.addMappingInfo(conversationId, requestId, mappingInfo);
+
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConversationIdOrRequestID("nomatch", requestId);
+        assertTrue(mappingInfoOptional.isPresent());
+        assertEquals(mappingInfo, mappingInfoOptional.orElseThrow());
+    }
+
+    @Test
+    void addMappingForConsentId_throwsIfParametersAreNull() {
+        assertThrows(NullPointerException.class, () -> edaIdMapper.addMappingForConsentId(null, "requestId"));
+        assertThrows(NullPointerException.class, () -> edaIdMapper.addMappingForConsentId("conversationId", null));
+    }
+
+    @Test
+    void addMappingForConsentId_NoMappingExists_ReturnsFalse() {
+        var conversationId = "conversationId";
+        var requestId = "requestId";
+
+        var result = edaIdMapper.addMappingForConsentId(conversationId, requestId);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void addMappingForConsentId_MappingExists_ReturnsTrue() {
+        var conversationId = "conversationId";
+        var requestId = "requestId";
+
+        edaIdMapper.addMappingInfo(conversationId, requestId, new MappingInfo("permissionId", "connectionId"));
+        var result = edaIdMapper.addMappingForConsentId(conversationId, requestId);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void getMappingInfoForConsentId_MappingExists_ReturnsMappingInfo() {
+        var mappingInfo = new MappingInfo("permissionId", "connectionId");
+        var conversationId = "conversationId";
+        var requestId = "requestId";
+
+        edaIdMapper.addMappingInfo(conversationId, requestId, mappingInfo);
+        edaIdMapper.addMappingForConsentId(conversationId, requestId);
+
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConsentId(conversationId);
+        assertTrue(mappingInfoOptional.isPresent());
+        assertEquals(mappingInfo, mappingInfoOptional.orElseThrow());
+    }
+
+    @Test
+    void getMappingInfoForConsentId_MappingDoesNotExist_ReturnsEmpty() {
+        var mappingInfoOptional = edaIdMapper.getMappingInfoForConsentId("nomatch");
+        assertFalse(mappingInfoOptional.isPresent());
+    }
+
+}

--- a/region-connectors/region-connector-at/src/test/java/energy/eddie/regionconnector/at/eda/InMemoryEdaIdMapperTest.java
+++ b/region-connectors/region-connector-at/src/test/java/energy/eddie/regionconnector/at/eda/InMemoryEdaIdMapperTest.java
@@ -1,0 +1,11 @@
+package energy.eddie.regionconnector.at.eda;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class InMemoryEdaIdMapperTest extends EdaIdMapperTest {
+
+    @BeforeEach
+    void setUp() {
+        edaIdMapper = new InMemoryEdaIdMapper();
+    }
+}


### PR DESCRIPTION
Added an interface taht can store mapping information i.e. permission  ID and connection ID and provide ways to retrieve the mapping information using ids from messages we receive from EDA.

Implemented teh interface with non persistent in memory structs. Currently no way to remove Mapping as this is something that should happen in the background in the future and for this we need more information to vheck for how long we need to store this information.

See #75 .