### PR TITLE
GH-434 Remove unintended trailing slash from region connector metadata

### DIFF
--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/EnerginetRegionConnector.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/EnerginetRegionConnector.java
@@ -63,7 +63,7 @@ public class EnerginetRegionConnector implements RegionConnector {
 
     @Override
     public RegionConnectorMetadata getMetadata() {
-        return new RegionConnectorMetadata(MDA_CODE, MDA_DISPLAY_NAME, COUNTRY_CODE, BASE_PATH + "/", COVERED_METERING_POINTS);
+        return new RegionConnectorMetadata(MDA_CODE, MDA_DISPLAY_NAME, COUNTRY_CODE, BASE_PATH, COVERED_METERING_POINTS);
     }
 
     @Override

--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/EnedisRegionConnector.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/EnedisRegionConnector.java
@@ -64,7 +64,7 @@ public class EnedisRegionConnector implements RegionConnector {
 
     @Override
     public RegionConnectorMetadata getMetadata() {
-        return new RegionConnectorMetadata(MDA_CODE, MDA_DISPLAY_NAME, COUNTRY_CODE, BASE_PATH + "/", COVERED_METERING_POINTS);
+        return new RegionConnectorMetadata(MDA_CODE, MDA_DISPLAY_NAME, COUNTRY_CODE, BASE_PATH, COVERED_METERING_POINTS);
     }
 
     @Override


### PR DESCRIPTION
Prevents request URLs from requiring double slashes. Fixes #434.