### PR TITLE
GH-83 Remove code owner for the simulation connector

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,4 +17,3 @@ framework @eddie-energy/fh-dev
 
 # Region Connectors
 region-connectors/* @eddie-energy/fh-dev
-region-connectors/region-connector-simulation @h-carl


### PR DESCRIPTION
Changes to the simulation connector will no longer require a response from a single person, preventing PRs from being blocked if the person is unavailable.