### PR TITLE
GH-278 Add Granularity to FrEnedisPermissionRequest

### DIFF
--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/EnedisPermissionRequest.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/EnedisPermissionRequest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.PermissionRequestState;
 import energy.eddie.api.v0.DataSourceInformation;
 import energy.eddie.regionconnector.fr.enedis.permission.request.api.FrEnedisPermissionRequest;
@@ -20,6 +21,7 @@ public class EnedisPermissionRequest extends TimestampedPermissionRequest implem
     private final ZonedDateTime start;
     private final ZonedDateTime end;
     private final String dataNeedId;
+    private final Granularity granularity;
     private PermissionRequestState state;
     @Nullable
     private String usagePointId;
@@ -29,8 +31,8 @@ public class EnedisPermissionRequest extends TimestampedPermissionRequest implem
             String connectionId,
             String dataNeedId,
             ZonedDateTime start,
-            ZonedDateTime end
-    ) {
+            ZonedDateTime end,
+            Granularity granularity) {
         super(ZONE_ID_FR);
         this.permissionId = permissionId;
         this.connectionId = connectionId;
@@ -38,15 +40,16 @@ public class EnedisPermissionRequest extends TimestampedPermissionRequest implem
         this.dataNeedId = dataNeedId;
         this.start = start;
         this.end = end;
+        this.granularity = granularity;
     }
 
     public EnedisPermissionRequest(
             String connectionId,
             String dataNeedId,
             ZonedDateTime start,
-            ZonedDateTime end
-    ) {
-        this(UUID.randomUUID().toString(), connectionId, dataNeedId, start, end);
+            ZonedDateTime end,
+            Granularity granularity) {
+        this(UUID.randomUUID().toString(), connectionId, dataNeedId, start, end, granularity);
     }
 
     @Override
@@ -98,5 +101,10 @@ public class EnedisPermissionRequest extends TimestampedPermissionRequest implem
     @Override
     public void setUsagePointId(String usagePointId) {
         this.usagePointId = usagePointId;
+    }
+
+    @Override
+    public Granularity granularity() {
+        return granularity;
     }
 }

