### PR TITLE
NOISSUE Remove duplicate method and use consistent naming

### DIFF
--- a/api/src/main/java/energy/eddie/api/v0/process/model/PermissionRequest.java
+++ b/api/src/main/java/energy/eddie/api/v0/process/model/PermissionRequest.java
@@ -72,15 +72,11 @@ public interface PermissionRequest {
         state().invalid();
     }
 
-    default void rejected() throws StateTransitionException {
+    default void reject() throws StateTransitionException {
         state().reject();
     }
 
-    default void terminated() throws StateTransitionException {
-        state().timeLimit();
-    }
-
-    default void revoked() throws StateTransitionException {
+    default void revoke() throws StateTransitionException {
         state().revoke();
     }
 
@@ -88,7 +84,7 @@ public interface PermissionRequest {
         state().timeLimit();
     }
 
-    default void timedOut() throws StateTransitionException {
+    default void timeOut() throws StateTransitionException {
         state().timeOut();
     }
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/EdaRegionConnector.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/EdaRegionConnector.java
@@ -105,7 +105,7 @@ public class EdaRegionConnector implements
                 request.accept();
             }
             case ERROR -> request.invalid();
-            case REJECTED -> request.rejected();
+            case REJECTED -> request.reject();
             case RECEIVED -> request.receivedPermissionAdministratorResponse();
             default -> {
                 // Other CMRequestStatus do not change the state of the permission request,

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/SimplePermissionRequest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/SimplePermissionRequest.java
@@ -61,7 +61,7 @@ public record SimplePermissionRequest(String permissionId,
     }
 
     @Override
-    public void rejected() {
+    public void reject() {
 
     }
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/permission/request/EdaPermissionRequestTest.java
@@ -341,7 +341,7 @@ class EdaPermissionRequestTest {
         permissionRequest.receivedPermissionAdministratorResponse();
 
         // When
-        permissionRequest.rejected();
+        permissionRequest.reject();
 
         // Then
         assertEquals(AtRejectedPermissionRequestState.class, permissionRequest.state().getClass());

--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/DkEnerginetCustomerPermissionRequestAdapter.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/DkEnerginetCustomerPermissionRequestAdapter.java
@@ -98,7 +98,7 @@ public class DkEnerginetCustomerPermissionRequestAdapter implements DkEnerginetC
     }
 
     @Override
-    public void rejected() throws StateTransitionException {
-        adaptee.rejected();
+    public void reject() throws StateTransitionException {
+        adaptee.reject();
     }
 }

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/DkEnerginetCustomerPermissionRequestAdapterTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/DkEnerginetCustomerPermissionRequestAdapterTest.java
@@ -211,7 +211,7 @@ class DkEnerginetCustomerPermissionRequestAdapterTest {
         DkEnerginetCustomerPermissionRequestAdapter adapter = new DkEnerginetCustomerPermissionRequestAdapter(request, decorator);
 
         // When
-        adapter.rejected();
+        adapter.reject();
 
         // Then
         assertTrue(decorator.didChange());
@@ -281,7 +281,7 @@ class DkEnerginetCustomerPermissionRequestAdapterTest {
         }
 
         @Override
-        public void rejected() {
+        public void reject() {
             change = true;
         }
 

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerSentToPermissionAdministratorStateTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerSentToPermissionAdministratorStateTest.java
@@ -95,7 +95,7 @@ class EnerginetCustomerSentToPermissionAdministratorStateTest {
         permissionRequest.changeState(state);
 
         // When
-        assertDoesNotThrow(permissionRequest::rejected);
+        assertDoesNotThrow(permissionRequest::reject);
 
         // Then
         assertEquals(EnerginetCustomerRejectedState.class, permissionRequest.state().getClass());

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisRegionConnector.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisRegionConnector.java
@@ -167,7 +167,7 @@ public class DatadisRegionConnector implements RegionConnector, AuthorizationRes
                 return;
             }
 
-            permissionRequest.get().rejected();
+            permissionRequest.get().reject();
             ctx.status(HttpStatus.OK);
         });
 

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequest.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequest.java
@@ -159,7 +159,7 @@ public class DatadisPermissionRequest implements EsPermissionRequest {
     }
 
     @Override
-    public void rejected() throws StateTransitionException {
+    public void reject() throws StateTransitionException {
         state.reject();
     }
 

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestAdapter.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestAdapter.java
@@ -79,8 +79,8 @@ public final class DatadisPermissionRequestAdapter implements EsPermissionReques
     }
 
     @Override
-    public void rejected() throws StateTransitionException {
-        adaptee.rejected();
+    public void reject() throws StateTransitionException {
+        adaptee.reject();
     }
 
     @Override

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestAdapterTest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestAdapterTest.java
@@ -249,7 +249,7 @@ class DatadisPermissionRequestAdapterTest {
         PermissionRequest decorator = new ThrowingPermissionRequest(request);
         DatadisPermissionRequestAdapter adapter = new DatadisPermissionRequestAdapter(request, decorator);
 
-        assertThrows(IllegalStateException.class, adapter::rejected);
+        assertThrows(IllegalStateException.class, adapter::reject);
     }
 
     private record ThrowingPermissionRequest(PermissionRequest request) implements PermissionRequest {
@@ -310,7 +310,7 @@ class DatadisPermissionRequestAdapterTest {
         }
 
         @Override
-        public void rejected() {
+        public void reject() {
             throw new IllegalStateException();
         }
     }

--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/EnedisRegionConnector.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/EnedisRegionConnector.java
@@ -135,7 +135,7 @@ public class EnedisRegionConnector implements RegionConnector {
             permissionRequest.receivedPermissionAdministratorResponse();
             var usagePointId = ctx.queryParam("usage_point_id");
             if (usagePointId == null || ctx.status() == HttpStatus.FORBIDDEN) { // probably when request was denied
-                permissionRequest.rejected();
+                permissionRequest.reject();
                 ctx.html("<h1>Access to data denied, you can close this window.</h1>");
                 return;
             }

--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/TimeFramedPermissionRequestAdapter.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/TimeFramedPermissionRequestAdapter.java
@@ -82,7 +82,7 @@ public class TimeFramedPermissionRequestAdapter implements TimeframedPermissionR
     }
 
     @Override
-    public void rejected() throws StateTransitionException {
-        adaptee.rejected();
+    public void reject() throws StateTransitionException {
+        adaptee.reject();
     }
 }

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/TimeFramedPermissionRequestAdapterTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/TimeFramedPermissionRequestAdapterTest.java
@@ -205,7 +205,7 @@ class TimeFramedPermissionRequestAdapterTest {
         TimeFramedPermissionRequestAdapter adapter = new TimeFramedPermissionRequestAdapter(request, decorator);
 
         // When
-        adapter.rejected();
+        adapter.reject();
 
         // Then
         assertTrue(decorator.didChange());
@@ -275,7 +275,7 @@ class TimeFramedPermissionRequestAdapterTest {
         }
 
         @Override
-        public void rejected() {
+        public void reject() {
             change = true;
         }
 

--- a/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequest.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequest.java
@@ -79,8 +79,8 @@ public class MessagingPermissionRequest implements PermissionRequest {
     }
 
     @Override
-    public void rejected() throws StateTransitionException {
-        permissionRequest.rejected();
+    public void reject() throws StateTransitionException {
+        permissionRequest.reject();
         emitState();
     }
 

--- a/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequest.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequest.java
@@ -74,8 +74,8 @@ public class SavingPermissionRequest<T extends PermissionRequest> implements Per
     }
 
     @Override
-    public void rejected() throws StateTransitionException {
-        executeAndSave(permissionRequest::rejected);
+    public void reject() throws StateTransitionException {
+        executeAndSave(permissionRequest::reject);
     }
 
     @Override

--- a/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequestTest.java
+++ b/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/MessagingPermissionRequestTest.java
@@ -25,7 +25,7 @@ class MessagingPermissionRequestTest {
                 Arguments.of(PermissionProcessStatus.TERMINATED, "terminate"),
                 Arguments.of(PermissionProcessStatus.ACCEPTED, "accept"),
                 Arguments.of(PermissionProcessStatus.INVALID, "invalid"),
-                Arguments.of(PermissionProcessStatus.REJECTED, "rejected"),
+                Arguments.of(PermissionProcessStatus.REJECTED, "reject"),
                 Arguments.of(PermissionProcessStatus.VALIDATED, "validate"),
                 Arguments.of(PermissionProcessStatus.MALFORMED, "validate")
         );

--- a/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequestTest.java
+++ b/region-connectors/shared/src/test/java/energy/eddie/regionconnector/shared/permission/requests/decorators/SavingPermissionRequestTest.java
@@ -22,7 +22,7 @@ class SavingPermissionRequestTest {
                 "receivedPermissionAdministratorResponse",
                 "invalid",
                 "accept",
-                "rejected",
+                "reject",
                 "terminate"
         );
     }


### PR DESCRIPTION
Removed duplicate `terminated()` method and renamed the methods to be consistent between `PermissionRequest` and `PermissionRequestState`.

SonarCloud fails because the renamed methods are considered new code and there is lots of duplications & missing coverage...