### PR TITLE
GH-542 Fix datadis permissionEnd by respecting equal case

### DIFF
--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequest.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequest.java
@@ -66,7 +66,7 @@ public class DatadisPermissionRequest implements EsPermissionRequest {
      * Calculate the date furthest in the future.
      */
     private ZonedDateTime latest(ZonedDateTime first, ZonedDateTime second) {
-        if (first.isAfter(second)) {
+        if (!first.isBefore(second)) {
             return first.plusDays(1); // if all the data is in the past we only need access for 1 day
         }
 

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestTest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/permission/request/DatadisPermissionRequestTest.java
@@ -88,6 +88,17 @@ class DatadisPermissionRequestTest {
     }
 
     @Test
+    void permissionEnd_whenRequestingTodaysData_isOneDayGraterThanPermissionStart() {
+        var today = ZonedDateTime.now(ZoneOffset.UTC);
+        requestForCreation = new PermissionRequestForCreation(connectionId, dataNeedId, nif, meteringPointId,
+                today, today, measurementType);
+
+        var request = new DatadisPermissionRequest(permissionId, requestForCreation, authorizationApi, repository);
+
+        assertEquals(request.permissionStart().plusDays(1), request.permissionEnd());
+    }
+
+    @Test
     void lastPulledMeterReading_whenConstructed_isEmpty() {
         var request = new DatadisPermissionRequest(permissionId, requestForCreation, authorizationApi, repository);
         assertTrue(request.lastPulledMeterReading().isEmpty());


### PR DESCRIPTION
Wrong logic for checking before in last PR so fix it in this one and add a test for it.
With the last PR, if you requested data for today, the check would fail because permissionStart was not after requestDataTo (since they where the same) which meant it would add the 1 day offest.


Feel free to merge this PR if you approve it