### PR TITLE
GH-531 Set Location header for new permission requests

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/web/PermissionRequestController.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/web/PermissionRequestController.java
@@ -10,10 +10,10 @@ import energy.eddie.regionconnector.shared.exceptions.PermissionNotFoundExceptio
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriTemplate;
 
 import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_REQUEST;
 import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_STATUS_WITH_PATH_PARAM;
@@ -39,11 +39,14 @@ public class PermissionRequestController {
     @PostMapping(value = PATH_PERMISSION_REQUEST,
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.CREATED)
-    public CreatedPermissionRequest createPermissionRequest(
+    public ResponseEntity<CreatedPermissionRequest> createPermissionRequest(
             @RequestBody @Valid PermissionRequestForCreation permissionRequestForCreation
     ) throws StateTransitionException {
         LOGGER.info("Creating new permission request");
-        return creationService.createAndSendPermissionRequest(permissionRequestForCreation);
+        var createdRequest = creationService.createAndSendPermissionRequest(permissionRequestForCreation);
+        var location = new UriTemplate(PATH_PERMISSION_STATUS_WITH_PATH_PARAM)
+                .expand(createdRequest.permissionId());
+
+        return ResponseEntity.created(location).body(createdRequest);
     }
 }

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/web/PermissionRequestControllerTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/web/PermissionRequestControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.util.UriTemplate;
 
 import java.time.Clock;
 import java.time.LocalDate;
@@ -33,6 +34,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_STATUS_WITH_PATH_PARAM;
 import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -183,8 +185,9 @@ class PermissionRequestControllerTest {
     }
 
     @Test
-    void createPermissionRequest_returnsPermissionRequest() throws Exception {
+    void createPermissionRequest_returnsPermissionRequest_andSetsLocationHeader() throws Exception {
         // Given
+        var expectedLocationHeader = new UriTemplate(PATH_PERMISSION_STATUS_WITH_PATH_PARAM).expand("pid").toString();
         CreatedPermissionRequest expected = new CreatedPermissionRequest("pid", "cmRequestId");
         when(permissionRequestCreationService.createAndSendPermissionRequest(any()))
                 .thenReturn(expected);
@@ -202,7 +205,8 @@ class PermissionRequestControllerTest {
                 )
                 // Then
                 .andExpect(status().isCreated())
-                .andExpect(content().json(objectMapper.writeValueAsString(expected)));
+                .andExpect(content().json(objectMapper.writeValueAsString(expected)))
+                .andExpect(header().string("Location", is(expectedLocationHeader)));
     }
 
     @Test
@@ -230,6 +234,9 @@ class PermissionRequestControllerTest {
     @Test
     void createPermissionRequest_201WhenEndDateNull() throws Exception {
         // Given
+        CreatedPermissionRequest expected = new CreatedPermissionRequest("pid", "cmRequestId");
+        when(permissionRequestCreationService.createAndSendPermissionRequest(any()))
+                .thenReturn(expected);
         LocalDate start = LocalDate.now(Clock.systemUTC()).minusDays(1);
         PermissionRequestForCreation permissionRequestForCreation = new PermissionRequestForCreation("cid", "0".repeat(33), "dnid", "0".repeat(8), start, null, Granularity.PT15M);
         String content = objectMapper.writeValueAsString(permissionRequestForCreation);

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/web/PermissionRequestControllerTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/web/PermissionRequestControllerTest.java
@@ -16,12 +16,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.util.UriTemplate;
 
 import java.net.URI;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_STATUS_WITH_PATH_PARAM;
 import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -84,6 +86,7 @@ class PermissionRequestControllerTest {
     @Test
     void createPermissionRequest_returnsCreated() throws Exception {
         // Given
+        var expectedLocationHeader = new UriTemplate(PATH_PERMISSION_STATUS_WITH_PATH_PARAM).expand("pid").toString();
         when(permissionRequestService.createPermissionRequest(any()))
                 .thenReturn(new CreatedPermissionRequest("pid", URI.create("https://redirect.com")));
         PermissionRequestForCreation pr = new PermissionRequestForCreation(
@@ -101,7 +104,7 @@ class PermissionRequestControllerTest {
                 )
                 // Then
                 .andExpect(status().isCreated())
-                .andExpect(header().exists("Location"));
+                .andExpect(header().string("Location", is(expectedLocationHeader)));
     }
 
     @Test


### PR DESCRIPTION
Only setting the location header in the controller.
The usage of it in the *ce.js* files will be implemented in #467.