### PR TITLE
NOISSUE Use DTO in PermissionRequest constructor

### DIFF
--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/EnerginetCustomerPermissionRequest.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/EnerginetCustomerPermissionRequest.java
@@ -5,6 +5,7 @@ import energy.eddie.api.v0.process.model.PermissionRequestState;
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.api.DkEnerginetCustomerPermissionRequest;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.states.EnerginetCustomerCreatedState;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 
 import java.time.ZonedDateTime;
@@ -25,24 +26,20 @@ public class EnerginetCustomerPermissionRequest implements DkEnerginetCustomerPe
 
     public EnerginetCustomerPermissionRequest(
             String permissionId,
-            String connectionId,
-            ZonedDateTime start,
-            ZonedDateTime end,
-            String refreshToken,
-            String meteringPoint,
-            String dataNeedId,
-            PeriodResolutionEnum periodResolution,
+            PermissionRequestForCreation request,
             EnerginetConfiguration configuration) {
+        requireNonNull(permissionId);
+        requireNonNull(request);
         requireNonNull(configuration);
 
         this.permissionId = requireNonNull(permissionId);
-        this.connectionId = requireNonNull(connectionId);
-        this.start = requireNonNull(start);
-        this.end = requireNonNull(end);
-        this.refreshToken = requireNonNull(refreshToken);
-        this.meteringPoint = requireNonNull(meteringPoint);
-        this.dataNeedId = requireNonNull(dataNeedId);
-        this.periodResolution = requireNonNull(periodResolution);
+        this.connectionId = requireNonNull(request.connectionId());
+        this.start = requireNonNull(request.start());
+        this.end = requireNonNull(request.end());
+        this.refreshToken = requireNonNull(request.refreshToken());
+        this.meteringPoint = requireNonNull(request.meteringPoint());
+        this.dataNeedId = requireNonNull(request.dataNeedId());
+        this.periodResolution = requireNonNull(request.periodResolution());
 
         this.state = new EnerginetCustomerCreatedState(this, configuration);
     }

--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/PermissionRequestFactory.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/PermissionRequestFactory.java
@@ -34,13 +34,7 @@ public class PermissionRequestFactory implements Mvp1ConnectionStatusMessageProv
         var permissionId = UUID.randomUUID().toString();
         var permissionRequest = new EnerginetCustomerPermissionRequest(
                 permissionId,
-                request.connectionId(),
-                request.start(),
-                request.end(),
-                request.refreshToken(),
-                request.meteringPoint(),
-                request.dataNeedId(),
-                request.periodResolution(),
+                request,
                 configuration
         );
 

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/DkEnerginetCustomerPermissionRequestAdapterTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/DkEnerginetCustomerPermissionRequestAdapterTest.java
@@ -8,6 +8,7 @@ import energy.eddie.regionconnector.dk.energinet.EnerginetRegionConnector;
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.api.DkEnerginetCustomerPermissionRequest;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.states.EnerginetCustomerMalformedState;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 import org.junit.jupiter.api.Test;
 
