### PR TITLE
GH-324 Start Spring before anything else so config applies to everything

### DIFF
--- a/framework/src/main/java/energy/eddie/framework/Framework.java
+++ b/framework/src/main/java/energy/eddie/framework/Framework.java
@@ -53,6 +53,7 @@ public class Framework {
     }
 
     public void run(String[] args) {
+        FrameworkSpringConfig.main(args);
         LOGGER.info("Starting up EDDIE framework");
         var connectionStatusMessageStream = JdkFlowAdapter.publisherToFlowPublisher(permissionService.getConnectionStatusMessageStream());
         var consumptionRecordMessageStream = JdkFlowAdapter.publisherToFlowPublisher(consumptionRecordService.getConsumptionRecordStream());
@@ -62,7 +63,6 @@ public class Framework {
             applicationConnector.setConnectionStatusMessageStream(connectionStatusMessageStream);
             applicationConnector.setConsumptionRecordStream(consumptionRecordMessageStream);
         });
-        FrameworkSpringConfig.main(args);
         javalinApp.init();
     }
 


### PR DESCRIPTION
Changing the config level would only apply to spring stuff, not to the region connectors, because SPring was initialized after creating the region connectors