### PR TITLE
NOISSUE Fix wrongfully casting RegionConnector to Mvp1ConsumptionRecordProvider

### DIFF
--- a/core/src/main/java/energy/eddie/core/ConsumptionRecordService.java
+++ b/core/src/main/java/energy/eddie/core/ConsumptionRecordService.java
@@ -28,10 +28,12 @@ public class ConsumptionRecordService {
     public Flux<ConsumptionRecord> getConsumptionRecordStream() {
         List<Flux<ConsumptionRecord>> consumptionRecordFluxes = new ArrayList<>(regionConnectors.size());
         for (var connector : regionConnectors) {
-            try {
-                consumptionRecordFluxes.add(JdkFlowAdapter.flowPublisherToFlux(((Mvp1ConsumptionRecordProvider) connector).getConsumptionRecordStream()));
-            } catch (Exception e) {
-                LOGGER.warn("Got no consumption record stream for connector {}", connector.getMetadata().mdaCode(), e);
+            if (connector instanceof Mvp1ConsumptionRecordProvider provider) {
+                try {
+                    consumptionRecordFluxes.add(JdkFlowAdapter.flowPublisherToFlux(provider.getConsumptionRecordStream()));
+                } catch (Exception e) {
+                    LOGGER.warn("Got no consumption record stream for connector {}", connector.getMetadata().mdaCode(), e);
+                }
             }
         }
         return Flux.merge(consumptionRecordFluxes).share();

--- a/core/src/main/java/energy/eddie/core/PermissionService.java
+++ b/core/src/main/java/energy/eddie/core/PermissionService.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Set;
 
 public class PermissionService {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(PermissionService.class);
 
     @Inject
@@ -26,10 +25,12 @@ public class PermissionService {
 
         List<Flux<ConnectionStatusMessage>> connectionStatusFluxes = new ArrayList<>(regionConnectors.size());
         for (var connector : regionConnectors) {
-            try {
-                connectionStatusFluxes.add(JdkFlowAdapter.flowPublisherToFlux(((Mvp1ConnectionStatusMessageProvider) connector).getConnectionStatusMessageStream()));
-            } catch (Exception e) {
-                LOGGER.warn("Got no connection status message stream for connector {}", connector.getMetadata().mdaCode(), e);
+            if (connector instanceof Mvp1ConnectionStatusMessageProvider statusMessageProvider) {
+                try {
+                    connectionStatusFluxes.add(JdkFlowAdapter.flowPublisherToFlux(statusMessageProvider.getConnectionStatusMessageStream()));
+                } catch (Exception e) {
+                    LOGGER.warn("Got no connection status message stream for connector {}", connector.getMetadata().mdaCode(), e);
+                }
             }
         }
         return Flux.merge(connectionStatusFluxes).share();


### PR DESCRIPTION
Since the `getConsumptionRecordStream` and `getConnectionStatusMessageStream` methods are now in their separate interfaces, they should be called only for RegionConnectors that implement the interfaces.
Not every RegionConnector should be blindly cast to e.g. a `Mvp1ConsumptionRecordProvider`.