### PR TITLE
GH-344 Add dataNeedId to all messages that are published via kafka

### DIFF
--- a/api/src/main/java/energy/eddie/api/v0/ConnectionStatusMessage.java
+++ b/api/src/main/java/energy/eddie/api/v0/ConnectionStatusMessage.java
@@ -8,17 +8,19 @@ import java.time.ZonedDateTime;
  *
  * @param connectionId id of the connection (a connectionId can be associated with multiple permissions)
  * @param permissionId unique id of the permission
+ * @param dataNeedId   id of the data need associated with the permission
  * @param timestamp    timestamp of the message
  * @param status       status of the message
  * @param message      contains additional information about the status
  */
 public record ConnectionStatusMessage(String connectionId, String permissionId,
+                                      String dataNeedId,
                                       ZonedDateTime timestamp, PermissionProcessStatus status,
                                       String message) {
 
 
-    public ConnectionStatusMessage(String connectionId, String permissionId, PermissionProcessStatus status) {
-        this(connectionId, permissionId, ZonedDateTime.now(ZoneId.systemDefault()), status, "");
+    public ConnectionStatusMessage(String connectionId, String permissionId, String dataNeedId, PermissionProcessStatus status) {
+        this(connectionId, permissionId, dataNeedId, ZonedDateTime.now(ZoneId.systemDefault()), status, "");
     }
 
 }

--- a/api/src/main/java/energy/eddie/api/v0/process/model/PermissionRequest.java
+++ b/api/src/main/java/energy/eddie/api/v0/process/model/PermissionRequest.java
@@ -25,6 +25,14 @@ public interface PermissionRequest {
      */
     String connectionId();
 
+
+    /**
+     * The dataNeedId identifies the data need that should be met by the permission request.
+     *
+     * @return dataNeedId
+     */
+    String dataNeedId();
+
     /**
      * The state of the permission request.
      *

--- a/api/src/main/schema.json/ConsumptionRecord.json
+++ b/api/src/main/schema.json/ConsumptionRecord.json
@@ -10,6 +10,10 @@
       "type": "string",
       "description": "Connection ID from the EP application, which uses it to associate consumption records with EP user."
     },
+    "dataNeedId": {
+      "type": "string",
+      "description": "The data need id that was used to request this consumption record."
+    },
     "permissionId": {
       "type": "string",
       "description": "The Persmission ID associates a ConsumptionRecord with a consent. It is unique per consent."

--- a/outbound-kafka/src/test/java/energy/eddie/outbound/kafka/CustomSerializerTest.java
+++ b/outbound-kafka/src/test/java/energy/eddie/outbound/kafka/CustomSerializerTest.java
@@ -34,8 +34,8 @@ class CustomSerializerTest {
     void testSerialize_StatusMessageData() {
         String topic = "test";
         ZonedDateTime now = ZonedDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        ConnectionStatusMessage data = new ConnectionStatusMessage("connectionId", "permissionId", now, PermissionProcessStatus.ACCEPTED, "Granted");
-        byte[] expected = "{\"connectionId\":\"connectionId\",\"permissionId\":\"permissionId\",\"timestamp\":1672531200.000000000,\"status\":\"ACCEPTED\",\"message\":\"Granted\"}"
+        ConnectionStatusMessage data = new ConnectionStatusMessage("connectionId", "permissionId", "dataNeedId", now, PermissionProcessStatus.ACCEPTED, "Granted");
+        byte[] expected = "{\"connectionId\":\"connectionId\",\"permissionId\":\"permissionId\",\"dataNeedId\":\"dataNeedId\",\"timestamp\":1672531200.000000000,\"status\":\"ACCEPTED\",\"message\":\"Granted\"}"
                 .getBytes(StandardCharsets.UTF_8);
 
         byte[] result = customSerializer.serialize(topic, data);

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ConsumptionRecordMapper.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ConsumptionRecordMapper.java
@@ -31,15 +31,20 @@ public class ConsumptionRecordMapper {
      * @param externalConsumptionRecord The external consumption record to map
      * @param permissionId              The permissionId to set on the mapped consumption record
      * @param connectionId              The connectionId to set on the mapped consumption record
+     * @param dataNeedId                The dataNeedId to set on the mapped consumption record
      * @return a CIM consumption record
      * @throws InvalidMappingException if the mapping cant be completed because of invalid {@link ConsumptionRecord}. This can happen if the {@link ConsumptionRecord} is missing required fields such as Energy and EnergyData
      */
-    public energy.eddie.api.v0.ConsumptionRecord mapToCIM(ConsumptionRecord externalConsumptionRecord, @Nullable String permissionId, @Nullable String connectionId) throws InvalidMappingException {
+    public energy.eddie.api.v0.ConsumptionRecord mapToCIM(ConsumptionRecord externalConsumptionRecord,
+                                                          @Nullable String permissionId,
+                                                          @Nullable String connectionId,
+                                                          @Nullable String dataNeedId) throws InvalidMappingException {
         requireNonNull(externalConsumptionRecord);
 
         var consumptionRecord = new energy.eddie.api.v0.ConsumptionRecord();
         consumptionRecord.setPermissionId(permissionId); // permissionId is optional so setting null is ok
         consumptionRecord.setConnectionId(connectionId); // connectionId is optional so setting null is ok
+        consumptionRecord.setDataNeedId(dataNeedId); // dataNeedId is optional so setting null is ok
 
         var crEnergy = externalConsumptionRecord.getProcessDirectory().getEnergy().stream().findFirst().orElseThrow(() -> new InvalidMappingException("No Energy found in ProcessDirectory of ConsumptionRecord"));
         consumptionRecord.setMeteringPoint(externalConsumptionRecord.getProcessDirectory().getMeteringPoint());

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequest.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequest.java
@@ -14,15 +14,17 @@ public class EdaPermissionRequest implements AtPermissionRequest {
     private final String permissionId;
     private final String cmRequestId;
     private final String conversationId;
+    private final String dataNeedId;
     private PermissionRequestState state;
 
-    public EdaPermissionRequest(String connectionId, CCMORequest ccmoRequest, EdaAdapter edaAdapter) {
-        this(connectionId, UUID.randomUUID().toString(), ccmoRequest, edaAdapter);
+    public EdaPermissionRequest(String connectionId, String dataNeedId, CCMORequest ccmoRequest, EdaAdapter edaAdapter) {
+        this(connectionId, UUID.randomUUID().toString(), dataNeedId, ccmoRequest, edaAdapter);
     }
 
-    public EdaPermissionRequest(String connectionId, String permissionId, CCMORequest ccmoRequest, EdaAdapter edaAdapter) {
+    public EdaPermissionRequest(String connectionId, String permissionId, String dataNeedId, CCMORequest ccmoRequest, EdaAdapter edaAdapter) {
         this.connectionId = connectionId;
         this.permissionId = permissionId;
+        this.dataNeedId = dataNeedId;
         this.cmRequestId = ccmoRequest.cmRequestId();
         this.conversationId = ccmoRequest.messageId();
         this.state = new AtCreatedPermissionRequestState(this, ccmoRequest, edaAdapter);
@@ -36,6 +38,11 @@ public class EdaPermissionRequest implements AtPermissionRequest {
     @Override
     public String connectionId() {
         return connectionId;
+    }
+
+    @Override
+    public String dataNeedId() {
+        return dataNeedId;
     }
 
     @Override
@@ -66,6 +73,7 @@ public class EdaPermissionRequest implements AtPermissionRequest {
 
         if (!Objects.equals(connectionId, that.connectionId())) return false;
         if (!Objects.equals(permissionId, that.permissionId())) return false;
+        if (!Objects.equals(dataNeedId, that.dataNeedId())) return false;
         if (!Objects.equals(cmRequestId, that.cmRequestId())) return false;
         if (!Objects.equals(conversationId, that.conversationId())) return false;
         return Objects.equals(state.getClass(), that.state().getClass());
@@ -75,6 +83,7 @@ public class EdaPermissionRequest implements AtPermissionRequest {
     public int hashCode() {
         int result = connectionId != null ? connectionId.hashCode() : 0;
         result = 31 * result + (permissionId != null ? permissionId.hashCode() : 0);
+        result = 31 * result + (dataNeedId != null ? dataNeedId.hashCode() : 0);
         result = 31 * result + (cmRequestId != null ? cmRequestId.hashCode() : 0);
         result = 31 * result + (conversationId != null ? conversationId.hashCode() : 0);
         result = 31 * result + (state != null ? state.getClass().hashCode() : 0);

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestAdapter.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestAdapter.java
@@ -30,6 +30,11 @@ public final class EdaPermissionRequestAdapter implements AtPermissionRequest {
     }
 
     @Override
+    public String dataNeedId() {
+        return edaPermissionRequest.dataNeedId();
+    }
+
+    @Override
     public PermissionRequestState state() {
         return edaPermissionRequest.state();
     }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/PermissionRequestFactory.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/PermissionRequestFactory.java
@@ -22,8 +22,8 @@ public class PermissionRequestFactory {
         this.permissionRequestRepository = permissionRequestRepository;
     }
 
-    public AtPermissionRequest create(String connectionId, CCMORequest ccmoRequest) {
-        AtPermissionRequest permissionRequest = new EdaPermissionRequest(connectionId, ccmoRequest, edaAdapter);
+    public AtPermissionRequest create(String connectionId, String dataNeedId, CCMORequest ccmoRequest) {
+        AtPermissionRequest permissionRequest = new EdaPermissionRequest(connectionId, dataNeedId, ccmoRequest, edaAdapter);
         PermissionRequest messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
         PermissionRequest savingPermissionRequest = new SavingPermissionRequest<>(
                 new EdaPermissionRequestAdapter(permissionRequest, messagingPermissionRequest),

--- a/region-connectors/region-connector-at-eda/src/main/web/permission-request-form.js
+++ b/region-connectors/region-connector-at-eda/src/main/web/permission-request-form.js
@@ -47,6 +47,7 @@ class PermissionRequestForm extends LitElement {
 
     formData.append("start", startDate.toISOString().substring(0, 10));
     formData.append("end", endDate.toISOString().substring(0, 10));
+    formData.append("dataNeedId", this.dataNeedAttributes.id);
 
     fetch(REQUEST_URL, {
       body: formData,
@@ -129,9 +130,9 @@ class PermissionRequestForm extends LitElement {
             </p>
 
             ${this.jumpOffUrl
-              ? html`<sl-button href="${this.jumpOffUrl}" target="_blank"
-                  >Visit permission administrator website</sl-button
-                >`
+              ? html` <sl-button href="${this.jumpOffUrl}" target="_blank">
+                  Visit permission administrator website
+                </sl-button>`
               : ""}
           </sl-alert>`}
       </div>

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ConsumptionRecordMapperTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ConsumptionRecordMapperTest.java
@@ -5,6 +5,7 @@ import energy.eddie.api.v0.ConsumptionPoint;
 import energy.eddie.regionconnector.at.eda.utils.ConversionFactor;
 import energy.eddie.regionconnector.at.eda.utils.DateTimeConstants;
 import energy.eddie.regionconnector.at.eda.xml.builders.helper.DateTimeConverter;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -36,6 +37,7 @@ class ConsumptionRecordMapperTest {
         var meteringPoint = "meteringPoint";
         var permissionId = "permissionId";
         var connectionId = "connectionId";
+        var dataNeedId = "dataNeedId";
         var expectedMeteringType = meteringType.equals("L1") ? ConsumptionPoint.MeteringType.MEASURED_VALUE : ConsumptionPoint.MeteringType.EXTRAPOLATED_VALUE;
         var conversionFactor = switch (unit) {
             case KWH -> ConversionFactor.KWH_TO_WH;
@@ -54,10 +56,11 @@ class ConsumptionRecordMapperTest {
 
         var uut = new ConsumptionRecordMapper();
 
-        var cimCR = uut.mapToCIM(edaCR, permissionId, connectionId);
+        var cimCR = uut.mapToCIM(edaCR, permissionId, connectionId, dataNeedId);
 
         assertEquals(permissionId, cimCR.getPermissionId());
         assertEquals(connectionId, cimCR.getConnectionId());
+        assertEquals(dataNeedId, cimCR.getDataNeedId());
         assertEquals(meteringPoint, cimCR.getMeteringPoint());
         assertNotNull(cimCR.getConsumptionPoints());
         assertEquals(expectedMeteringInterval, cimCR.getMeteringInterval());
@@ -72,7 +75,7 @@ class ConsumptionRecordMapperTest {
         edaCR.setProcessDirectory(new ProcessDirectory());
         var uut = new ConsumptionRecordMapper();
 
-        assertThrows(InvalidMappingException.class, () -> uut.mapToCIM(edaCR, null, null));
+        assertThrows(InvalidMappingException.class, () -> uut.mapToCIM(edaCR, null, null, null));
     }
 
     @Test
@@ -81,24 +84,25 @@ class ConsumptionRecordMapperTest {
         edaCR.getProcessDirectory().getEnergy().forEach(e -> e.getEnergyData().clear());
         var uut = new ConsumptionRecordMapper();
 
-        assertThrows(InvalidMappingException.class, () -> uut.mapToCIM(edaCR, null, null));
+        assertThrows(InvalidMappingException.class, () -> uut.mapToCIM(edaCR, null, null, null));
     }
 
     @Test
     void mapToCIM_EdaConsumptionRecordIsNull_throwsNullPointerException() {
         var uut = new ConsumptionRecordMapper();
 
-        assertThrows(NullPointerException.class, () -> uut.mapToCIM(null, null, null));
+        assertThrows(NullPointerException.class, () -> uut.mapToCIM(null, null, null, null));
     }
 
     @Test
-    void mapToCIM_mapsEDAConsumptionRecordWithSingleConsumptionPointWithNoConnectionAndNoPermissionId_asExpected() throws InvalidMappingException {
+    @DisplayName("mapToCIM maps EDA consumption record with permissionId, no connectionId and no dataNeedId as expected")
+    void mapToCIM_mapsEDAConsumptionRecordWithNullParameters_asExpected() throws InvalidMappingException {
         var meteringPoint = "meteringPoint";
         var edaCR = createConsumptionRecord(meteringPoint, "L1", ZonedDateTime.now(ZoneOffset.UTC), MeteringIntervall.QH, 1, UOMType.KWH);
 
         var uut = new ConsumptionRecordMapper();
 
-        var cimCR = uut.mapToCIM(edaCR, null, null);
+        var cimCR = uut.mapToCIM(edaCR, null, null, null);
 
         assertNull(cimCR.getPermissionId());
         assertNull(cimCR.getConnectionId());
@@ -116,7 +120,7 @@ class ConsumptionRecordMapperTest {
 
         var uut = new ConsumptionRecordMapper();
 
-        var cimCR = uut.mapToCIM(edaCR, null, null);
+        var cimCR = uut.mapToCIM(edaCR, null, null, null);
 
         assertNotNull(cimCR.getConsumptionPoints());
         assertEquals(1, cimCR.getConsumptionPoints().size());

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/EdaRegionConnectorTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/EdaRegionConnectorTest.java
@@ -108,8 +108,8 @@ class EdaRegionConnectorTest {
         when(adapter.getConsumptionRecordStream()).thenReturn(testPublisher.flux());
 
         var repo = new InMemoryPermissionRequestRepository();
-        repo.save(new SimplePermissionRequest("pmId1", "connId1", "test1", "any1", null));
-        repo.save(new SimplePermissionRequest("pmId2", "connId2", "test2", "any2", null));
+        repo.save(new SimplePermissionRequest("pmId1", "connId1", "dataNeedId1", "test1", "any1", null));
+        repo.save(new SimplePermissionRequest("pmId2", "connId2", "dataNeedId2", "test2", "any2", null));
 
         var uut = new EdaRegionConnector(config, adapter, repo);
 
@@ -123,10 +123,12 @@ class EdaRegionConnectorTest {
                 .assertNext(csm -> {
                     assertEquals("connId1", csm.getConnectionId());
                     assertEquals("pmId1", csm.getPermissionId());
+                    assertEquals("dataNeedId1", csm.getDataNeedId());
                 })
                 .assertNext(csm -> {
                     assertEquals("connId2", csm.getConnectionId());
                     assertEquals("pmId2", csm.getPermissionId());
+                    assertEquals("dataNeedId2", csm.getDataNeedId());
                 })
                 .expectComplete().verify();
     }
@@ -144,7 +146,7 @@ class EdaRegionConnectorTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var permissionRequest = new EdaPermissionRequest("connectionId", "permissionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "permissionId", "dataNeedId", ccmoRequest, null);
         permissionRequest.changeState(new AtSentToPermissionAdministratorPermissionRequestState(permissionRequest));
 
         var repo = new InMemoryPermissionRequestRepository();
@@ -191,7 +193,7 @@ class EdaRegionConnectorTest {
         when(adapter.getCMRequestStatusStream()).thenReturn(testPublisher.flux());
 
         var repo = new InMemoryPermissionRequestRepository();
-        repo.save(new SimplePermissionRequest("permissionId", "connectionId", "test", "test", null));
+        repo.save(new SimplePermissionRequest("permissionId", "connectionId", "dataNeedId", "test", "test", null));
 
         var uut = new EdaRegionConnector(config, adapter, repo);
 
@@ -223,7 +225,7 @@ class EdaRegionConnectorTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var request = new EdaPermissionRequest("connectionId", "permissionId", ccmoRequest, null);
+        var request = new EdaPermissionRequest("connectionId", "permissionId", "dataNeedId", ccmoRequest, null);
         request.changeState(new AtSentToPermissionAdministratorPermissionRequestState(request));
 
         var repo = new InMemoryPermissionRequestRepository();
@@ -272,7 +274,7 @@ class EdaRegionConnectorTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var request = new EdaPermissionRequest("connectionId", "permissionId", ccmoRequest, null);
+        var request = new EdaPermissionRequest("connectionId", "permissionId", "dataNeedId", ccmoRequest, null);
         request.changeState(new AtSentToPermissionAdministratorPermissionRequestState(request));
 
         var repo = new InMemoryPermissionRequestRepository();
@@ -367,7 +369,7 @@ class EdaRegionConnectorTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var request = new EdaPermissionRequest("connectionId", "permissionId", ccmoRequest, null);
+        var request = new EdaPermissionRequest("connectionId", "permissionId", "dataNeedId", ccmoRequest, null);
         request.changeState(new AtPendingAcknowledgmentPermissionRequestState(request));
 
         var repo = new InMemoryPermissionRequestRepository();

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/SimplePermissionRequest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/SimplePermissionRequest.java
@@ -3,12 +3,14 @@ package energy.eddie.regionconnector.at.eda;
 import energy.eddie.api.v0.process.model.PermissionRequestState;
 import energy.eddie.regionconnector.at.api.AtPermissionRequest;
 
-public record SimplePermissionRequest(String permissionId, String connectionId, String cmRequestId,
+public record SimplePermissionRequest(String permissionId, String connectionId,
+                                      String dataNeedId,
+                                      String cmRequestId,
                                       String conversationId,
                                       PermissionRequestState state) implements AtPermissionRequest {
 
     public SimplePermissionRequest(String permissionId, String connectionId) {
-        this(permissionId, connectionId, null, null, null);
+        this(permissionId, connectionId, null, null, null, null);
     }
 
     @Override
@@ -54,8 +56,7 @@ public record SimplePermissionRequest(String permissionId, String connectionId, 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof AtPermissionRequest)) return false;
-        AtPermissionRequest that = (AtPermissionRequest) o;
+        if (!(o instanceof AtPermissionRequest that)) return false;
         return permissionId.equals(that.permissionId()) && connectionId.equals(that.connectionId()) && cmRequestId.equals(that.cmRequestId()) && conversationId.equals(that.conversationId()) && state == that.state();
     }
 }

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestAdapterTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestAdapterTest.java
@@ -16,7 +16,7 @@ class EdaPermissionRequestAdapterTest {
     @Test
     void adapter_returnsPermissionId() {
         // Given
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", null);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", null);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -30,7 +30,7 @@ class EdaPermissionRequestAdapterTest {
     @Test
     void adapter_returnsConnectionId() {
         // Given
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", null);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", null);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -44,7 +44,7 @@ class EdaPermissionRequestAdapterTest {
     @Test
     void adapter_returnsCmRequestId() {
         // Given
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", null);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", null);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -56,9 +56,23 @@ class EdaPermissionRequestAdapterTest {
     }
 
     @Test
+    void adapter_returnsDataNeedId() {
+        // Given
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", null);
+        PermissionRequest decorator = new ThrowingPermissionRequest(request);
+        EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
+
+        // When
+        var dataNeedId = adapter.dataNeedId();
+
+        // Then
+        assertEquals("dataNeedId", dataNeedId);
+    }
+
+    @Test
     void adapter_returnsConversationId() {
         // Given
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", null);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", null);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -73,7 +87,7 @@ class EdaPermissionRequestAdapterTest {
     void adapter_returnsState() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -88,7 +102,7 @@ class EdaPermissionRequestAdapterTest {
     void adapter_changesState() {
         // Given
         CCMORequest ccmoRequest = mock(CCMORequest.class);
-        AtPermissionRequest permissionRequest = new EdaPermissionRequest("cid", ccmoRequest, null);
+        AtPermissionRequest permissionRequest = new EdaPermissionRequest("cid", "dataNeedId", ccmoRequest, null);
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
         PermissionRequest decorator = new ThrowingPermissionRequest(permissionRequest);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(permissionRequest, decorator);
@@ -104,7 +118,7 @@ class EdaPermissionRequestAdapterTest {
     void validateCallsDecorator() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -117,7 +131,7 @@ class EdaPermissionRequestAdapterTest {
     void sendToPermissionAdministratorCallsDecorator() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -130,7 +144,7 @@ class EdaPermissionRequestAdapterTest {
     void receivedPermissionAdministratorResponseCallsDecorator() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -143,7 +157,7 @@ class EdaPermissionRequestAdapterTest {
     void terminateCallsDecorator() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -156,7 +170,7 @@ class EdaPermissionRequestAdapterTest {
     void acceptCallsDecorator() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -169,7 +183,7 @@ class EdaPermissionRequestAdapterTest {
     void invalidCallsDecorator() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -182,7 +196,7 @@ class EdaPermissionRequestAdapterTest {
     void rejectedCallsDecorator() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -195,7 +209,7 @@ class EdaPermissionRequestAdapterTest {
     void adapter_equalsReturnsTrueForPermissionRequest() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -210,7 +224,7 @@ class EdaPermissionRequestAdapterTest {
     void adapter_equalsReturnsFalse() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -225,7 +239,7 @@ class EdaPermissionRequestAdapterTest {
     void adapter_hashCodeIsEqualToPermissionRequestHashCode() {
         // Given
         AtInvalidPermissionRequestState state = new AtInvalidPermissionRequestState(null);
-        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "cmId", "conversationId", state);
+        AtPermissionRequest request = new SimplePermissionRequest("pid", "cid", "dataNeedId", "cmId", "conversationId", state);
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         EdaPermissionRequestAdapter adapter = new EdaPermissionRequestAdapter(request, decorator);
 
@@ -246,6 +260,11 @@ class EdaPermissionRequestAdapterTest {
         @Override
         public String connectionId() {
             return request.connectionId();
+        }
+
+        @Override
+        public String dataNeedId() {
+            return request.dataNeedId();
         }
 
         @Override

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestTest.java
@@ -19,7 +19,7 @@ class EdaPermissionRequestTest {
     void edaPermissionRequest_hasCreatedStateAsInitialState() {
         // Given
         CCMORequest ccmoRequest = mock(CCMORequest.class);
-        PermissionRequest permissionRequest = new EdaPermissionRequest("cid", ccmoRequest, null);
+        PermissionRequest permissionRequest = new EdaPermissionRequest("cid", "dataNeedId", ccmoRequest, null);
 
         // When
         var state = permissionRequest.state();
@@ -33,7 +33,7 @@ class EdaPermissionRequestTest {
         // Given
         AtCreatedPermissionRequestState createdState = new AtCreatedPermissionRequestState(null, null, null);
         CCMORequest ccmoRequest = mock(CCMORequest.class);
-        PermissionRequest permissionRequest = new EdaPermissionRequest("cid", ccmoRequest, null);
+        PermissionRequest permissionRequest = new EdaPermissionRequest("cid", "dataNeedId", ccmoRequest, null);
 
         // When
         permissionRequest.changeState(createdState);
@@ -48,7 +48,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
 
         // When
         String cmRequestId = permissionRequest.cmRequestId();
@@ -63,7 +63,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
 
         // When
         String conversationId = permissionRequest.conversationId();
@@ -78,8 +78,8 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        PermissionRequest permissionRequest1 = new EdaPermissionRequest("connectionId", "pid", ccmoRequest, null);
-        PermissionRequest permissionRequest2 = new EdaPermissionRequest("connectionId", "pid", ccmoRequest, null);
+        PermissionRequest permissionRequest1 = new EdaPermissionRequest("connectionId", "pid", "dataNeedId", ccmoRequest, null);
+        PermissionRequest permissionRequest2 = new EdaPermissionRequest("connectionId", "pid", "dataNeedId", ccmoRequest, null);
 
         // When
         boolean res = permissionRequest1.equals(permissionRequest2);
@@ -196,8 +196,8 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        PermissionRequest permissionRequest1 = new EdaPermissionRequest("connectionId", "pid", ccmoRequest, null);
-        PermissionRequest permissionRequest2 = new EdaPermissionRequest("connectionId", "pid", ccmoRequest, null);
+        PermissionRequest permissionRequest1 = new EdaPermissionRequest("connectionId", "pid", "dataNeedId", ccmoRequest, null);
+        PermissionRequest permissionRequest2 = new EdaPermissionRequest("connectionId", "pid", "dataNeedId", ccmoRequest, null);
 
         // When
         int res1 = permissionRequest1.hashCode();
@@ -230,7 +230,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
 
         // When
         permissionRequest.validate();
@@ -246,7 +246,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, edaAdapter);
+        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, edaAdapter);
         permissionRequest.validate();
 
         // When
@@ -264,7 +264,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, edaAdapter);
+        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, edaAdapter);
         permissionRequest.validate();
         permissionRequest.sendToPermissionAdministrator();
 
@@ -282,7 +282,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, edaAdapter);
+        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, edaAdapter);
         permissionRequest.validate();
         permissionRequest.sendToPermissionAdministrator();
         permissionRequest.receivedPermissionAdministratorResponse();
@@ -301,7 +301,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, edaAdapter);
+        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, edaAdapter);
         permissionRequest.validate();
         permissionRequest.sendToPermissionAdministrator();
         permissionRequest.receivedPermissionAdministratorResponse();
@@ -320,7 +320,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, edaAdapter);
+        PermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, edaAdapter);
         permissionRequest.validate();
         permissionRequest.sendToPermissionAdministrator();
         permissionRequest.receivedPermissionAdministratorResponse();
@@ -339,7 +339,7 @@ class EdaPermissionRequestTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        AtPermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, edaAdapter);
+        AtPermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, edaAdapter);
         permissionRequest.changeState(new AtAcceptedPermissionRequestState(permissionRequest));
 
         // When

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/InMemoryPermissionRequestRepositoryTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/InMemoryPermissionRequestRepositoryTest.java
@@ -58,7 +58,7 @@ class InMemoryPermissionRequestRepositoryTest {
     void findByConversationIdAndCmRequestId_returnsEmptyOptional_ifIdsDoNotMatch() {
         // Given
         var repository = new InMemoryPermissionRequestRepository();
-        var request = new SimplePermissionRequest("permissionId1", "connectionId1", "rid1", "cid1", null);
+        var request = new SimplePermissionRequest("permissionId1", "connectionId1", "dataNeedId", "rid1", "cid1", null);
         repository.save(request);
 
         // When
@@ -72,7 +72,7 @@ class InMemoryPermissionRequestRepositoryTest {
     void findByConversationIdAndCmRequestId_returnsRequest_ifConversationIdMatches() {
         // Given
         var repository = new InMemoryPermissionRequestRepository();
-        var request = new SimplePermissionRequest("permissionId1", "connectionId1", "rid1", "cid1", null);
+        var request = new SimplePermissionRequest("permissionId1", "connectionId1", "dataNeedId", "rid1", "cid1", null);
         repository.save(request);
 
         // When
@@ -86,7 +86,7 @@ class InMemoryPermissionRequestRepositoryTest {
     void findByConversationIdAndCmRequestId_returnsRequest_ifCmRequestIdMatches() {
         // Given
         var repository = new InMemoryPermissionRequestRepository();
-        var request = new SimplePermissionRequest("permissionId1", "connectionId1", "rid1", "cid1", null);
+        var request = new SimplePermissionRequest("permissionId1", "connectionId1", "dataNeedId", "rid1", "cid1", null);
         repository.save(request);
 
         // When
@@ -100,7 +100,7 @@ class InMemoryPermissionRequestRepositoryTest {
     void removeByPermissionId_withNonExistentKey_returnsFalse() {
         // Given
         var repository = new InMemoryPermissionRequestRepository();
-        var request = new SimplePermissionRequest("permissionId1", "connectionId1", "rid1", "cid1", null);
+        var request = new SimplePermissionRequest("permissionId1", "connectionId1", "dataNeedId", "rid1", "cid1", null);
         repository.save(request);
 
         // When
@@ -114,7 +114,7 @@ class InMemoryPermissionRequestRepositoryTest {
     void removeByPermissionId_withExistingKey_returnsTrue() {
         // Given
         var repository = new InMemoryPermissionRequestRepository();
-        var request = new SimplePermissionRequest("permissionId", "connectionId1", "rid1", "cid1", null);
+        var request = new SimplePermissionRequest("permissionId", "connectionId1", "dataNeedId", "rid1", "cid1", null);
         repository.save(request);
 
         // When

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/PermissionRequestFactoryTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/PermissionRequestFactoryTest.java
@@ -29,10 +29,11 @@ class PermissionRequestFactoryTest {
         PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(edaAdapterMock, permissionStateMessages, permissionRequestRepository);
 
         String connectionId = "connection123";
+        String dataNeedId = "dataNeedId";
         CCMORequest ccmoRequest = mock(CCMORequest.class);
 
         // When
-        PermissionRequest permissionRequest = permissionRequestFactory.create(connectionId, ccmoRequest);
+        PermissionRequest permissionRequest = permissionRequestFactory.create(connectionId, dataNeedId, ccmoRequest);
 
         // Then
         assertNotNull(permissionRequest);
@@ -47,10 +48,11 @@ class PermissionRequestFactoryTest {
         PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(edaAdapterMock, permissionStateMessages, permissionRequestRepository);
 
         String connectionId = "connection123";
+        String dataNeedId = "dataNeedId";
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        AtPermissionRequest permissionRequest = permissionRequestFactory.create(connectionId, ccmoRequest);
+        AtPermissionRequest permissionRequest = permissionRequestFactory.create(connectionId, dataNeedId, ccmoRequest);
         permissionRequestRepository.removeByPermissionId(permissionRequest.permissionId());
 
         // When
@@ -70,10 +72,11 @@ class PermissionRequestFactoryTest {
         PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(edaAdapterMock, permissionStateMessages, permissionRequestRepository);
 
         String connectionId = "connection123";
+        String dataNeedId = "dataNeedId";
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        AtPermissionRequest permissionRequest = permissionRequestFactory.create(connectionId, ccmoRequest);
+        AtPermissionRequest permissionRequest = permissionRequestFactory.create(connectionId, dataNeedId, ccmoRequest);
 
         // When
         permissionRequest.validate();

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/states/CreatedPermissionRequestStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/states/CreatedPermissionRequestStateTest.java
@@ -20,7 +20,7 @@ class CreatedPermissionRequestStateTest {
         // Given
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.toCMRequest()).thenReturn(mock(CMRequest.class));
-        AtPermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        AtPermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
         AtCreatedPermissionRequestState permissionRequestState = new AtCreatedPermissionRequestState(permissionRequest, ccmoRequest, null);
 
         // When
@@ -35,7 +35,7 @@ class CreatedPermissionRequestStateTest {
         // Given
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.toCMRequest()).thenThrow(new InvalidDsoIdException("msg"));
-        AtPermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        AtPermissionRequest permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
         AtCreatedPermissionRequestState permissionRequestState = new AtCreatedPermissionRequestState(permissionRequest, ccmoRequest, null);
 
         // When

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/states/PendingAcknowledgmentPermissionRequestStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/states/PendingAcknowledgmentPermissionRequestStateTest.java
@@ -21,7 +21,7 @@ class PendingAcknowledgmentPermissionRequestStateTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("conversationId");
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, edaAdapter);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, edaAdapter);
         AtPendingAcknowledgmentPermissionRequestState state = new AtPendingAcknowledgmentPermissionRequestState(permissionRequest);
         permissionRequest.changeState(state);
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/states/SentToPermissionAdministratorPermissionRequestStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/states/SentToPermissionAdministratorPermissionRequestStateTest.java
@@ -19,7 +19,7 @@ class SentToPermissionAdministratorPermissionRequestStateTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
         AtSentToPermissionAdministratorPermissionRequestState state = new AtSentToPermissionAdministratorPermissionRequestState(permissionRequest);
         permissionRequest.changeState(state);
 
@@ -36,7 +36,7 @@ class SentToPermissionAdministratorPermissionRequestStateTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
         AtSentToPermissionAdministratorPermissionRequestState state = new AtSentToPermissionAdministratorPermissionRequestState(permissionRequest);
         permissionRequest.changeState(state);
 
@@ -53,7 +53,7 @@ class SentToPermissionAdministratorPermissionRequestStateTest {
         CCMORequest ccmoRequest = mock(CCMORequest.class);
         when(ccmoRequest.cmRequestId()).thenReturn("cmRequestId");
         when(ccmoRequest.messageId()).thenReturn("messageId");
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
         AtSentToPermissionAdministratorPermissionRequestState state = new AtSentToPermissionAdministratorPermissionRequestState(permissionRequest);
         permissionRequest.changeState(state);
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/states/ValidatedPermissionRequestStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/states/ValidatedPermissionRequestStateTest.java
@@ -23,7 +23,7 @@ class ValidatedPermissionRequestStateTest {
         // Given
         EdaAdapter edaAdapter = mock(EdaAdapter.class);
         CCMORequest ccmoRequest = mock(CCMORequest.class);
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
         AtValidatedPermissionRequestState state = new AtValidatedPermissionRequestState(permissionRequest, new CMRequest(), edaAdapter);
         permissionRequest.changeState(state);
 
@@ -40,7 +40,7 @@ class ValidatedPermissionRequestStateTest {
         EdaAdapter edaAdapter = mock(EdaAdapter.class);
         doThrow(new JAXBException("msg")).when(edaAdapter).sendCMRequest(any());
         CCMORequest ccmoRequest = mock(CCMORequest.class);
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
         AtValidatedPermissionRequestState state = new AtValidatedPermissionRequestState(permissionRequest, new CMRequest(), edaAdapter);
         permissionRequest.changeState(state);
 
@@ -57,7 +57,7 @@ class ValidatedPermissionRequestStateTest {
         EdaAdapter edaAdapter = mock(EdaAdapter.class);
         doThrow(new TransmissionException(new Exception())).when(edaAdapter).sendCMRequest(any());
         CCMORequest ccmoRequest = mock(CCMORequest.class);
-        var permissionRequest = new EdaPermissionRequest("connectionId", ccmoRequest, null);
+        var permissionRequest = new EdaPermissionRequest("connectionId", "dataNeedId", ccmoRequest, null);
         AtValidatedPermissionRequestState state = new AtValidatedPermissionRequestState(permissionRequest, new CMRequest(), edaAdapter);
         permissionRequest.changeState(state);
 

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/ConsumptionRecordMapper.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/ConsumptionRecordMapper.java
@@ -17,10 +17,11 @@ public class ConsumptionRecordMapper {
 
     public static final int CONVERSION_FACTOR = 1000;
 
-    public ConsumptionRecord mapToCIM(List<MeteringData> meteringData, @Nullable String permissionId, @Nullable String connectionId, MeasurementType measurementType) throws InvalidMappingException {
+    public ConsumptionRecord mapToCIM(List<MeteringData> meteringData, @Nullable String permissionId, @Nullable String connectionId, MeasurementType measurementType, @Nullable String dataNeedId) throws InvalidMappingException {
         ConsumptionRecord consumptionRecord = new ConsumptionRecord();
         consumptionRecord.setPermissionId(permissionId);
         consumptionRecord.setConnectionId(connectionId);
+        consumptionRecord.setDataNeedId(dataNeedId);
 
         if (meteringData.isEmpty()) {
             throw new InvalidMappingException("No metering data found");

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisScheduler.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisScheduler.java
@@ -147,7 +147,9 @@ public class DatadisScheduler {
                     meteringData,
                     permissionRequest.permissionId(),
                     permissionRequest.connectionId(),
-                    permissionRequest.measurementType());
+                    permissionRequest.measurementType(),
+                    permissionRequest.dataNeedId()
+            );
             consumptionRecordSink.tryEmitNext(consumptionRecord);
             return Mono.empty();
         } catch (InvalidMappingException e) {

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequest.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequest.java
@@ -31,6 +31,7 @@ public class DatadisPermissionRequest implements EsPermissionRequest {
     private final ZonedDateTime requestDataFrom;
     private final ZonedDateTime requestDataTo;
     private final MeasurementType measurementType;
+    private final String dataNeedId;
     private PermissionRequestState state;
     @Nullable
     private String distributorCode;
@@ -39,15 +40,17 @@ public class DatadisPermissionRequest implements EsPermissionRequest {
     @Nullable
     private ZonedDateTime lastPulledMeterReading;
 
-    public DatadisPermissionRequest(String permissionId, String connectionId, Context ctx, AuthorizationApi authorizationApi, AuthorizationResponseHandler authorizationResponseHandler) {
+    public DatadisPermissionRequest(String permissionId, String connectionId, String dataNeedId, Context ctx, AuthorizationApi authorizationApi, AuthorizationResponseHandler authorizationResponseHandler) {
         requireNonNull(permissionId);
         requireNonNull(connectionId);
+        requireNonNull(dataNeedId);
         requireNonNull(ctx);
         requireNonNull(authorizationApi);
         requireNonNull(authorizationResponseHandler);
 
         this.permissionId = permissionId;
         this.connectionId = connectionId;
+        this.dataNeedId = dataNeedId;
         this.state = new CreatedState(this, ctx, authorizationApi, authorizationResponseHandler);
         this.nif = ctx.formParam(NIF_KEY);
         this.meteringPointId = ctx.formParam(METERING_POINT_ID_KEY);
@@ -58,12 +61,12 @@ public class DatadisPermissionRequest implements EsPermissionRequest {
         this.measurementType = ctx.formParamAsClass(MEASUREMENT_TYPE_KEY, MeasurementType.class).getOrDefault(null);
     }
 
-    public DatadisPermissionRequest(String connectionId, Context ctx, AuthorizationApi authorizationApi, AuthorizationResponseHandler authorizationResponseHandler) {
-        this(UUID.randomUUID().toString(), connectionId, ctx, authorizationApi, authorizationResponseHandler);
+    public DatadisPermissionRequest(String connectionId, String dataNeedId, Context ctx, AuthorizationApi authorizationApi, AuthorizationResponseHandler authorizationResponseHandler) {
+        this(UUID.randomUUID().toString(), connectionId, dataNeedId, ctx, authorizationApi, authorizationResponseHandler);
     }
 
     public DatadisPermissionRequest(Context ctx, AuthorizationApi authorizationApi, AuthorizationResponseHandler authorizationResponseHandler) {
-        this(ctx.formParam(CONNECTION_ID_KEY), ctx, authorizationApi, authorizationResponseHandler);
+        this(ctx.formParam(CONNECTION_ID_KEY), ctx.formParam(DATA_NEED_ID_KEY), ctx, authorizationApi, authorizationResponseHandler);
     }
 
     /**
@@ -109,6 +112,11 @@ public class DatadisPermissionRequest implements EsPermissionRequest {
     @Override
     public String connectionId() {
         return connectionId;
+    }
+
+    @Override
+    public String dataNeedId() {
+        return dataNeedId;
     }
 
     @Override

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestAdapter.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestAdapter.java
@@ -34,6 +34,11 @@ public final class DatadisPermissionRequestAdapter implements EsPermissionReques
     }
 
     @Override
+    public String dataNeedId() {
+        return esPermissionRequest.dataNeedId();
+    }
+
+    @Override
     public PermissionRequestState state() {
         return esPermissionRequest.state();
     }

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/utils/ParameterKeys.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/utils/ParameterKeys.java
@@ -4,6 +4,7 @@ public class ParameterKeys {
 
     public static final String PERMISSION_ID_KEY = "permissionId";
     public static final String CONNECTION_ID_KEY = "connectionId";
+    public static final String DATA_NEED_ID_KEY = "dataNeedId";
 
     public static final String NIF_KEY = "nif";
     public static final String METERING_POINT_ID_KEY = "meteringPointId";

--- a/region-connectors/region-connector-es-datadis/src/main/web/permission-request-form.js
+++ b/region-connectors/region-connector-es-datadis/src/main/web/permission-request-form.js
@@ -22,6 +22,7 @@ class PermissionRequestForm extends LitElement {
   };
 
   intervalId = null;
+  permissionId = null;
 
   constructor() {
     super();
@@ -31,8 +32,6 @@ class PermissionRequestForm extends LitElement {
     this._isSubmitHidden = false;
     this._areResponseButtonsDisabled = false;
   }
-
-  permissionId = null;
 
   handleSubmit(event) {
     this._isSubmitDisabled = true;
@@ -57,6 +56,7 @@ class PermissionRequestForm extends LitElement {
 
     formData.append("start", startDate.toISOString().substring(0, 10));
     formData.append("end", endDate.toISOString().substring(0, 10));
+    formData.append("dataNeedId", this.dataNeedAttributes.id);
 
     fetch(REQUEST_URL, {
       body: formData,

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestAdapterTest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestAdapterTest.java
@@ -124,6 +124,18 @@ class DatadisPermissionRequestAdapterTest {
         assertEquals(nif, res);
     }
 
+    @Test
+    void adapter_returnsDataNeedId() {
+        String dataNeedId = "dataNeedId";
+        EsPermissionRequest request = SimplePermissionRequest.fromDataNeedId(dataNeedId);
+        PermissionRequest decorator = new ThrowingPermissionRequest(request);
+        DatadisPermissionRequestAdapter adapter = new DatadisPermissionRequestAdapter(request, decorator);
+
+        var res = adapter.dataNeedId();
+
+        assertEquals(dataNeedId, res);
+    }
+
 
     @Test
     void adapter_returnsMeteringPointId() {
@@ -248,6 +260,11 @@ class DatadisPermissionRequestAdapterTest {
         @Override
         public String connectionId() {
             return request.connectionId();
+        }
+
+        @Override
+        public String dataNeedId() {
+            return request.dataNeedId();
         }
 
         @Override

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestTest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestTest.java
@@ -69,7 +69,7 @@ class DatadisPermissionRequestTest {
 
         AuthorizationApi api = mock(AuthorizationApi.class);
         DatadisPermissionRequest request = new DatadisPermissionRequest(
-                "connectionId", ctx, api, mock(AuthorizationResponseHandler.class)
+                "connectionId", "dataNeedId", ctx, api, mock(AuthorizationResponseHandler.class)
         );
 
         assertNotNull(request.permissionId());
@@ -82,6 +82,7 @@ class DatadisPermissionRequestTest {
         Context ctx = mock(Context.class);
         when(ctx.formParamAsClass(anyString(), any())).thenReturn(nullValidator);
         when(ctx.formParam(CONNECTION_ID_KEY)).thenReturn(expectedConnectionId);
+        when(ctx.formParam(DATA_NEED_ID_KEY)).thenReturn("dataNeedId");
         AuthorizationApi api = mock(AuthorizationApi.class);
         DatadisPermissionRequest request = new DatadisPermissionRequest(
                 ctx, api, mock(AuthorizationResponseHandler.class)
@@ -93,7 +94,7 @@ class DatadisPermissionRequestTest {
     @Test
     void base_constructor_WithNullArguments_ThrowsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new DatadisPermissionRequest(
-                null, null, null, null
+                null, null, null, null, null
         ));
     }
 
@@ -120,10 +121,26 @@ class DatadisPermissionRequestTest {
         AuthorizationApi api = mock(AuthorizationApi.class);
 
         DatadisPermissionRequest request = new DatadisPermissionRequest(
-                "connectionId", ctx, api, mock(AuthorizationResponseHandler.class)
+                "connectionId", "dataNeedId", ctx, api, mock(AuthorizationResponseHandler.class)
         );
 
         assertEquals(expectedNif, request.nif());
+    }
+
+    @Test
+    void dataNeedId_Comes_From_Context() {
+        var expectedDataNeedId = "dataNeedId";
+        Context ctx = mock(Context.class);
+        when(ctx.formParam(DATA_NEED_ID_KEY)).thenReturn(expectedDataNeedId);
+        when(ctx.formParam(CONNECTION_ID_KEY)).thenReturn("connectionID");
+        when(ctx.formParamAsClass(anyString(), any())).thenReturn(nullValidator);
+        AuthorizationApi api = mock(AuthorizationApi.class);
+
+        DatadisPermissionRequest request = new DatadisPermissionRequest(
+                ctx, api, mock(AuthorizationResponseHandler.class)
+        );
+
+        assertEquals(expectedDataNeedId, request.dataNeedId());
     }
 
     @Test
@@ -135,7 +152,7 @@ class DatadisPermissionRequestTest {
         AuthorizationApi api = mock(AuthorizationApi.class);
 
         DatadisPermissionRequest request = new DatadisPermissionRequest(
-                "connectionId", ctx, api, mock(AuthorizationResponseHandler.class)
+                "connectionId", "dataNeedId", ctx, api, mock(AuthorizationResponseHandler.class)
         );
 
         assertEquals(expectedMetringPointId, request.meteringPointId());
@@ -152,7 +169,7 @@ class DatadisPermissionRequestTest {
         AuthorizationApi api = mock(AuthorizationApi.class);
 
         DatadisPermissionRequest request = new DatadisPermissionRequest(
-                "connectionId", ctx, api, mock(AuthorizationResponseHandler.class)
+                "connectionId", "dataNeedId", ctx, api, mock(AuthorizationResponseHandler.class)
         );
 
         assertEquals(expected, request.requestDataFrom());
@@ -169,7 +186,7 @@ class DatadisPermissionRequestTest {
         AuthorizationApi api = mock(AuthorizationApi.class);
 
         DatadisPermissionRequest request = new DatadisPermissionRequest(
-                "connectionId", ctx, api, mock(AuthorizationResponseHandler.class)
+                "connectionId", "dataNeedId", ctx, api, mock(AuthorizationResponseHandler.class)
         );
 
         assertEquals(expected, request.requestDataTo());
@@ -186,7 +203,7 @@ class DatadisPermissionRequestTest {
         AuthorizationApi api = mock(AuthorizationApi.class);
 
         DatadisPermissionRequest request = new DatadisPermissionRequest(
-                "connectionId", ctx, api, mock(AuthorizationResponseHandler.class)
+                "connectionId", "dataNeedId", ctx, api, mock(AuthorizationResponseHandler.class)
         );
 
         assertEquals(expected, request.measurementType());
@@ -203,7 +220,7 @@ class DatadisPermissionRequestTest {
         AuthorizationApi api = mock(AuthorizationApi.class);
 
         DatadisPermissionRequest request = new DatadisPermissionRequest(
-                "connectionId", ctx, api, mock(AuthorizationResponseHandler.class)
+                "connectionId", "dataNeedId", ctx, api, mock(AuthorizationResponseHandler.class)
         );
 
         assertEquals(request.requestDataTo(), request.permissionEnd());
@@ -220,7 +237,7 @@ class DatadisPermissionRequestTest {
         AuthorizationApi api = mock(AuthorizationApi.class);
 
         DatadisPermissionRequest request = new DatadisPermissionRequest(
-                "connectionId", ctx, api, mock(AuthorizationResponseHandler.class)
+                "connectionId", "dataNeedId", ctx, api, mock(AuthorizationResponseHandler.class)
         );
 
         assertEquals(request.permissionStart(), request.permissionEnd());

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/SimplePermissionRequest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/SimplePermissionRequest.java
@@ -16,6 +16,7 @@ public class SimplePermissionRequest implements EsPermissionRequest {
     private ZonedDateTime permissionEnd;
     private PermissionRequestState state;
     private String nif;
+    private String dataNeedId;
     private String meteringPointId;
     private ZonedDateTime lastPulledMeterReading;
     private MeasurementType measurementType;
@@ -63,6 +64,12 @@ public class SimplePermissionRequest implements EsPermissionRequest {
         return request;
     }
 
+    static public SimplePermissionRequest fromDataNeedId(String dataNeedId) {
+        var request = new SimplePermissionRequest();
+        request.dataNeedId = dataNeedId;
+        return request;
+    }
+
     public static EsPermissionRequest fromLastPulledMeterReading(ZonedDateTime start) {
         var request = new SimplePermissionRequest();
         request.lastPulledMeterReading = start;
@@ -77,6 +84,11 @@ public class SimplePermissionRequest implements EsPermissionRequest {
     @Override
     public String connectionId() {
         return connectionId;
+    }
+
+    @Override
+    public String dataNeedId() {
+        return dataNeedId;
     }
 
     @Override

--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/RequestInfo.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/RequestInfo.java
@@ -2,5 +2,5 @@ package energy.eddie.regionconnector.fr.enedis;
 
 import java.time.ZonedDateTime;
 
-public record RequestInfo(String connectionId, ZonedDateTime start, ZonedDateTime end) {
+public record RequestInfo(String connectionId, String dataNeedId, ZonedDateTime start, ZonedDateTime end) {
 }

--- a/region-connectors/region-connector-fr-enedis/src/main/web/permission-request-form.js
+++ b/region-connectors/region-connector-fr-enedis/src/main/web/permission-request-form.js
@@ -45,6 +45,7 @@ class PermissionRequestForm extends LitElement {
 
     formData.append("start", startDate.toISOString().substring(0, 10));
     formData.append("end", endDate.toISOString().substring(0, 10));
+    formData.append("dataNeedId", this.dataNeedAttributes.id);
 
     fetch(REQUEST_URL, {
       body: formData,

--- a/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequest.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequest.java
@@ -29,6 +29,11 @@ public class MessagingPermissionRequest<T extends PermissionRequest> implements 
     }
 
     @Override
+    public String dataNeedId() {
+        return permissionRequest.dataNeedId();
+    }
+
+    @Override
     public PermissionRequestState state() {
         return permissionRequest.state();
     }
@@ -98,6 +103,7 @@ public class MessagingPermissionRequest<T extends PermissionRequest> implements 
                 new ConnectionStatusMessage(
                         connectionId(),
                         permissionId(),
+                        dataNeedId(),
                         permissionRequest.state().status()
                 )
         );

--- a/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequest.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequest.java
@@ -26,6 +26,11 @@ public class SavingPermissionRequest<T extends PermissionRequest> implements Per
     }
 
     @Override
+    public String dataNeedId() {
+        return permissionRequest.dataNeedId();
+    }
+
+    @Override
     public PermissionRequestState state() {
         return permissionRequest.state();
     }

--- a/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequestTest.java
+++ b/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequestTest.java
@@ -40,7 +40,7 @@ class MessagingPermissionRequestTest {
         // Given
         Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
         TransitionableState createdState = new TransitionableState(PermissionProcessStatus.CREATED, expectedStatus);
-        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
 
         // When
@@ -66,7 +66,7 @@ class MessagingPermissionRequestTest {
         // Given
         Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
         SimpleState createdState = new SimpleState();
-        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
 
         // When
@@ -82,7 +82,7 @@ class MessagingPermissionRequestTest {
         Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
         SimpleState initialState = new SimpleState();
         TransitionableState changedState = new TransitionableState(PermissionProcessStatus.CREATED, PermissionProcessStatus.ACCEPTED);
-        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", initialState);
+        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", initialState, "dataNeedId");
         MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
 
         // When
@@ -97,7 +97,7 @@ class MessagingPermissionRequestTest {
         // Given
         Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
         SimpleState createdState = new SimpleState(PermissionProcessStatus.CREATED);
-        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
 
         // When
         new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
@@ -117,7 +117,7 @@ class MessagingPermissionRequestTest {
     void messagingPermissionRequest_equalsReturnsTrueForDecoratee() {
         Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
         SimpleState createdState = new SimpleState();
-        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
 
         // When
@@ -131,7 +131,7 @@ class MessagingPermissionRequestTest {
     void messagingPermissionRequest_equalsReturnsFalse() {
         Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
         SimpleState createdState = new SimpleState();
-        PermissionRequest permissionRequest1 = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        PermissionRequest permissionRequest1 = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest1, permissionStateMessages);
 
         // When
@@ -145,7 +145,7 @@ class MessagingPermissionRequestTest {
     void messagingPermissionRequest_hashCodeIsSameForDecoratee() {
         Sinks.Many<ConnectionStatusMessage> permissionStateMessages = Sinks.many().unicast().onBackpressureBuffer();
         SimpleState createdState = new SimpleState();
-        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        PermissionRequest permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         MessagingPermissionRequest<PermissionRequest> messagingPermissionRequest = new MessagingPermissionRequest<>(permissionRequest, permissionStateMessages);
 
         // When

--- a/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequestTest.java
+++ b/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequestTest.java
@@ -35,7 +35,7 @@ class SavingPermissionRequestTest {
         // Given
         PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
         SimpleState createdState = new SimpleState();
-        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
 
         // When
@@ -51,7 +51,7 @@ class SavingPermissionRequestTest {
         // Given
         PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
         SimpleState createdState = new SimpleState();
-        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
 
         // When
@@ -66,7 +66,7 @@ class SavingPermissionRequestTest {
         // Given
         PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
         SimpleState createdState = new SimpleState();
-        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
 
         // When
@@ -81,7 +81,7 @@ class SavingPermissionRequestTest {
         // Given
         PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
         SimpleState createdState = new SimpleState();
-        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
 
         // When
@@ -96,7 +96,7 @@ class SavingPermissionRequestTest {
         // Given
         PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
         SimpleState createdState = new SimpleState();
-        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
 
         // When
@@ -106,13 +106,28 @@ class SavingPermissionRequestTest {
         assertEquals("connectionId", connectionId);
     }
 
+    @Test
+    void savingPermissionRequest_returnsDataNeedId() {
+        // Given
+        PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
+        SimpleState createdState = new SimpleState();
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
+        SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
+
+        // When
+        String dataNeedId = savingPermissionRequest.dataNeedId();
+
+        // Then
+        assertEquals("dataNeedId", dataNeedId);
+    }
+
 
     @Test
     void savingPermissionRequest_equalsReturnsTrueForDecoratee() {
         // Given
         PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
         SimpleState createdState = new SimpleState();
-        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
 
         // When
@@ -127,7 +142,7 @@ class SavingPermissionRequestTest {
         // Given
         PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
         SimpleState createdState = new SimpleState();
-        var permissionRequest1 = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        var permissionRequest1 = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest1, repo);
 
         // When
@@ -142,7 +157,7 @@ class SavingPermissionRequestTest {
         // Given
         PermissionRequestRepository<PermissionRequest> repo = new SimplePermissionRequestRepository();
         SimpleState createdState = new SimpleState();
-        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState);
+        var permissionRequest = new SimplePermissionRequest("permissionId", "connectionId", createdState, "dataNeedId");
         SavingPermissionRequest<PermissionRequest> savingPermissionRequest = new SavingPermissionRequest<>(permissionRequest, repo);
 
         // When

--- a/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SimplePermissionRequest.java
+++ b/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SimplePermissionRequest.java
@@ -6,12 +6,14 @@ import energy.eddie.api.v0.process.model.PermissionRequestState;
 public final class SimplePermissionRequest implements PermissionRequest {
     private final String permissionId;
     private final String connectionId;
+    private final String dataNeedId;
     private PermissionRequestState state;
 
-    public SimplePermissionRequest(String permissionId, String connectionId, PermissionRequestState state) {
+    public SimplePermissionRequest(String permissionId, String connectionId, PermissionRequestState state, String dataNeedId) {
         this.permissionId = permissionId;
         this.connectionId = connectionId;
         this.state = state;
+        this.dataNeedId = dataNeedId;
     }
 
     @Override
@@ -27,6 +29,11 @@ public final class SimplePermissionRequest implements PermissionRequest {
     @Override
     public String connectionId() {
         return connectionId;
+    }
+
+    @Override
+    public String dataNeedId() {
+        return dataNeedId;
     }
 
     @Override


### PR DESCRIPTION
Verified that the dataNeedId is appended by running eda and datadis and consuming the kafka topics.