### PR TITLE
GH-387 Fix bug that caused the end date to be before the start

### DIFF
--- a/region-connectors/region-connector-dk-energinet/src/main/web/permission-request-form.js
+++ b/region-connectors/region-connector-dk-energinet/src/main/web/permission-request-form.js
@@ -44,7 +44,6 @@ class PermissionRequestForm extends LitElement {
     if (this.dataNeedAttributes.durationEnd === 0) {
       endDate.setDate(endDate.getDate() - 1); // subtract one day by default
     } else {
-      endDate = new Date(startDate);
       endDate.setDate(endDate.getDate() + this.dataNeedAttributes.durationEnd);
     }
 


### PR DESCRIPTION
The following data need was used
```
- id: ONE_DAY_TWO_DAYS_BACK
  description: one day from two days back in time
  granularity: P_1_D
  duration-start: -3
  duration-open-end: false
  duration-end: -2
```
but the end date happened to be before the start date when creating a request.