### PR TITLE
GH-320 Update handling of CMRequestStatus messages

### DIFF
--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/EdaRegionConnectorTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/EdaRegionConnectorTest.java
@@ -1,19 +1,24 @@
 package energy.eddie.regionconnector.at.eda;
 
 import at.ebutilities.schemata.customerprocesses.consumptionrecord._01p30.*;
+import energy.eddie.api.v0.ConnectionStatusMessage;
 import energy.eddie.api.v0.HealthState;
 import energy.eddie.api.v0.PermissionProcessStatus;
 import energy.eddie.regionconnector.at.eda.config.AtConfiguration;
 import energy.eddie.regionconnector.at.eda.models.CMRequestStatus;
 import energy.eddie.regionconnector.at.eda.permission.request.EdaPermissionRequest;
+import energy.eddie.regionconnector.at.eda.permission.request.EdaPermissionRequestAdapter;
 import energy.eddie.regionconnector.at.eda.permission.request.InMemoryPermissionRequestRepository;
+import energy.eddie.regionconnector.at.eda.permission.request.PermissionRequestFactory;
 import energy.eddie.regionconnector.at.eda.permission.request.states.AtPendingAcknowledgmentPermissionRequestState;
 import energy.eddie.regionconnector.at.eda.permission.request.states.AtSentToPermissionAdministratorPermissionRequestState;
 import energy.eddie.regionconnector.at.eda.requests.CCMORequest;
 import energy.eddie.regionconnector.at.eda.xml.builders.helper.DateTimeConverter;
+import energy.eddie.regionconnector.shared.permission.requests.decorators.MessagingPermissionRequest;
 import org.junit.jupiter.api.Test;
 import reactor.adapter.JdkFlowAdapter;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 
