### PR TITLE
NOISSUE Fix FR Enedis not redirecting after clicking button

### DIFF
--- a/region-connectors/region-connector-fr-enedis/src/main/web/permission-request-form.js
+++ b/region-connectors/region-connector-fr-enedis/src/main/web/permission-request-form.js
@@ -63,6 +63,7 @@ class PermissionRequestForm extends LitElement {
             5000
           );
         }
+        return response;
       })
       .then((response) => response.json())
       .then((result) => {


### PR DESCRIPTION
Fixes a bug where the ENEDIS region connector wouldn't redirect to the Enedis page because of the response is not passed down the chain. 