### PR TITLE
NOISSUE Move name of error property to api module

### DIFF
--- a/api/src/main/java/energy/eddie/api/agnostic/GlobalConfig.java
+++ b/api/src/main/java/energy/eddie/api/agnostic/GlobalConfig.java
@@ -1,0 +1,7 @@
+package energy.eddie.api.agnostic;
+
+public final class GlobalConfig {
+    public static final String ERRORS_PROPERTY_NAME = "errors";
+
+    private GlobalConfig() {}
+}

--- a/core/src/main/java/energy/eddie/core/dataneeds/DataNeedsManagementControllerAdvice.java
+++ b/core/src/main/java/energy/eddie/core/dataneeds/DataNeedsManagementControllerAdvice.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import java.util.List;
 import java.util.Map;
 
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_PROPERTY_NAME;
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_PROPERTY_NAME;
 
 @ControllerAdvice
 @ConditionalOnProperty(value = "eddie.data-needs-config.data-need-source", havingValue = "DATABASE")

--- a/core/src/test/java/energy/eddie/core/dataneeds/DataNeedsManagementControllerAdviceTest.java
+++ b/core/src/test/java/energy/eddie/core/dataneeds/DataNeedsManagementControllerAdviceTest.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import java.util.List;
 import java.util.Map;
 
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_PROPERTY_NAME;
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_PROPERTY_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/region-connectors/shared/src/main/java/energy/eddie/spring/regionconnector/extensions/RegionConnectorsCommonControllerAdvice.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/spring/regionconnector/extensions/RegionConnectorsCommonControllerAdvice.java
@@ -25,10 +25,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_PROPERTY_NAME;
+
 @RegionConnectorExtension
 @RestControllerAdvice
 public class RegionConnectorsCommonControllerAdvice {
-    public static final String ERRORS_PROPERTY_NAME = "errors";
     public static final String ERRORS_JSON_PATH = "$." + ERRORS_PROPERTY_NAME;
     private static final Logger LOGGER = LoggerFactory.getLogger(RegionConnectorsCommonControllerAdvice.class);
 

--- a/region-connectors/shared/src/test/java/energy/eddie/spring/regionconnector/extensions/RegionConnectorsCommonControllerAdviceTest.java
+++ b/region-connectors/shared/src/test/java/energy/eddie/spring/regionconnector/extensions/RegionConnectorsCommonControllerAdviceTest.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_PROPERTY_NAME;
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_PROPERTY_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
Other modules may also use this information, and we want it to be consistent across all modules.

This file can be extended with other global configuration values, that are e.g. not only intended for region connectors.