### PR TITLE
Track VCS configuration to automatically enable issue navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ build
 ### IntelliJ
 .idea
 !.idea/prettier.xml
+!.idea/vcs.xml
 
 ### jte template generated files ###
 **/jte-classes

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="GH-(\d+)" />
+          <option name="linkRegexp" value="https://github.com/eddie-energy/eddie/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
As I have only tried this on my machine, please try if this works for you before approving.

The configuration was created by following the instructions for adding [Issue Navigation](https://www.jetbrains.com/help/idea/settings-version-control-issue-navigation.html) in Jetbrains IDEs.

Add a new Issue Navigation Link with

- Issue ID: `GH-(\d+)`
- Issue link: `https://github.com/eddie-energy/eddie/issues/$1`

![Jetbrains Add Issue Navigation Link](https://github.com/eddie-energy/eddie/assets/10999017/bf58d03f-1058-4b0a-a6e8-71ed496318ec)

Issue references will now link to the matching issue on the EDDIE repository.

![Issue Navigation Links](https://github.com/eddie-energy/eddie/assets/10999017/0e83b47f-0b7f-40ea-b879-a9d9c28fa4fc)