--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/PermissionRequestFactory.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/PermissionRequestFactory.java
@@ -29,7 +29,8 @@ public class PermissionRequestFactory {
                 permissionRequestForCreation.connectionId(),
                 permissionRequestForCreation.dataNeedId(),
                 permissionRequestForCreation.start(),
-                permissionRequestForCreation.end()
+                permissionRequestForCreation.end(),
+                permissionRequestForCreation.granularity()
         );
         return PermissionRequestProxy.createProxy(
                 permissionRequest,

--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/api/FrEnedisPermissionRequest.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/api/FrEnedisPermissionRequest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request.api;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.TimeframedPermissionRequest;
 import energy.eddie.regionconnector.shared.permission.requests.annotations.InvokeExtensions;
 
@@ -10,4 +11,6 @@ public interface FrEnedisPermissionRequest extends TimeframedPermissionRequest {
 
     @InvokeExtensions
     void setUsagePointId(String usagePointId);
+
+    Granularity granularity();
 }

--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/dtos/PermissionRequestForCreation.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/permission/request/dtos/PermissionRequestForCreation.java
@@ -1,5 +1,7 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request.dtos;
 
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.regionconnector.shared.validation.SupportedGranularities;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -13,6 +15,8 @@ public record PermissionRequestForCreation(
         @NotNull(message = "must not be null")
         ZonedDateTime start,
         @NotNull(message = "must not be null")
-        ZonedDateTime end
+        ZonedDateTime end,
+        @SupportedGranularities({Granularity.P1D, Granularity.PT30M})
+        Granularity granularity
 ) {
 }

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/EnedisRegionConnectorTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/EnedisRegionConnectorTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.states.TerminatedPermissionRequestState;
 import energy.eddie.api.v0.ConnectionStatusMessage;
 import energy.eddie.api.v0.HealthState;
@@ -82,7 +83,8 @@ class EnedisRegionConnectorTest {
                 "cid",
                 "dnid",
                 ZonedDateTime.now(ZoneOffset.UTC),
-                ZonedDateTime.now(ZoneOffset.UTC)
+                ZonedDateTime.now(ZoneOffset.UTC),
+                Granularity.P1D
         );
         request.changeState(new FrEnedisAcceptedState(request));
         when(permissionRequestService.findPermissionRequestByPermissionId(anyString()))
@@ -112,7 +114,8 @@ class EnedisRegionConnectorTest {
                 Optional.of("upId"),
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
-                new FrEnedisInvalidState(null)
+                new FrEnedisInvalidState(null),
+                Granularity.P1D
         );
         when(permissionRequestService.findPermissionRequestByPermissionId(anyString())).thenReturn(Optional.of(request));
         Sinks.Many<ConnectionStatusMessage> sink = Sinks.many().multicast().onBackpressureBuffer();

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/EnedisPermissionRequestTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/EnedisPermissionRequestTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.PermissionRequestState;
 import energy.eddie.regionconnector.fr.enedis.permission.request.states.FrEnedisMalformedState;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ class EnedisPermissionRequestTest {
         ZonedDateTime end = start.plusDays(1);
 
         // When
-        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end, Granularity.P1D);
 
         // Then
         assertEquals(permissionId, request.permissionId());
@@ -35,7 +36,7 @@ class EnedisPermissionRequestTest {
         ZonedDateTime end = start.plusDays(1);
 
         // When
-        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end, Granularity.P1D);
 
         // Then
         assertEquals(connectionId, request.connectionId());
@@ -49,7 +50,7 @@ class EnedisPermissionRequestTest {
         ZonedDateTime end = start.plusDays(1);
 
         // When
-        EnedisPermissionRequest request = new EnedisPermissionRequest(connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(connectionId, "dnid", start, end, Granularity.P1D);
 
         // Then
         assertNotNull(request.permissionId());
@@ -64,7 +65,7 @@ class EnedisPermissionRequestTest {
         ZonedDateTime end = start.plusDays(1);
 
         // When
-        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end, Granularity.P1D);
 
         // Then
         assertEquals(start, request.start());
@@ -79,7 +80,7 @@ class EnedisPermissionRequestTest {
         ZonedDateTime end = start.plusDays(1);
 
         // When
-        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end, Granularity.P1D);
 
         // Then
         assertEquals(end, request.end());
@@ -94,7 +95,7 @@ class EnedisPermissionRequestTest {
         ZonedDateTime end = start.plusDays(1);
 
         // When
-        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end, Granularity.P1D);
 
         // Then
         assertEquals("testConnectionId", request.connectionId());
@@ -107,7 +108,7 @@ class EnedisPermissionRequestTest {
         String connectionId = "testConnectionId";
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
-        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end, Granularity.P1D);
         PermissionRequestState newState = new FrEnedisMalformedState(request, List.of());
 
         // When
@@ -125,7 +126,7 @@ class EnedisPermissionRequestTest {
         String connectionId = "testConnectionId";
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
-        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end, Granularity.P1D);
         String usagePointId = "testUsagePointId";
 
         // When
@@ -142,7 +143,7 @@ class EnedisPermissionRequestTest {
         String connectionId = "testConnectionId";
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
-        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end);
+        EnedisPermissionRequest request = new EnedisPermissionRequest(permissionId, connectionId, "dnid", start, end, Granularity.P1D);
 
         // Then
         assertFalse(request.usagePointId().isPresent());

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/PermissionRequestFactoryTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/PermissionRequestFactoryTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.PermissionRequest;
 import energy.eddie.regionconnector.fr.enedis.permission.request.api.FrEnedisPermissionRequest;
 import energy.eddie.regionconnector.fr.enedis.permission.request.dtos.PermissionRequestForCreation;
@@ -18,7 +19,7 @@ class PermissionRequestFactoryTest {
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
         PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(Set.of());
-        PermissionRequestForCreation permissionRequestForCreation = new PermissionRequestForCreation("cid", "dnid", start, end);
+        PermissionRequestForCreation permissionRequestForCreation = new PermissionRequestForCreation("cid", "dnid", start, end, Granularity.P1D);
 
         // When
         PermissionRequest permissionRequest = permissionRequestFactory.create(permissionRequestForCreation);
@@ -33,7 +34,7 @@ class PermissionRequestFactoryTest {
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
         PermissionRequestFactory permissionRequestFactory = new PermissionRequestFactory(Set.of());
-        FrEnedisPermissionRequest original = new EnedisPermissionRequest("cid", "dnid", start, end);
+        FrEnedisPermissionRequest original = new EnedisPermissionRequest("cid", "dnid", start, end, Granularity.P1D);
 
         // When
         PermissionRequest permissionRequest = permissionRequestFactory.create(original);

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/SimplePermissionRequest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/SimplePermissionRequest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.PermissionRequestState;
 import energy.eddie.api.v0.DataSourceInformation;
 import energy.eddie.regionconnector.fr.enedis.permission.request.api.FrEnedisPermissionRequest;
@@ -10,9 +11,10 @@ import java.util.Optional;
 public record SimplePermissionRequest(String permissionId, String connectionId, String dataNeedId,
                                       Optional<String> usagePointId,
                                       ZonedDateTime start, ZonedDateTime end,
-                                      PermissionRequestState state) implements FrEnedisPermissionRequest {
+                                      PermissionRequestState state,
+                                      Granularity granularity) implements FrEnedisPermissionRequest {
     public SimplePermissionRequest(String permissionId, String connectionId) {
-        this(permissionId, connectionId, null, Optional.empty(), null, null, null);
+        this(permissionId, connectionId, null, Optional.empty(), null, null, null, Granularity.P1D);
     }
 
     @Override

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisAcceptedStateTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisAcceptedStateTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request.states;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.states.TerminatedPermissionRequestState;
 import energy.eddie.regionconnector.fr.enedis.permission.request.EnedisPermissionRequest;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,8 @@ class FrEnedisAcceptedStateTest {
                 "cid",
                 "dnid",
                 ZonedDateTime.now(ZoneOffset.UTC),
-                ZonedDateTime.now(ZoneOffset.UTC)
-        );
+                ZonedDateTime.now(ZoneOffset.UTC),
+                Granularity.P1D);
         FrEnedisAcceptedState acceptedState = new FrEnedisAcceptedState(request);
 
         // When

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisCreatedStateTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisCreatedStateTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request.states;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.validation.ValidationException;
 import energy.eddie.regionconnector.fr.enedis.permission.request.EnedisPermissionRequest;
 import energy.eddie.regionconnector.fr.enedis.permission.request.api.FrEnedisPermissionRequest;
@@ -17,7 +18,7 @@ class FrEnedisCreatedStateTest {
     void validate_changesToValidatedState_whenValid() throws ValidationException {
         // Given
         ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
-        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", now, now.plusDays(1));
+        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", now, now.plusDays(1), Granularity.P1D);
         FrEnedisCreatedState createdState = new FrEnedisCreatedState(permissionRequest);
 
         // When
@@ -32,7 +33,7 @@ class FrEnedisCreatedStateTest {
         // Given
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.minusDays(1);
-        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", start, end);
+        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", start, end, Granularity.P1D);
         FrEnedisCreatedState createdState = new FrEnedisCreatedState(permissionRequest);
 
         // When, Then
@@ -45,7 +46,7 @@ class FrEnedisCreatedStateTest {
         // Given
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusYears(4);
-        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", start, end);
+        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", start, end, Granularity.P1D);
         FrEnedisCreatedState createdState = new FrEnedisCreatedState(permissionRequest);
 
         // When, Then

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisPendingAcknowledgmentStateTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisPendingAcknowledgmentStateTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request.states;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.regionconnector.fr.enedis.permission.request.EnedisPermissionRequest;
 import energy.eddie.regionconnector.fr.enedis.permission.request.api.FrEnedisPermissionRequest;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class FrEnedisPendingAcknowledgmentStateTest {
         // Given
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
-        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         FrEnedisPendingAcknowledgmentState state = new FrEnedisPendingAcknowledgmentState(permissionRequest);
 
         // When

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisSentToPermissionAdministratorStateTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisSentToPermissionAdministratorStateTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request.states;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.regionconnector.fr.enedis.permission.request.EnedisPermissionRequest;
 import energy.eddie.regionconnector.fr.enedis.permission.request.api.FrEnedisPermissionRequest;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class FrEnedisSentToPermissionAdministratorStateTest {
         // Given
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
-        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         FrEnedisSentToPermissionAdministratorState state = new FrEnedisSentToPermissionAdministratorState(permissionRequest);
 
         // When
@@ -31,7 +32,7 @@ class FrEnedisSentToPermissionAdministratorStateTest {
         // Given
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
-        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         FrEnedisSentToPermissionAdministratorState state = new FrEnedisSentToPermissionAdministratorState(permissionRequest);
 
         // When
@@ -46,7 +47,7 @@ class FrEnedisSentToPermissionAdministratorStateTest {
         // Given
         ZonedDateTime start = ZonedDateTime.now(ZoneId.systemDefault());
         ZonedDateTime end = start.plusDays(1);
-        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         FrEnedisSentToPermissionAdministratorState state = new FrEnedisSentToPermissionAdministratorState(permissionRequest);
 
         // When

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisValidatedStateTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/states/FrEnedisValidatedStateTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request.states;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.regionconnector.fr.enedis.permission.request.EnedisPermissionRequest;
 import energy.eddie.regionconnector.fr.enedis.permission.request.api.FrEnedisPermissionRequest;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,7 @@ class FrEnedisValidatedStateTest {
     void sendToPermissionAdministrator_transitionsStatePendingAcknowledgmentState() {
         // Given
         ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
-        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", now, now.plusDays(1));
+        FrEnedisPermissionRequest permissionRequest = new EnedisPermissionRequest("pid", "cid", "dnid", now, now.plusDays(1), Granularity.P1D);
         FrEnedisValidatedState state = new FrEnedisValidatedState(permissionRequest);
 
         // When

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/validation/NotFurtherThanValidatorTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/permission/request/validation/NotFurtherThanValidatorTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.permission.request.validation;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.TimeframedPermissionRequest;
 import energy.eddie.api.agnostic.process.model.validation.AttributeError;
 import energy.eddie.regionconnector.fr.enedis.permission.request.EnedisPermissionRequest;
@@ -17,7 +18,7 @@ class NotFurtherThanValidatorTest {
     @Test
     void test_validate_when_endDateIsWithinLimit() {
         // Given
-        TimeframedPermissionRequest request = new EnedisPermissionRequest("cid", "dnid", ZonedDateTime.now(ZoneOffset.UTC), ZonedDateTime.now(ZoneOffset.UTC).plusHours(1));
+        TimeframedPermissionRequest request = new EnedisPermissionRequest("cid", "dnid", ZonedDateTime.now(ZoneOffset.UTC), ZonedDateTime.now(ZoneOffset.UTC).plusHours(1), Granularity.P1D);
         NotFurtherThanValidator validator = new NotFurtherThanValidator(ChronoUnit.DAYS, 1);
 
         // When
@@ -30,7 +31,7 @@ class NotFurtherThanValidatorTest {
     @Test
     void test_validate_when_endDateIsOutOfBounds() {
         // Given
-        TimeframedPermissionRequest request = new EnedisPermissionRequest("cid", "dnid", ZonedDateTime.now(ZoneOffset.UTC), ZonedDateTime.now(ZoneOffset.UTC).plusDays(2));
+        TimeframedPermissionRequest request = new EnedisPermissionRequest("cid", "dnid", ZonedDateTime.now(ZoneOffset.UTC), ZonedDateTime.now(ZoneOffset.UTC).plusDays(2), Granularity.P1D);
         NotFurtherThanValidator validator = new NotFurtherThanValidator(ChronoUnit.DAYS, 1);
 
         // When

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/services/PermissionRequestServiceTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/services/PermissionRequestServiceTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.services;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.PermissionRequestRepository;
 import energy.eddie.api.agnostic.process.model.StateTransitionException;
 import energy.eddie.regionconnector.fr.enedis.permission.request.EnedisPermissionRequest;
@@ -31,7 +32,7 @@ class PermissionRequestServiceTest {
         // Given
         var start = ZonedDateTime.now(ZoneOffset.UTC);
         var end = ZonedDateTime.now(ZoneOffset.UTC).plusDays(10);
-        var request = new PermissionRequestForCreation("cid", "dnid", start, end);
+        var request = new PermissionRequestForCreation("cid", "dnid", start, end, Granularity.P1D);
 
         // When
         var res = permissionRequestService.createPermissionRequest(request);
@@ -49,7 +50,7 @@ class PermissionRequestServiceTest {
         // Given
         var start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(3);
         var end = ZonedDateTime.now(ZoneOffset.UTC);
-        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         request.changeState(new FrEnedisPendingAcknowledgmentState(request));
         repository.save(request);
 
@@ -66,7 +67,7 @@ class PermissionRequestServiceTest {
         // Given
         var start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(3);
         var end = ZonedDateTime.now(ZoneOffset.UTC);
-        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         request.changeState(new FrEnedisPendingAcknowledgmentState(request));
         repository.save(request);
 
@@ -89,7 +90,7 @@ class PermissionRequestServiceTest {
         // Given
         var start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(3);
         var end = ZonedDateTime.now(ZoneOffset.UTC);
-        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         repository.save(request);
 
         // When
@@ -106,7 +107,7 @@ class PermissionRequestServiceTest {
         // Given
         var start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(3);
         var end = ZonedDateTime.now(ZoneOffset.UTC);
-        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         repository.save(request);
 
         // When
@@ -122,7 +123,7 @@ class PermissionRequestServiceTest {
         // Given
         var start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(3);
         var end = ZonedDateTime.now(ZoneOffset.UTC);
-        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         repository.save(request);
 
         // When
@@ -139,7 +140,7 @@ class PermissionRequestServiceTest {
         // Given
         var start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(3);
         var end = ZonedDateTime.now(ZoneOffset.UTC);
-        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        var request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         repository.save(request);
 
         // When

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/services/PollingServiceTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/services/PollingServiceTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.services;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.v0.PermissionProcessStatus;
 import energy.eddie.regionconnector.fr.enedis.invoker.ApiException;
 import energy.eddie.regionconnector.fr.enedis.model.ConsumptionLoadCurveMeterReading;
@@ -34,7 +35,7 @@ class PollingServiceTest {
         PollingService pollingService = new PollingService(enedisApiService, sink);
         ZonedDateTime start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(20);
         ZonedDateTime end = ZonedDateTime.now(ZoneOffset.UTC).minusDays(10);
-        FrEnedisPermissionRequest request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        FrEnedisPermissionRequest request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
 
         // When
         pollingService.requestData(request, "usagePointId");
@@ -60,7 +61,7 @@ class PollingServiceTest {
         PollingService pollingService = new PollingService(enedisApiService, sink);
         ZonedDateTime start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(20);
         ZonedDateTime end = ZonedDateTime.now(ZoneOffset.UTC).minusDays(10);
-        FrEnedisPermissionRequest request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        FrEnedisPermissionRequest request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         request.changeState(new FrEnedisAcceptedState(request));
 
         // When
@@ -83,7 +84,7 @@ class PollingServiceTest {
         PollingService pollingService = new PollingService(enedisApiService, sink);
         ZonedDateTime start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(20);
         ZonedDateTime end = ZonedDateTime.now(ZoneOffset.UTC).minusDays(10);
-        FrEnedisPermissionRequest request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        FrEnedisPermissionRequest request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
         request.changeState(new FrEnedisAcceptedState(request));
 
         // When
@@ -106,7 +107,7 @@ class PollingServiceTest {
         PollingService pollingService = new PollingService(enedisApiService, sink);
         ZonedDateTime start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(20);
         ZonedDateTime end = ZonedDateTime.now(ZoneOffset.UTC).minusDays(10);
-        FrEnedisPermissionRequest request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end);
+        FrEnedisPermissionRequest request = new EnedisPermissionRequest("pid", "cid", "dnid", start, end, Granularity.P1D);
 
         // When
         pollingService.requestData(request, "usagePointId");

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/utils/EnedisDurationTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/utils/EnedisDurationTest.java
@@ -1,5 +1,6 @@
 package energy.eddie.regionconnector.fr.enedis.utils;
 
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.process.model.TimeframedPermissionRequest;
 import energy.eddie.regionconnector.fr.enedis.permission.request.EnedisPermissionRequest;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ class EnedisDurationTest {
         // Given
         ZonedDateTime start = ZonedDateTime.now(ZoneOffset.UTC).minusDays(10);
         ZonedDateTime end = start.plusDays(3);
-        TimeframedPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", start, end);
+        TimeframedPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", start, end, Granularity.P1D);
         EnedisDuration duration = new EnedisDuration(permissionRequest);
 
         // When
@@ -42,7 +43,7 @@ class EnedisDurationTest {
     @MethodSource("testEnedisDuration_returnsISODuration_ifEndIsInFuture_methodSource")
     void testEnedisDuration_returnsISODuration_ifEndIsInFuture(ZonedDateTime start, ZonedDateTime end, String expected) {
         // Given
-        TimeframedPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", start, end);
+        TimeframedPermissionRequest permissionRequest = new EnedisPermissionRequest("cid", "dnid", start, end, Granularity.P1D);
         EnedisDuration duration = new EnedisDuration(permissionRequest);
 
         // When

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/web/PermissionRequestControllerTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/web/PermissionRequestControllerTest.java
@@ -1,6 +1,7 @@
 package energy.eddie.regionconnector.fr.enedis.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.v0.ConnectionStatusMessage;
 import energy.eddie.api.v0.PermissionProcessStatus;
 import energy.eddie.regionconnector.fr.enedis.permission.request.dtos.CreatedPermissionRequest;
@@ -42,19 +43,6 @@ class PermissionRequestControllerTest {
     @MockBean
     private PermissionRequestService permissionRequestService;
 
-    /**
-     * The {@link RegionConnectorsCommonControllerAdvice} is automatically registered for each region connector when the
-     * whole core is started. To be able to properly test the controller's error responses, manually add the advice
-     * to this test class.
-     */
-    @TestConfiguration
-    static class ControllerTestConfiguration {
-        @Bean
-        public RegionConnectorsCommonControllerAdvice regionConnectorsCommonControllerAdvice() {
-            return new RegionConnectorsCommonControllerAdvice();
-        }
-    }
-
     @Test
     void permissionStatus_permissionExists_returnsOk() throws Exception {
         // Given
@@ -93,7 +81,8 @@ class PermissionRequestControllerTest {
                 "cid",
                 "dnid",
                 ZonedDateTime.now(ZoneOffset.UTC),
-                ZonedDateTime.now(ZoneOffset.UTC).plusDays(10)
+                ZonedDateTime.now(ZoneOffset.UTC).plusDays(10),
+                Granularity.P1D
         );
 
         // When
@@ -156,5 +145,18 @@ class PermissionRequestControllerTest {
                         hasItem("start: must not be null"),
                         hasItem("end: must not be null")
                 )));
+    }
+
+    /**
+     * The {@link RegionConnectorsCommonControllerAdvice} is automatically registered for each region connector when the
+     * whole core is started. To be able to properly test the controller's error responses, manually add the advice
+     * to this test class.
+     */
+    @TestConfiguration
+    static class ControllerTestConfiguration {
+        @Bean
+        public RegionConnectorsCommonControllerAdvice regionConnectorsCommonControllerAdvice() {
+            return new RegionConnectorsCommonControllerAdvice();
+        }
     }
 }


### PR DESCRIPTION
Add Granularity so Enedis can support PT1D and PT30M reuqests. This is a preparation for another PR.
With this Enedis does not actually support Granularities on an API level yet