### PR TITLE
NOISSUE Ensure CIM compliance by checking type field of termination consent market documents

### DIFF
--- a/OPERATION.md
+++ b/OPERATION.md
@@ -60,11 +60,12 @@ page. It can be integrated into a frontend based application (e.g. a single-page
 web application as it's implemented using standard HTML custom elements.
 
 ```html
+
 <script type="module" src="${eddieUrl}/lib/eddie-components.js"></script>
 <!-- ... -->
 <eddie-connect-button
-  connection-id="1"
-  data-need-id="LAST_3_MONTHS_ONE_MEASUREMENT_PER_DAY"
+        connection-id="1"
+        data-need-id="LAST_3_MONTHS_ONE_MEASUREMENT_PER_DAY"
 ></eddie-connect-button>
 ```
 
@@ -252,11 +253,14 @@ kafka.bootstrap.servers=localhost:9093
 To terminate permission requests, a consent market document in json format has to be sent to
 the `kafka.termination.topic`.
 The key should be the ID of the region connector, from which the request originated.
-The consent market document can look like this:
+The consent market document for termination can look like the following JSON message.
+**Keep in mind that some kafka clients use newlines as message separator, in that case minimize the message, or change
+the message separator!**
 
 ```json
 {
   "mrid": "REPLACE_ME",
+  "type": "Z01",
   "permissionList": {
     "permissions": [
       {
@@ -280,6 +284,7 @@ The consent market document can look like this:
 }
 ```
 
-The MRID should be replaced by the permission ID, the code `Z03` stands for „cancelled by eligible party“.
+The MRID should be replaced by the permission ID, the code `Z03` stands for „cancelled by eligible party“ and the
+type `Z01` identifies this document as a termination document.
 If the kafka message key is unknown, the type of the mktActivityRecord is used, which is identical to the region
 connector id.

--- a/core/src/main/java/energy/eddie/core/services/TerminationRouter.java
+++ b/core/src/main/java/energy/eddie/core/services/TerminationRouter.java
@@ -4,6 +4,7 @@ import energy.eddie.api.utils.Pair;
 import energy.eddie.api.v0.RegionConnector;
 import energy.eddie.api.v0_82.outbound.TerminationConnector;
 import energy.eddie.cim.v0_82.cmd.ConsentMarketDocument;
+import energy.eddie.cim.v0_82.cmd.MessageTypeList;
 import energy.eddie.cim.v0_82.cmd.ReasonCodeTypeList;
 import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
@@ -38,7 +39,9 @@ public class TerminationRouter {
     }
 
     private static boolean isTerminationMessage(Pair<String, ConsentMarketDocument> pair) {
-        return pair.value().getPermissionList().getPermissions().getFirst().getReasonList().getReasons().getFirst().getCode() == ReasonCodeTypeList.CANCELLED_EP;
+        return pair.value().getPermissionList().getPermissions().getFirst().getReasonList().getReasons().getFirst()
+                .getCode() == ReasonCodeTypeList.CANCELLED_EP
+                && pair.value().getType() == MessageTypeList.PERMISSION_TERMINATION_DOCUMENT;
     }
 
     private static String getRegionConnectorId(Pair<String, ConsentMarketDocument> cmd) {

--- a/core/src/test/java/energy/eddie/core/services/TerminationRouterTest.java
+++ b/core/src/test/java/energy/eddie/core/services/TerminationRouterTest.java
@@ -36,6 +36,7 @@ class TerminationRouterTest {
         router.registerRegionConnector(regionConnector2);
         ConsentMarketDocument cmd = new ConsentMarketDocument()
                 .withMRID("pid")
+                .withType(MessageTypeList.PERMISSION_TERMINATION_DOCUMENT)
                 .withPermissionList(new ConsentMarketDocument.PermissionList()
                         .withPermissions(new PermissionComplexType()
                                 .withReasonList(new PermissionComplexType.ReasonList()
@@ -79,6 +80,7 @@ class TerminationRouterTest {
         router.registerRegionConnector(regionConnector2);
         ConsentMarketDocument cmd = new ConsentMarketDocument()
                 .withMRID("pid")
+                .withType(MessageTypeList.PERMISSION_TERMINATION_DOCUMENT)
                 .withPermissionList(new ConsentMarketDocument.PermissionList()
                         .withPermissions(new PermissionComplexType()
                                 .withReasonList(new PermissionComplexType.ReasonList()
@@ -125,6 +127,7 @@ class TerminationRouterTest {
         router.registerRegionConnector(regionConnector2);
         ConsentMarketDocument cmd = new ConsentMarketDocument()
                 .withMRID("pid")
+                .withType(MessageTypeList.PERMISSION_TERMINATION_DOCUMENT)
                 .withSenderMarketParticipantMRID(new PartyIDStringComplexType()
                         .withCodingScheme(CodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME)
                 )


### PR DESCRIPTION
This will break old termination documents, as they will be filtered out if the `"type": "Z01"` field is missing in the top level JSON object.
Check [OPERATION.md](https://github.com/eddie-energy/eddie/blob/7b856017dc62855e037b97221e8c168257d2259b/OPERATION.md#termination-of-permission-requests) for the correct format.