### PR TITLE
NOISSUE Fix termination status messages not being published to Kafka

### DIFF
--- a/core/src/test/java/energy/eddie/core/services/TerminationRouterTest.java
+++ b/core/src/test/java/energy/eddie/core/services/TerminationRouterTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import reactor.adapter.JdkFlowAdapter;
 import reactor.test.publisher.TestPublisher;
 
+import java.util.Optional;
+
 import static org.mockito.Mockito.*;
 
 class TerminationRouterTest {
@@ -19,7 +21,7 @@ class TerminationRouterTest {
         TestPublisher<Pair<String, ConsentMarketDocument>> publisher = TestPublisher.create();
         var connector = mock(TerminationConnector.class);
         when(connector.getTerminationMessages()).thenReturn(JdkFlowAdapter.publisherToFlowPublisher(publisher));
-        var router = new TerminationRouter(connector);
+        var router = new TerminationRouter(Optional.of(connector));
 
         var metadata1 = mock(RegionConnectorMetadata.class);
         when(metadata1.id()).thenReturn("id");
@@ -60,7 +62,7 @@ class TerminationRouterTest {
         TestPublisher<Pair<String, ConsentMarketDocument>> publisher = TestPublisher.create();
         var connector = mock(TerminationConnector.class);
         when(connector.getTerminationMessages()).thenReturn(JdkFlowAdapter.publisherToFlowPublisher(publisher));
-        var router = new TerminationRouter(connector);
+        var router = new TerminationRouter(Optional.of(connector));
 
         var metadata1 = mock(RegionConnectorMetadata.class);
         when(metadata1.id()).thenReturn("id");
@@ -106,7 +108,7 @@ class TerminationRouterTest {
         TestPublisher<Pair<String, ConsentMarketDocument>> publisher = TestPublisher.create();
         var connector = mock(TerminationConnector.class);
         when(connector.getTerminationMessages()).thenReturn(JdkFlowAdapter.publisherToFlowPublisher(publisher));
-        var router = new TerminationRouter(connector);
+        var router = new TerminationRouter(Optional.of(connector));
 
         var metadata1 = mock(RegionConnectorMetadata.class);
         when(metadata1.id()).thenReturn("id");

--- a/outbound-kafka/src/main/java/energy/eddie/outbound/kafka/TerminationKafkaConnector.java
+++ b/outbound-kafka/src/main/java/energy/eddie/outbound/kafka/TerminationKafkaConnector.java
@@ -29,6 +29,9 @@ public class TerminationKafkaConnector implements TerminationConnector {
         ReceiverOptions<String, ConsentMarketDocument> options = ReceiverOptions
                 .<String, ConsentMarketDocument>create(kafkaProperties)
                 .subscription(Collections.singleton(terminationTopic))
+                // ensure no messages are skipped: start at the beginning of topic of no committed offsets are found
+                .consumerProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                .commitBatchSize(1) // commit after every message
                 .withKeyDeserializer(new StringDeserializer())
                 .withValueDeserializer(new CustomDeserializer())
                 .addAssignListener(partitions -> log.debug("onPartitionsAssigned {}", partitions))


### PR DESCRIPTION
Apparently, in the docker image, @ConditionalOnBean(TerminationConnector.class) causes the class to never be instantiated, although the same config works when running the Gradle run task in the IDE.