### PR TITLE
NOISSUE Fix EDA PermissionRequestFactory to properly include saving and messaging permission request decorators

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestAdapter.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestAdapter.java
@@ -83,4 +83,18 @@ public final class EdaPermissionRequestAdapter implements AtPermissionRequest {
     public void rejected() throws FutureStateException, PastStateException {
         adaptee.rejected();
     }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PermissionRequest) {
+            return edaPermissionRequest.equals(obj);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return edaPermissionRequest.hashCode();
+    }
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/PermissionRequestFactory.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/PermissionRequestFactory.java
@@ -6,6 +6,8 @@ import energy.eddie.regionconnector.at.api.AtPermissionRequest;
 import energy.eddie.regionconnector.at.api.AtPermissionRequestRepository;
 import energy.eddie.regionconnector.at.eda.EdaAdapter;
 import energy.eddie.regionconnector.at.eda.requests.CCMORequest;
+import energy.eddie.regionconnector.shared.permission.requests.decorators.MessagingPermissionRequest;
+import energy.eddie.regionconnector.shared.permission.requests.decorators.SavingPermissionRequest;
 import reactor.core.publisher.Sinks;
 
 public class PermissionRequestFactory {
@@ -22,10 +24,13 @@ public class PermissionRequestFactory {
 
     public AtPermissionRequest create(String connectionId, CCMORequest ccmoRequest) {
         AtPermissionRequest permissionRequest = new EdaPermissionRequest(connectionId, ccmoRequest, edaAdapter);
-        PermissionRequest savingPermissionRequest = new energy.eddie.regionconnector.shared.permission.requests.decorators.SavingPermissionRequest<>(permissionRequest, permissionRequestRepository);
-        PermissionRequest messagingPermissionRequest = new energy.eddie.regionconnector.shared.permission.requests.decorators.MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
-        return new EdaPermissionRequestAdapter(
+        PermissionRequest messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
+        PermissionRequest savingPermissionRequest = new SavingPermissionRequest<>(
                 new EdaPermissionRequestAdapter(permissionRequest, messagingPermissionRequest),
+                permissionRequestRepository
+        );
+        return new EdaPermissionRequestAdapter(
+                permissionRequest,
                 savingPermissionRequest
         );
     }

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestAdapterTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestAdapterTest.java
@@ -8,8 +8,7 @@ import energy.eddie.regionconnector.at.eda.permission.request.states.AtInvalidPe
 import energy.eddie.regionconnector.at.eda.requests.CCMORequest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 class EdaPermissionRequestAdapterTest {
@@ -190,6 +189,51 @@ class EdaPermissionRequestAdapterTest {
         // When
         // Then
         assertThrows(IllegalStateException.class, adapter::rejected);
+    }
+
+    @Test
+    void adapter_equalsReturnsTrueForPermissionRequest() {
+        // Given
+        AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        PermissionRequest decorator = new ThrowingPermissionRequest(request);
+        EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
+
+        // When
+        var res = adapter.equals(request);
+
+        // Then
+        assertTrue(res);
+    }
+
+    @Test
+    void adapter_equalsReturnsFalse() {
+        // Given
+        AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        PermissionRequest decorator = new ThrowingPermissionRequest(request);
+        EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
+
+        // When
+        var res = adapter.equals(new Object());
+
+        // Then
+        assertFalse(res);
+    }
+
+    @Test
+    void adapter_hashCodeIsEqualToPermissionRequestHashCode() {
+        // Given
+        AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        PermissionRequest decorator = new ThrowingPermissionRequest(request);
+        EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
+
+        // When
+        var res = adapter.hashCode();
+
+        // Then
+        assertEquals(request.hashCode(), res);
     }
 
     private record ThrowingPermissionRequest(PermissionRequest request) implements PermissionRequest {

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/PermissionRequestFactoryTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/PermissionRequestFactoryTest.java
@@ -1,15 +1,23 @@
 package energy.eddie.regionconnector.at.eda.permission.request;
 
 import energy.eddie.api.v0.ConnectionStatusMessage;
+import energy.eddie.api.v0.PermissionProcessStatus;
+import energy.eddie.api.v0.process.model.FutureStateException;
+import energy.eddie.api.v0.process.model.PastStateException;
 import energy.eddie.api.v0.process.model.PermissionRequest;
+import energy.eddie.regionconnector.at.api.AtPermissionRequest;
 import energy.eddie.regionconnector.at.api.AtPermissionRequestRepository;
 import energy.eddie.regionconnector.at.eda.EdaAdapter;
 import energy.eddie.regionconnector.at.eda.requests.CCMORequest;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class PermissionRequestFactoryTest {
     @Test
@@ -28,5 +36,58 @@ class PermissionRequestFactoryTest {
 
         // Then
         assertNotNull(permissionRequest);
+    }
+
+    @Test
+    void testCreatedPermissionRequest_isSaving() throws FutureStateException, PastStateException {
+        // Given
+        EdaAdapter edaAdapterMock = mock(EdaAdapter.class);
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
+        AtPermissionRequestRepository permissionRequestRepository = new InMemoryPermissionRequestRepository();
+        PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(edaAdapterMock, permissionStateMessages, permissionRequestRepository);
+
+        String connectionId = "connection123";
+        CCMORequest ccmoRequest = mock(CCMORequest.class);
+        when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
+        when(ccmoRequest.messageId()).thenReturn("messageId");
+        AtPermissionRequest permissionRequest = permissionRequestFactory.create(connectionId, ccmoRequest);
+        permissionRequestRepository.removeByPermissionId(permissionRequest.permissionId());
+
+        // When
+        permissionRequest.validate();
+
+        // Then
+        Optional<AtPermissionRequest> res = permissionRequestRepository.findByConversationIdOrCMRequestId("messageId", "cmRequestId");
+        assertEquals(permissionRequest, res.get());
+    }
+
+    @Test
+    void testCreatedPermissionRequest_isMessaging() throws FutureStateException, PastStateException {
+        // Given
+        EdaAdapter edaAdapterMock = mock(EdaAdapter.class);
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
+        AtPermissionRequestRepository permissionRequestRepository = new InMemoryPermissionRequestRepository();
+        PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(edaAdapterMock, permissionStateMessages, permissionRequestRepository);
+
+        String connectionId = "connection123";
+        CCMORequest ccmoRequest = mock(CCMORequest.class);
+        when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
+        when(ccmoRequest.messageId()).thenReturn("messageId");
+        AtPermissionRequest permissionRequest = permissionRequestFactory.create(connectionId, ccmoRequest);
+
+        // When
+        permissionRequest.validate();
+        permissionStateMessages.tryEmitComplete();
+
+        // Then
+        StepVerifier.create(permissionStateMessages.asFlux())
+                .consumeNextWith(cr -> {
+                })
+                .assertNext(cr -> assertAll(
+                        () -> assertEquals(PermissionProcessStatus.VALIDATED, cr.status()),
+                        () -> assertEquals(permissionRequest.permissionId(), cr.permissionId()),
+                        () -> assertEquals(permissionRequest.connectionId(), cr.connectionId())
+                ))
+                .verifyComplete();
     }
 }

--- a/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequest.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequest.java
@@ -81,6 +81,19 @@ public class MessagingPermissionRequest<T extends PermissionRequest> implements 
         emitState(PermissionProcessStatus.REJECTED);
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PermissionRequest) {
+            return permissionRequest.equals(obj);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return permissionRequest.hashCode();
+    }
+
     private void emitState(PermissionProcessStatus processStatus) {
         permissionStateMessages.tryEmitNext(
                 new ConnectionStatusMessage(

--- a/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequest.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequest.java
@@ -70,6 +70,19 @@ public class SavingPermissionRequest<T extends PermissionRequest> implements Per
         executeAndSave(permissionRequest::rejected);
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PermissionRequest) {
+            return permissionRequest.equals(obj);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return permissionRequest.hashCode();
+    }
+
     private void executeAndSave(Transition transition) throws FutureStateException, PastStateException {
         transition.transit();
         permissionRequestRepository.save(permissionRequest);

--- a/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequestTest.java
+++ b/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequestTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class MessagingPermissionRequestTest {
     @Test
@@ -230,5 +229,47 @@ class MessagingPermissionRequestTest {
                         () -> assertEquals("connectionId", cr.connectionId())
                 ))
                 .verifyComplete();
+    }
+
+    @Test
+    void messagingPermissionRequest_equalsReturnsTrueForDecoratee() {
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
+        SimpleState createdState = new SimpleState();
+        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
+
+        // When
+        var res = messagingPermissionRequest.equals(permissionRequest);
+
+        // Then
+        assertTrue(res);
+    }
+
+    @Test
+    void messagingPermissionRequest_equalsReturnsFalse() {
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
+        SimpleState createdState = new SimpleState();
+        PermissionRequest permissionRequest1 = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest1, permissionStateMessages);
+
+        // When
+        var res = messagingPermissionRequest.equals(new Object());
+
+        // Then
+        assertFalse(res);
+    }
+
+    @Test
+    void messagingPermissionRequest_hashCodeIsSameForDecoratee() {
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
+        SimpleState createdState = new SimpleState();
+        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
+
+        // When
+        var res = messagingPermissionRequest.hashCode();
+
+        // Then
+        assertEquals(permissionRequest.hashCode(), res);
     }
 }

--- a/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequestTest.java
+++ b/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequestTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SavingPermissionRequestTest {
     @Test
@@ -168,6 +167,52 @@ class SavingPermissionRequestTest {
         savingPermissionRequest.terminate();
 
         assertTrue(repo.findByPermissionId("permissionId").isPresent());
+    }
+
+
+    @Test
+    void savingPermissionRequest_equalsReturnsTrueForDecoratee() {
+        // Given
+        PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
+        SimpleState createdState = new SimpleState();
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
+
+        // When
+        var res = savingPermissionRequest.equals(permissionRequest);
+
+        // Then
+        assertTrue(res);
+    }
+
+    @Test
+    void savingPermissionRequest_equalsReturnsFalse() {
+        // Given
+        PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
+        SimpleState createdState = new SimpleState();
+        var permissionRequest1 = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest1, repo);
+
+        // When
+        var res = savingPermissionRequest.equals(new Object());
+
+        // Then
+        assertFalse(res);
+    }
+
+    @Test
+    void savingPermissionRequest_hashCodeIsSameForDecoratee() {
+        // Given
+        PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
+        SimpleState createdState = new SimpleState();
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
+
+        // When
+        var res = savingPermissionRequest.hashCode();
+
+        // Then
+        assertEquals(permissionRequest.hashCode(), res);
     }
 
     private final static class SimplePermissionRequestRepository implements PermissionRequestRepository<PermissionRequest> {


### PR DESCRIPTION
The way we constructed the PermissionRequest object in the PermissionRequestFactory was flawed.
This led to a bug where either the permission request is saved or state changes were propagated, but not both.
This PR also introduces tests, to check for this unwanted behavior.