### PR TITLE
Fix wrong property name in .properties files

### DIFF
--- a/framework/src/main/resources/application.properties
+++ b/framework/src/main/resources/application.properties
@@ -13,4 +13,4 @@ kafka.bootstrap.servers=localhost:9093
 # UUIDs from your Enedis application
 #region-connector.fr.enedis.client.id=UUID
 #region-connector.fr.enedis.client.secret=UUID
-region-connector.fr.enedis.client.basePath=https://ext.prod.api.enedis.fr
+region-connector.fr.enedis.basePath=https://ext.prod.api.enedis.fr

--- a/region-connectors/region-connector-fr-enedis/src/main/resources/example-regionconnector-fr-enedis.properties
+++ b/region-connectors/region-connector-fr-enedis/src/main/resources/example-regionconnector-fr-enedis.properties
@@ -1,3 +1,3 @@
 region-connector.fr.enedis.client.id=REPLACE_ME
 region-connector.fr.enedis.client.secret=REPLACE_ME
-region-connector.fr.enedis.client.basePath=https://ext.prod.api.enedis.fr
+region-connector.fr.enedis.basePath=https://ext.prod.api.enedis.fr


### PR DESCRIPTION
Accidentally prefixed the basePath property for enedis fir client.basePath