### PR TITLE
GH-565 Use PostgreSQL as default db

### DIFF
--- a/OPERATION.md
+++ b/OPERATION.md
@@ -23,7 +23,7 @@ services:
   eddie:
     image: ghcr.io/eddie-energy/eddie:latest
     environment:
-      JDBC_URL: "jdbc:h2:tcp://h2/demo-db"
+      JDBC_URL: "jdbc:postgresql://localhost:5432/example_app"
       JDBC_USER: "test"
       JDBC_PASSWORD: "test"
       PUBLIC_CONTEXT_PATH: ""                            # default value

--- a/README.md
+++ b/README.md
@@ -36,17 +36,24 @@ Or you can use the following links:
 
 There are three tasks in the **development** group that have to run at the same time, e.g. in different windows:
 
-- `./gradlew run-db-server`
+- `./gradlew run-db-server` (obsolete, the default DB is a PostgreSQL)
 - `./gradlew run-core`
 - `./gradlew run-example-app`
 
 The three processes are:
 
-#### H2 Database Engine
+#### Database
 
+Instead of the H2 database, a PostgreSQL database is used as default.
+Check the [docker-compose.yml](env/docker-compose.yml) file for an example PostgreSQL container that you can use as it
+is. The necessary database for the example app and the EDDIE core are created automatically when starting the docker
+container for the first time.
+
+You can still use the H2 database by changing the JDBC URLs for the example app and the EDDIE core and running
+the `run-db-server` gradle task.
 [H2 Database Engine](https://www.h2database.com/html/main.html) started as a network server.
 
-- the databases interface is acessible through <http://localhost:8082>
+- the databases interface is accessible through <http://localhost:8082>
 - JDBC connection through: `jdbc:h2:tcp://localhost/./examples/example-app` (username and password empty)
 
 #### Eligible party demo app

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
 
     runtimeOnly(libs.h2database)
+    runtimeOnly(libs.postgresql)
 
 
     testImplementation(libs.junit.jupiter)
@@ -65,10 +66,18 @@ tasks.register("run-core", JavaExec::class) {
     group = "development"
     description = "run EDDIE with Spring"
 
-    environment["JDBC_URL"] = "jdbc:h2:tcp://localhost:9091/./examples/example-app"
     environment["CORE_PORT"] = 8080
     environment["IMPORT_CONFIG_FILE"] = "file:./core/src/test/resources/data-needs.yml"
-    environment["SPRING_JPA_DATABASE_PLATFORM"] = "org.hibernate.dialect.H2Dialect"
+
+    // when using PostgreSQL
+    environment["JDBC_USER"] = "test"
+    environment["JDBC_PASSWORD"] = "test"
+    environment["JDBC_URL"] = "jdbc:postgresql://localhost:5432/eddie"
+    environment["SPRING_JPA_DATABASE_PLATFORM"] = "org.hibernate.dialect.PostgreSQLDialect"
+
+    // when using H2 database, no credentials are needed
+    // environment["JDBC_URL"] = "jdbc:h2:tcp://localhost:9091/./examples/example-app"
+    // environment["SPRING_JPA_DATABASE_PLATFORM"] = "org.hibernate.dialect.H2Dialect"
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -8,6 +8,7 @@ spring.datasource.url=${JDBC_URL}
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.username=${JDBC_USER:}
 spring.datasource.password=${JDBC_PASSWORD:}
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 # General configurations
 # Patterns for allowed domains for CORS requests; see org.springframework.web.cors.CorsConfiguration#setAllowedOriginPatterns() for examples

--- a/env/.env
+++ b/env/.env
@@ -5,9 +5,11 @@ PUBLIC_CONTEXT_PATH=/prototype/main
 
 # EDDIE specific configuration
 CORE_PORT=8080
-JDBC_URL=jdbc:h2:tcp://h2/demo-db
+JDBC_URL=jdbc:postgresql://db:5432/eddie
 JDBC_USER=test
 JDBC_PASSWORD=test
+SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.PostgreSQLDialect
+
 # Patterns for allowed domains for CORS requests; see org.springframework.web.cors.CorsConfiguration#setAllowedOriginPatterns() for examples
 EDDIE_CORS_ALLOWED_ORIGINS=*
 
@@ -23,8 +25,6 @@ KAFKA_BOOTSTRAP_SERVERS=kafka:9092
 MANAGEMENT_SERVER_PORT=9090
 # url prefix for the management api (must not be used for other purposes)
 MANAGEMENT_SERVER_URLPREFIX=management
-# When using a config file for data needs, set the above property to CONFIG
-#DATA_NEEDS_CONFIG_FILE: "file:../core/src/test/resources/data-needs.yml"
 IMPORT_CONFIG_FILE=file:./config/data-needs.yml
 
 

--- a/env/create-example-app-db.sql
+++ b/env/create-example-app-db.sql
@@ -1,0 +1,2 @@
+CREATE
+DATABASE example_app;

--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -1,12 +1,26 @@
 version: "3.9"
 name: eddie-test
 services:
-  h2:
-    image: "pcarmona/h2database"
+  # Use either H2 or postgresql as database
+  #h2:
+  #  image: "pcarmona/h2database"
+  #  environment:
+  #    H2_DBNAME: demo-db
+  #    H2_USER: "test"
+  #    H2_PASSWORD: "test"
+
+  db:
+    image: postgres
+    ports:
+      - "5432:5432"
     environment:
-      H2_DBNAME: demo-db
-      H2_USER: "test"
-      H2_PASSWORD: "test"
+      POSTGRES_PASSWORD: "test"
+      POSTGRES_USER: "test"
+      POSTGRES_DB: "eddie"
+    restart: "always"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./create-example-app-db.sql:/docker-entrypoint-initdb.d/create_database.sql
 
   eddie:
     image: ghcr.io/eddie-energy/eddie:latest
@@ -22,6 +36,7 @@ services:
       - ./data-needs.yml:/opt/core/config/data-needs.yml
     depends_on:
       - kafka
+      - db
 
   eddie-example-app:
     image: ghcr.io/eddie-energy/eddie-example-app:latest
@@ -29,11 +44,14 @@ services:
       dockerfile: src/main/docker/Dockerfile
       context: ../examples/example-app
     environment:
-      JDBC_URL: "jdbc:h2:tcp://h2/demo-db"
+      JDBC_URL: "jdbc:postgresql://db:5432/example_app"
       JDBC_USER: "test"
       JDBC_PASSWORD: "test"
       EDDIE_PUBLIC_URL: ${PUBLIC_CONTEXT_PATH}
       PUBLIC_CONTEXT_PATH: ${PUBLIC_CONTEXT_PATH}
+    restart: always
+    depends_on:
+      - db
 
   kafka:
     image: bitnami/kafka:3.6
@@ -63,3 +81,4 @@ services:
 
 volumes:
   caddy_data:
+  postgres_data:

--- a/examples/example-app/build.gradle.kts
+++ b/examples/example-app/build.gradle.kts
@@ -35,7 +35,10 @@ dependencies {
     implementation(libs.reactor.core)
     implementation(libs.jte)
     implementation(libs.slf4j.simple)
+
     runtimeOnly(libs.h2database)
+    runtimeOnly(libs.postgresql)
+
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.jupiter)
 }
@@ -50,9 +53,16 @@ tasks.register("run-example-app", JavaExec::class) {
     systemProperties.set("developmentMode", "true")
     group = "development"
     description = "run the example-app in development mode (for Jte templates)"
-    environment["JDBC_URL"] = "jdbc:h2:tcp://localhost:9091/./examples/example-app"
     environment["PUBLIC_CONTEXT_PATH"] = ""
     environment["EDDIE_PUBLIC_URL"] = "http://localhost:8080"
+
+    // when using PostgreSQL
+    environment["JDBC_URL"] = "jdbc:postgresql://localhost:5432/example_app"
+    environment["JDBC_USER"] = "test"
+    environment["JDBC_PASSWORD"] = "test"
+
+    // when using H2
+//    environment["JDBC_URL"] = "jdbc:h2:tcp://localhost:9091/./examples/example-app"
 }
 
 tasks.getByName<Test>("test") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ commons-codec = "1.15"
 jsonschema2pojo = "1.2.1"
 jackson = "2.15.2"
 h2database = "2.1.212"
+postgresql = "42.7.1"
 javalin = "5.6.2"
 jdbi3 = "3.37.1"
 reactor = "3.5.5"
@@ -86,6 +87,7 @@ commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka-clients" }
 
 # used by core
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 h2database = { module = "com.h2database:h2", version.ref = "h2database" }
 javalin = { module = "io.javalin:javalin", version.ref = "javalin" }
 jetty-proxy = { module = "org.eclipse.jetty:jetty-proxy", version.ref = "jetty" }


### PR DESCRIPTION
Updated the DB URLs for example app and core to use PostgreSQL.

Added a PostgreSQL container to the docker compose file.

H2 is still supported.