### PR TITLE
NOISSUE  Fix bean creation of enedis region connector

### DIFF
--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/EnedisRegionConnector.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/EnedisRegionConnector.java
@@ -6,12 +6,14 @@ import energy.eddie.regionconnector.fr.enedis.api.EnedisApi;
 import energy.eddie.regionconnector.fr.enedis.services.PermissionRequestService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 import reactor.adapter.JdkFlowAdapter;
 import reactor.core.publisher.Sinks;
 
 import java.util.Map;
 import java.util.concurrent.Flow;
 
+@Component
 public class EnedisRegionConnector implements RegionConnector, Mvp1ConnectionStatusMessageProvider,
         Mvp1ConsumptionRecordProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(EnedisRegionConnector.class);

--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/FrEnedisSpringConfig.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/FrEnedisSpringConfig.java
@@ -13,7 +13,6 @@ import energy.eddie.regionconnector.fr.enedis.config.EnedisConfiguration;
 import energy.eddie.regionconnector.fr.enedis.config.PlainEnedisConfiguration;
 import energy.eddie.regionconnector.fr.enedis.permission.request.InMemoryPermissionRequestRepository;
 import energy.eddie.regionconnector.fr.enedis.permission.request.PermissionRequestFactory;
-import energy.eddie.regionconnector.fr.enedis.services.PermissionRequestService;
 import energy.eddie.regionconnector.shared.permission.requests.extensions.Extension;
 import energy.eddie.regionconnector.shared.permission.requests.extensions.MessagingExtension;
 import energy.eddie.regionconnector.shared.permission.requests.extensions.SavingExtension;
@@ -81,15 +80,5 @@ public class FrEnedisSpringConfig {
     @Bean
     public PermissionRequestFactory factory(Set<Extension<TimeframedPermissionRequest>> extensions) {
         return new PermissionRequestFactory(extensions);
-    }
-
-    @Bean
-    public energy.eddie.api.v0.RegionConnector regionConnector(
-            EnedisApi enedisApi,
-            PermissionRequestService permissionRequestService,
-            Sinks.Many<ConnectionStatusMessage> messages,
-            Sinks.Many<ConsumptionRecord> consumptionRecordSink
-    ) {
-        return new EnedisRegionConnector(enedisApi, permissionRequestService, messages, consumptionRecordSink);
     }
 }


### PR DESCRIPTION
The automatically built docker image failed to start when enabling the `fr-enedis` region connector, as it cannot find a bean of type `energy.eddie.api.v0.Mvp1ConnectionStatusMessageProvider`.

The cause of this issue is that the French region connector implementation (which implements the `Mvp1ConnectionStatusMessageProvider` interface), is not annotated as `@Component` but created as `Bean` in the `FrEnedisSpringConfig` by a method that returns the type `energy.eddie.api.v0.RegionConnector`. This interface return type appears to be the problem, why *Spring Magic* cannot find the required bean.

Strangely, when checking out the main branch and running the same commands as in the workflow file, the built docker image works, it does not fail with the same error as the automatically built one.