@@ -105,9 +106,9 @@ class DkEnerginetCustomerPermissionRequestAdapterTest {
         String connectionId = "cid";
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, start.plusDays(1), refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var request = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, start.plusDays(1),
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var request = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
 
         EnerginetCustomerMalformedState state = new EnerginetCustomerMalformedState(null, null);
         PermissionRequest decorator = new ChangingPermissionRequest(request);

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/EnerginetCustomerPermissionRequestTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/EnerginetCustomerPermissionRequestTest.java
@@ -4,6 +4,7 @@ import energy.eddie.api.v0.process.model.PermissionRequestState;
 import energy.eddie.regionconnector.dk.energinet.EnerginetRegionConnector;
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.states.EnerginetCustomerRejectedState;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 import org.junit.jupiter.api.Test;
 
@@ -25,10 +26,10 @@ class EnerginetCustomerPermissionRequestTest {
         String meteringPoint = "meteringPoint";
         PeriodResolutionEnum resolution = PeriodResolutionEnum.PT1H;
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
         // When
-        var request = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var request = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
 
         // Then
         assertEquals(permissionId, request.permissionId());
@@ -53,10 +54,10 @@ class EnerginetCustomerPermissionRequestTest {
         String meteringPoint = "meteringPoint";
         PeriodResolutionEnum resolution = PeriodResolutionEnum.PT1H;
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
         // When
-        var request = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var request = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
         PermissionRequestState newState = new EnerginetCustomerRejectedState(request);
 
         // When

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerCreatedStateTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerCreatedStateTest.java
@@ -7,6 +7,7 @@ import energy.eddie.regionconnector.dk.energinet.EnerginetRegionConnector;
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.config.PlainEnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.EnerginetCustomerPermissionRequest;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 import org.junit.jupiter.api.Test;
 
@@ -30,9 +31,9 @@ class EnerginetCustomerCreatedStateTest {
         String connectionId = "cid";
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = new PlainEnerginetConfiguration("foo:bar");
+        var forCreation = new PermissionRequestForCreation(connectionId, start, start.plusDays(5), refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
 
         // When
         assertDoesNotThrow(permissionRequest::validate);
@@ -53,9 +54,9 @@ class EnerginetCustomerCreatedStateTest {
         PeriodResolutionEnum resolution = PeriodResolutionEnum.PT1H;
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId,
-                start, end, refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
 
         // When
         var thrown = assertThrows(ValidationException.class, permissionRequest::validate);
@@ -77,9 +78,9 @@ class EnerginetCustomerCreatedStateTest {
         String dataNeedId = "dataNeedId";
         String meteringPoint = "meteringPoint";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
 
         // When
         var thrown = assertThrows(ValidationException.class, permissionRequest::validate);
@@ -102,9 +103,9 @@ class EnerginetCustomerCreatedStateTest {
         String dataNeedId = "dataNeedId";
         String meteringPoint = "meteringPoint";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
 
         // When
         var thrown = assertThrows(ValidationException.class, permissionRequest::validate);

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerPendingAcknowledgmentStateTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerPendingAcknowledgmentStateTest.java
@@ -6,6 +6,7 @@ import energy.eddie.api.v0.process.model.PastStateException;
 import energy.eddie.regionconnector.dk.energinet.EnerginetRegionConnector;
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.EnerginetCustomerPermissionRequest;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 import org.junit.jupiter.api.Test;
 
@@ -38,9 +39,9 @@ class EnerginetCustomerPendingAcknowledgmentStateTest {
         String connectionId = "cid";
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, start.plusDays(5), refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start,
-                start.plusDays(5), refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
         EnerginetCustomerPendingAcknowledgmentState state = new EnerginetCustomerPendingAcknowledgmentState(permissionRequest);
 
         // When

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerSentToPermissionAdministratorStateTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerSentToPermissionAdministratorStateTest.java
@@ -6,6 +6,7 @@ import energy.eddie.api.v0.process.model.PastStateException;
 import energy.eddie.regionconnector.dk.energinet.EnerginetRegionConnector;
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.EnerginetCustomerPermissionRequest;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 import org.junit.jupiter.api.Test;
 
@@ -38,9 +39,9 @@ class EnerginetCustomerSentToPermissionAdministratorStateTest {
         String connectionId = "cid";
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
         var state = new EnerginetCustomerSentToPermissionAdministratorState(permissionRequest);
         permissionRequest.changeState(state);
 
@@ -63,9 +64,9 @@ class EnerginetCustomerSentToPermissionAdministratorStateTest {
         String connectionId = "cid";
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
         var state = new EnerginetCustomerSentToPermissionAdministratorState(permissionRequest);
         permissionRequest.changeState(state);
 
@@ -88,9 +89,9 @@ class EnerginetCustomerSentToPermissionAdministratorStateTest {
         String connectionId = "cid";
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
         var state = new EnerginetCustomerSentToPermissionAdministratorState(permissionRequest);
         permissionRequest.changeState(state);
 

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerValidatedStateTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/states/EnerginetCustomerValidatedStateTest.java
@@ -9,6 +9,7 @@ import energy.eddie.regionconnector.dk.energinet.EnerginetRegionConnector;
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.client.EnerginetCustomerApiClient;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.EnerginetCustomerPermissionRequest;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 import feign.FeignException;
 import feign.Request;
@@ -57,9 +58,9 @@ class EnerginetCustomerValidatedStateTest {
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
         EnerginetCustomerApiClient apiClient = mock(EnerginetCustomerApiClient.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
         var state = new EnerginetCustomerValidatedState(permissionRequest, apiClient);
         permissionRequest.changeState(state);
 
@@ -137,9 +138,9 @@ class EnerginetCustomerValidatedStateTest {
         String connectionId = "cid";
         String dataNeedId = "dataNeedId";
         EnerginetConfiguration config = mock(EnerginetConfiguration.class);
+        var forCreation = new PermissionRequestForCreation(connectionId, start, end, refreshToken, resolution, meteringPoint, dataNeedId);
 
-        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, connectionId, start, end,
-                refreshToken, meteringPoint, dataNeedId, resolution, config);
+        var permissionRequest = new EnerginetCustomerPermissionRequest(permissionId, forCreation, config);
         var state = new EnerginetCustomerValidatedState(permissionRequest, mockApiClient);
         permissionRequest.changeState(state);
         return permissionRequest;

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/validation/NotAfterNowValidatorTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/validation/NotAfterNowValidatorTest.java
@@ -2,6 +2,7 @@ package energy.eddie.regionconnector.dk.energinet.customer.permission.request.va
 
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.EnerginetCustomerPermissionRequest;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -99,7 +100,8 @@ class NotAfterNowValidatorTest {
     }
 
     private EnerginetCustomerPermissionRequest createTestRequest(ZonedDateTime start, ZonedDateTime end) {
-        return new EnerginetCustomerPermissionRequest("foo", "bar", start, end,
-                "too", "laa", "luu", PeriodResolutionEnum.PT1H, mockConfig);
+        var forCreation = new PermissionRequestForCreation("bar", start, end, "too", PeriodResolutionEnum.PT1H, "laa", "luu");
+
+        return new EnerginetCustomerPermissionRequest("foo", forCreation, mockConfig);
     }
 }

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/validation/NotOlderThanValidatorTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/customer/permission/request/validation/NotOlderThanValidatorTest.java
@@ -2,6 +2,7 @@ package energy.eddie.regionconnector.dk.energinet.customer.permission.request.va
 
 import energy.eddie.regionconnector.dk.energinet.config.EnerginetConfiguration;
 import energy.eddie.regionconnector.dk.energinet.customer.permission.request.EnerginetCustomerPermissionRequest;
+import energy.eddie.regionconnector.dk.energinet.dtos.PermissionRequestForCreation;
 import energy.eddie.regionconnector.dk.energinet.enums.PeriodResolutionEnum;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ class NotOlderThanValidatorTest {
     }
 
     private EnerginetCustomerPermissionRequest createTestRequest(ZonedDateTime start, ZonedDateTime end) {
-        return new EnerginetCustomerPermissionRequest("foo", "bar", start, end,
-                "too", "laa", "luu", PeriodResolutionEnum.PT1H, mockConfig);
+        var forCreation = new PermissionRequestForCreation("bar", start, end, "too", PeriodResolutionEnum.PT1H, "laa", "luu");
+        return new EnerginetCustomerPermissionRequest("foo", forCreation, mockConfig);
     }
 }

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/web/PermissionRequestControllerTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/web/PermissionRequestControllerTest.java
@@ -146,9 +146,7 @@ class PermissionRequestControllerTest {
         when(service.createAndSendPermissionRequest(any())).thenAnswer(invocation -> {
             PermissionRequestForCreation request = invocation.getArgument(0);
             return new EnerginetCustomerPermissionRequest(
-                    permissionId, request.connectionId(), request.start(), request.end(),
-                    request.refreshToken(), request.meteringPoint(), request.dataNeedId(),
-                    request.periodResolution(), mock(EnerginetConfiguration.class)
+                    permissionId, request, mock(EnerginetConfiguration.class)
             );
         });
 
@@ -175,9 +173,7 @@ class PermissionRequestControllerTest {
         when(service.createAndSendPermissionRequest(any())).thenAnswer(invocation -> {
             PermissionRequestForCreation request = invocation.getArgument(0);
             return new EnerginetCustomerPermissionRequest(
-                    permissionId, request.connectionId(), request.start(), request.end(),
-                    request.refreshToken(), request.meteringPoint(), request.dataNeedId(),
-                    request.periodResolution(), mock(EnerginetConfiguration.class)
+                    permissionId, request, mock(EnerginetConfiguration.class)
             );
         });
 


### PR DESCRIPTION
To fix SonarCloud warning and be consistent with other region connectors.