### PR TITLE
GH-713 Fix JpaRepository not found in Docker image

### DIFF
--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/EnerginetPersistenceConfig.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/EnerginetPersistenceConfig.java
@@ -1,0 +1,11 @@
+package energy.eddie.regionconnector.dk;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableJpaRepositories
+@EntityScan
+@Configuration
+public class EnerginetPersistenceConfig {
+}

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisPersistenceConfig.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisPersistenceConfig.java
@@ -1,0 +1,11 @@
+package energy.eddie.regionconnector.es.datadis;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableJpaRepositories
+@EntityScan
+@Configuration
+public class DatadisPersistenceConfig {
+}

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisSpringConfig.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisSpringConfig.java
@@ -2,6 +2,7 @@ package energy.eddie.regionconnector.es.datadis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import energy.eddie.api.agnostic.RegionConnector;
 import energy.eddie.api.v0.ConnectionStatusMessage;
 import energy.eddie.api.v0_82.ConsentMarketDocumentProvider;
 import energy.eddie.api.v0_82.cim.config.CommonInformationModelConfiguration;
@@ -43,7 +44,7 @@ import static energy.eddie.regionconnector.es.datadis.DatadisRegionConnectorMeta
 @EnableWebMvc
 @SpringBootApplication
 @EnableScheduling
-@energy.eddie.api.agnostic.RegionConnector(name = REGION_CONNECTOR_ID)
+@RegionConnector(name = REGION_CONNECTOR_ID)
 public class DatadisSpringConfig {
     @Bean
     public DatadisConfig datadisConfig(


### PR DESCRIPTION
Docker image fails to run because `Could not find a Bean of type JpaPermissionRequestRepository`.
This only happens in the docker image, local Gradle runs execute as expected.

It seems that the `@Repository` annotated classes are not instantiated in the Docker image, but they are when using Gradle.
This can be fixed by explicitly creating a `@Configuration` class with `@EnableJpaRepositories` for each region connector.
Note that it has to be declared in a dedicated Java class, otherwise weird side effects occur, e.g. `@WebMvcTests` fail.


Aside from these code changes, I changed the default database for EDDIE on the EDDIE Online server to PostgreSQL and migrated all DataNeeds to the new database.