### PR TITLE
NOISSUE Fix incorrect mapping of MeterReading.IntervalReading to VHD.SeriesPeriod

### DIFF
--- a/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/providers/v0_82/IntermediateValidatedHistoricalDocument.java
+++ b/region-connectors/region-connector-fr-enedis/src/main/java/energy/eddie/regionconnector/fr/enedis/providers/v0_82/IntermediateValidatedHistoricalDocument.java
@@ -126,29 +126,29 @@ public final class IntermediateValidatedHistoricalDocument {
         );
         var meterReading = meterReading();
         String resolution = identifiableMeterReading.permissionRequest().granularity().name();
-        List<SeriesPeriodComplexType> seriesPeriods = new ArrayList<>();
+        List<PointComplexType> points = new ArrayList<>();
         int position = 0;
         for (IntervalReading intervalReading
                 : meterReading.intervalReadings()) {
-            var seriesPeriod = new SeriesPeriodComplexType()
-                    .withResolution(resolution)
-                    .withTimeInterval(new ESMPDateTimeIntervalComplexType()
-                            .withStart(interval.start())
-                            .withEnd(interval.end())
-                    )
-                    .withPointList(
-                            new SeriesPeriodComplexType.PointList()
-                                    .withPoints(List.of(
-                                            new PointComplexType()
-                                                    .withPosition("%d".formatted(position))
-                                                    .withEnergyQuantityQuantity(new BigDecimal(intervalReading.value()))
-                                                    .withEnergyQuantityQuality(QualityTypeList.AS_PROVIDED)
-                                    ))
-                    );
-            seriesPeriods.add(seriesPeriod);
+            PointComplexType point = new PointComplexType()
+                    .withPosition("%d".formatted(position))
+                    .withEnergyQuantityQuantity(new BigDecimal(intervalReading.value()))
+                    .withEnergyQuantityQuality(QualityTypeList.AS_PROVIDED);
+            points.add(point);
             position++;
         }
-        return seriesPeriods;
+
+        var seriesPeriod = new SeriesPeriodComplexType()
+                .withResolution(resolution)
+                .withTimeInterval(new ESMPDateTimeIntervalComplexType()
+                        .withStart(interval.start())
+                        .withEnd(interval.end())
+                )
+                .withPointList(
+                        new SeriesPeriodComplexType.PointList()
+                                .withPoints(points)
+                );
+        return new ArrayList<>(List.of(seriesPeriod));
     }
 
     private MeterReading meterReading() {

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/providers/v0_82/IntermediateValidatedHistoricalDocumentTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/providers/v0_82/IntermediateValidatedHistoricalDocumentTest.java
@@ -71,7 +71,8 @@ class IntermediateValidatedHistoricalDocumentTest {
                 () -> assertEquals(ACTIVE_ENERGY, timeSeries.getProduct()),
                 () -> assertEquals(AggregateKind.SUM, timeSeries.getMarketEvaluationPointMeterReadingsReadingsReadingTypeAggregation()),
                 () -> assertEquals("24115050XXXXXX", timeSeries.getMarketEvaluationPointMRID().getValue()),
-                () -> assertEquals(7, timeSeries.getSeriesPeriodList().getSeriesPeriods().size()),
+                () -> assertEquals(1, timeSeries.getSeriesPeriodList().getSeriesPeriods().size()),
+                () -> assertEquals(7, timeSeries.getSeriesPeriodList().getSeriesPeriods().getFirst().getPointList().getPoints().size()),
                 () -> assertEquals(Granularity.P1D.name(), seriesPeriod.getResolution()),
                 () -> assertEquals(esmpTimeInterval.start(), seriesPeriod.getTimeInterval().getStart()),
                 () -> assertEquals(esmpTimeInterval.end(), seriesPeriod.getTimeInterval().getEnd()),
@@ -124,7 +125,8 @@ class IntermediateValidatedHistoricalDocumentTest {
                 () -> assertEquals(ACTIVE_POWER, timeSeries.getProduct()),
                 () -> assertEquals(AggregateKind.AVERAGE, timeSeries.getMarketEvaluationPointMeterReadingsReadingsReadingTypeAggregation()),
                 () -> assertEquals("24115050XXXXXX", timeSeries.getMarketEvaluationPointMRID().getValue()),
-                () -> assertEquals(47, timeSeries.getSeriesPeriodList().getSeriesPeriods().size()), // for some reason enedis only returns 47 values instead of 48
+                () -> assertEquals(1, timeSeries.getSeriesPeriodList().getSeriesPeriods().size()),
+                () -> assertEquals(47, timeSeries.getSeriesPeriodList().getSeriesPeriods().getFirst().getPointList().getPoints().size()), // for some reason enedis only returns 47 values instead of 48
                 () -> assertEquals(Granularity.PT30M.name(), seriesPeriod.getResolution()),
                 () -> assertEquals(esmpTimeInterval.start(), seriesPeriod.getTimeInterval().getStart()),
                 () -> assertEquals(esmpTimeInterval.end(), seriesPeriod.getTimeInterval().getEnd()),


### PR DESCRIPTION
I noticed we did the mapping of MeterReading.IntervalReading to the CIM SeriesPeriod type incorrectly.

Before we created a SeriesPeriod for every IntervalReading, however we should  create one SeriesPeriod that contains points for all IntervalReadings.

TLDR: IntervalReading should be mapped to Points and not SeriesPeriod