### PR TITLE
GH-380 Read boolean properties for eddie button correctly

### DIFF
--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -68,10 +68,10 @@ function durationFromDateString(dateString) {
 
 class EddieConnectButton extends LitElement {
   static properties = {
-    connectionId: { attribute: "connection-id" },
-    dataNeedId: { attribute: "data-need-id" },
-    allowDataNeedModifications: { attribute: "allow-data-need-modifications" },
-    allowDataNeedSelection: { attribute: "allow-data-need-selection" },
+    connectionId: { attribute: "connection-id", type: String },
+    dataNeedId: { attribute: "data-need-id", type: String },
+    allowDataNeedModifications: { attribute: "allow-data-need-modifications", type: Object },
+    allowDataNeedSelection: { attribute: "allow-data-need-selection", type: Object },
 
     _dataNeedIds: { type: Array },
     _selectedCountry: { type: String },


### PR DESCRIPTION
Add type to connect button properties to interpret boolean values as objects. Otherwise, the boolean value will always be true if the property exists with any value.

As can be seen in the screenshot, the button has the boolean values as strings and they are interpreted correctly.
![image](https://github.com/eddie-energy/eddie/assets/10999017/1f788ad1-0bf2-4fd3-888f-d1048421c7ea)
