### PR TITLE
GH-357 Fix data need start duration and open end input change handlers

### DIFF
--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -154,7 +154,7 @@ class EddieConnectButton extends LitElement {
 
     if (!customElements.get(customElementName)) {
       const regionConnector = this._availableConnectors[regionConnectorId];
-      // loaded module needs to have the custom element class as it's default export
+      // loaded module needs to have the custom element class as its default export
       const module = await import(`${BASE_URL}${regionConnector.urlPath}ce.js`);
       customElements.define(customElementName, module.default);
     }
@@ -303,7 +303,7 @@ class EddieConnectButton extends LitElement {
                     this._dataNeedAttributes.durationStart
                   )}"
                   @sl-change="${(event) => {
-                    this._dataNeedAttributes.durationEnd =
+                    this._dataNeedAttributes.durationStart =
                       durationFromDateString(event.target.value);
                   }}"
                 ></sl-input>
@@ -313,8 +313,7 @@ class EddieConnectButton extends LitElement {
                     name="durationOpenEnd"
                     checked="${this._dataNeedAttributes.durationOpenEnd}"
                     @sl-change="${(event) => {
-                      this._dataNeedAttributes.durationOpenEnd =
-                        event.target.value;
+                      this._dataNeedAttributes.durationOpenEnd = event.target.checked;
                     }}"
                   >
                     Open End


### PR DESCRIPTION
Fabian told me recently that the data need configuration does not work. Found two related issues. Booking to the previous issue they were implemented with.

Tested with simulation connector.

Might go back to a save button again to automatically reload RC elements on changes. Created #453 for this.