### PR TITLE
NOISSUE Make run-framework task depend on pnpm build

### DIFF
--- a/framework/build.gradle.kts
+++ b/framework/build.gradle.kts
@@ -110,6 +110,7 @@ tasks.getByName<Test>("test") {
 }
 
 tasks.register("run-framework", JavaExec::class) {
+    dependsOn(":pnpmBuild")
     mainModule.set("energy.eddie.framework")
     mainClass.set("energy.eddie.framework.Framework")
     classpath = sourceSets["main"].runtimeClasspath


### PR DESCRIPTION
Removes the need to remember building front-end elements on framework restarts.

Goerg asked me for it. Guess we have all been there.