@@ -115,35 +120,51 @@ class EdaRegionConnectorTest {
 
         StepVerifier.create(source)
                 .then(() -> testPublisher.emit(unmapableConsumptionRecord, consumptionRecord, consumptionRecord2))
-                .assertNext(cr -> {
-                    assertEquals("connId1", cr.getConnectionId());
-                    assertEquals("pmId1", cr.getPermissionId());
+                .assertNext(csm -> {
+                    assertEquals("connId1", csm.getConnectionId());
+                    assertEquals("pmId1", csm.getPermissionId());
                 })
-                .assertNext(cr -> {
-                    assertEquals("connId2", cr.getConnectionId());
-                    assertEquals("pmId2", cr.getPermissionId());
+                .assertNext(csm -> {
+                    assertEquals("connId2", csm.getConnectionId());
+                    assertEquals("pmId2", csm.getPermissionId());
                 })
                 .expectComplete().verify();
     }
 
 
     @Test
-    void subscribeToConnectionStatusMessagePublisher_returnsCorrectlyMappedMessages() throws TransmissionException {
+    void subscribeToConnectionStatusMessagePublisher_returnsAccepted_onAccepted() throws TransmissionException {
         var config = mock(AtConfiguration.class);
 
         var adapter = mock(EdaAdapter.class);
         TestPublisher<CMRequestStatus> testPublisher = TestPublisher.create();
         when(adapter.getCMRequestStatusStream()).thenReturn(testPublisher.flux());
 
-        var repo = new InMemoryPermissionRequestRepository();
-        repo.save(new SimplePermissionRequest("permissionId", "connectionId", "test", "test", null));
 
-        var uut = new EdaRegionConnector(config, adapter, repo);
+        CCMORequest ccmoRequest = mock(CCMORequest.class);
+        when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
+        when(ccmoRequest.messageId()).thenReturn("messageId");
+        var permissionRequest = new EdaPermissionRequest("connectionId", "permissionId", ccmoRequest, null);
+        permissionRequest.changeState(new AtSentToPermissionAdministratorPermissionRequestState(permissionRequest));
+
+        var repo = new InMemoryPermissionRequestRepository();
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().multicast().onBackpressureBuffer();
+        PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(adapter, permissionStateMessages, repo);
+
+        // wrap the request in a MessagingPermissionRequest to emit messages to the sink
+        var messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
+        repo.save(new EdaPermissionRequestAdapter(permissionRequest, messagingPermissionRequest));
+
+        var uut = new EdaRegionConnector(config, adapter, repo, permissionRequestFactory, permissionStateMessages);
 
         var source = JdkFlowAdapter.flowPublisherToFlux(uut.getConnectionStatusMessageStream());
-        var cmRequestStatus = new CMRequestStatus(CMRequestStatus.Status.ACCEPTED, "", "test");
+        var cmRequestStatus = new CMRequestStatus(CMRequestStatus.Status.ACCEPTED, "", "messageId");
 
         StepVerifier.create(source)
+                .assertNext(csm -> {
+                    // Creating the MessagingPermissionRequest adds a message to the sink
+                    assertEquals(PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR, csm.status());
+                })
                 .then(() -> {
                     testPublisher.emit(cmRequestStatus);
                     try {
@@ -152,9 +173,10 @@ class EdaRegionConnectorTest {
                         throw new RuntimeException(e);
                     }
                 })
-                .assertNext(cr -> {
-                    assertEquals("connectionId", cr.connectionId());
-                    assertEquals("permissionId", cr.permissionId());
+                .assertNext(csm -> {
+                    assertEquals("connectionId", csm.connectionId());
+                    assertEquals("permissionId", csm.permissionId());
+                    assertEquals(PermissionProcessStatus.ACCEPTED, csm.status());
                 })
                 .expectComplete()
                 .verify();
@@ -205,14 +227,23 @@ class EdaRegionConnectorTest {
         request.changeState(new AtSentToPermissionAdministratorPermissionRequestState(request));
 
         var repo = new InMemoryPermissionRequestRepository();
-        repo.save(request);
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().multicast().onBackpressureBuffer();
+        PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(adapter, permissionStateMessages, repo);
 
-        var uut = new EdaRegionConnector(config, adapter, repo);
+        // wrap the request in a MessagingPermissionRequest to emit messages to the sink
+        var messagingPermissionRequest = new MessagingPermissionRequest<>(request, permissionStateMessages);
+        repo.save(new EdaPermissionRequestAdapter(request, messagingPermissionRequest));
+
+        var uut = new EdaRegionConnector(config, adapter, repo, permissionRequestFactory, permissionStateMessages);
 
         var source = JdkFlowAdapter.flowPublisherToFlux(uut.getConnectionStatusMessageStream());
         var cmRequestStatus = new CMRequestStatus(CMRequestStatus.Status.ERROR, "", "messageId");
 
         StepVerifier.create(source)
+                .assertNext(csm -> {
+                    // Creating the MessagingPermissionRequest adds a message to the sink
+                    assertEquals(PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR, csm.status());
+                })
                 .then(() -> {
                     testPublisher.emit(cmRequestStatus);
                     try {
@@ -221,10 +252,10 @@ class EdaRegionConnectorTest {
                         throw new RuntimeException(e);
                     }
                 })
-                .assertNext(cr -> {
-                    assertEquals("connectionId", cr.connectionId());
-                    assertEquals("permissionId", cr.permissionId());
-                    assertEquals(PermissionProcessStatus.INVALID, cr.status());
+                .assertNext(csm -> {
+                    assertEquals("connectionId", csm.connectionId());
+                    assertEquals("permissionId", csm.permissionId());
+                    assertEquals(PermissionProcessStatus.INVALID, csm.status());
                 })
                 .expectComplete()
                 .verify();
@@ -245,14 +276,23 @@ class EdaRegionConnectorTest {
         request.changeState(new AtSentToPermissionAdministratorPermissionRequestState(request));
 
         var repo = new InMemoryPermissionRequestRepository();
-        repo.save(request);
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().multicast().onBackpressureBuffer();
+        PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(adapter, permissionStateMessages, repo);
 
-        var uut = new EdaRegionConnector(config, adapter, repo);
+        // wrap the request in a MessagingPermissionRequest to emit messages to the sink
+        var messagingPermissionRequest = new MessagingPermissionRequest<>(request, permissionStateMessages);
+        repo.save(new EdaPermissionRequestAdapter(request, messagingPermissionRequest));
+
+        var uut = new EdaRegionConnector(config, adapter, repo, permissionRequestFactory, permissionStateMessages);
 
         var source = JdkFlowAdapter.flowPublisherToFlux(uut.getConnectionStatusMessageStream());
         var cmRequestStatus = new CMRequestStatus(CMRequestStatus.Status.REJECTED, "", "messageId");
 
         StepVerifier.create(source)
+                .assertNext(csm -> {
+                    // Creating the MessagingPermissionRequest adds a message to the sink
+                    assertEquals(PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR, csm.status());
+                })
                 .then(() -> {
                     testPublisher.emit(cmRequestStatus);
                     try {
@@ -261,17 +301,17 @@ class EdaRegionConnectorTest {
                         throw new RuntimeException(e);
                     }
                 })
-                .assertNext(cr -> {
-                    assertEquals("connectionId", cr.connectionId());
-                    assertEquals("permissionId", cr.permissionId());
-                    assertEquals(PermissionProcessStatus.REJECTED, cr.status());
+                .assertNext(csm -> {
+                    assertEquals("connectionId", csm.connectionId());
+                    assertEquals("permissionId", csm.permissionId());
+                    assertEquals(PermissionProcessStatus.REJECTED, csm.status());
                 })
                 .expectComplete()
                 .verify();
     }
 
     @Test
-    void subscribeToConnectionStatusMessagePublisher_returnsSentToPermissionAdmin_onSent() throws TransmissionException {
+    void subscribeToConnectionStatusMessagePublisher_returnsPendingAcknowledgement_onSentAndonDelivered() throws TransmissionException {
         var config = mock(AtConfiguration.class);
 
         var adapter = mock(EdaAdapter.class);
@@ -285,28 +325,34 @@ class EdaRegionConnectorTest {
         request.changeState(new AtPendingAcknowledgmentPermissionRequestState(request));
 
         var repo = new InMemoryPermissionRequestRepository();
-        repo.save(request);
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().multicast().onBackpressureBuffer();
+        PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(adapter, permissionStateMessages, repo);
 
-        var uut = new EdaRegionConnector(config, adapter, repo);
+        // wrap the request in a MessagingPermissionRequest to emit messages to the sink
+        var messagingPermissionRequest = new MessagingPermissionRequest<>(request, permissionStateMessages);
+        repo.save(new EdaPermissionRequestAdapter(request, messagingPermissionRequest));
+
+        var uut = new EdaRegionConnector(config, adapter, repo, permissionRequestFactory, permissionStateMessages);
 
         var source = JdkFlowAdapter.flowPublisherToFlux(uut.getConnectionStatusMessageStream());
-        var cmRequestStatus = new CMRequestStatus(CMRequestStatus.Status.SENT, "", "messageId");
+        var cmRequestStatusSent = new CMRequestStatus(CMRequestStatus.Status.SENT, "", "messageId");
+        var cmRequestStatusDelivered = new CMRequestStatus(CMRequestStatus.Status.DELIVERED, "", "messageId");
 
         StepVerifier.create(source)
+                .assertNext(csm -> {
+                    // Creating the MessagingPermissionRequest adds a message to the sink
+                    assertEquals(PermissionProcessStatus.PENDING_PERMISSION_ADMINISTRATOR_ACKNOWLEDGEMENT, csm.status());
+                })
                 .then(() -> {
-                    testPublisher.emit(cmRequestStatus);
+                    testPublisher.emit(cmRequestStatusSent);
+                    testPublisher.emit(cmRequestStatusDelivered);
                     try {
                         uut.close();
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
                 })
-                .assertNext(cr -> {
-                    assertEquals("connectionId", cr.connectionId());
-                    assertEquals("permissionId", cr.permissionId());
-                    assertEquals(PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR, cr.status());
-                })
-                .expectComplete()
+                .expectComplete() // receiving SENT or DELIVERED should not change the state of the PermissionRequest and thus not emit a ConnectionStatusMessage
                 .verify();
     }
 
@@ -325,14 +371,23 @@ class EdaRegionConnectorTest {
         request.changeState(new AtPendingAcknowledgmentPermissionRequestState(request));
 
         var repo = new InMemoryPermissionRequestRepository();
-        repo.save(request);
+        Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().multicast().onBackpressureBuffer();
+        PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(adapter, permissionStateMessages, repo);
 
-        var uut = new EdaRegionConnector(config, adapter, repo);
+        // wrap the request in a MessagingPermissionRequest to emit messages to the sink
+        var messagingPermissionRequest = new MessagingPermissionRequest<>(request, permissionStateMessages);
+        repo.save(new EdaPermissionRequestAdapter(request, messagingPermissionRequest));
+
+        var uut = new EdaRegionConnector(config, adapter, repo, permissionRequestFactory, permissionStateMessages);
 
         var source = JdkFlowAdapter.flowPublisherToFlux(uut.getConnectionStatusMessageStream());
         var cmRequestStatus = new CMRequestStatus(CMRequestStatus.Status.RECEIVED, "", "messageId");
 
         StepVerifier.create(source)
+                .assertNext(csm -> {
+                    // Creating the MessagingPermissionRequest adds a message to the sink
+                    assertEquals(PermissionProcessStatus.PENDING_PERMISSION_ADMINISTRATOR_ACKNOWLEDGEMENT, csm.status());
+                })
                 .then(() -> {
                     testPublisher.emit(cmRequestStatus);
                     try {
@@ -341,10 +396,10 @@ class EdaRegionConnectorTest {
                         throw new RuntimeException(e);
                     }
                 })
-                .assertNext(cr -> {
-                    assertEquals("connectionId", cr.connectionId());
-                    assertEquals("permissionId", cr.permissionId());
-                    assertEquals(PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR, cr.status());
+                .assertNext(csm -> {
+                    assertEquals("connectionId", csm.connectionId());
+                    assertEquals("permissionId", csm.permissionId());
+                    assertEquals(PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR, csm.status());
                 })
                 .expectComplete()
                 .verify();


### PR DESCRIPTION
As described in #320, this PR updates the handling of CMRequestStatus updates.

Removed the part where `processIncomingCmStatusMessages` would emit states after changing the state, as this should happen in the `MessagingPermissionRequest` wrapper, it now only emits errors in case the order of state changes are not valid.

In the case of receiving SENT or DELIVERED, the state of the PermissionRequest itself is not changed.

Inlined the switch statement and moved the update to the permissionIdToConnectionStatusMessageMap into its own method so it can be easily removed once we get websockets working.