### PR TITLE
NOISSUE Move global properties into api module

### DIFF
--- a/api/src/main/java/energy/eddie/api/agnostic/GlobalConfig.java
+++ b/api/src/main/java/energy/eddie/api/agnostic/GlobalConfig.java
@@ -2,6 +2,7 @@ package energy.eddie.api.agnostic;
 
 public final class GlobalConfig {
     public static final String ERRORS_PROPERTY_NAME = "errors";
+    public static final String ERRORS_JSON_PATH = "$." + ERRORS_PROPERTY_NAME;
 
     private GlobalConfig() {}
 }

--- a/core/src/test/java/energy/eddie/core/dataneeds/DataNeedsControllerTest.java
+++ b/core/src/test/java/energy/eddie/core/dataneeds/DataNeedsControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Optional;
 import java.util.Set;
 
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.startsWith;

--- a/core/src/test/java/energy/eddie/core/dataneeds/DataNeedsManagementControllerDifferentUrlPrefixTest.java
+++ b/core/src/test/java/energy/eddie/core/dataneeds/DataNeedsManagementControllerDifferentUrlPrefixTest.java
@@ -12,9 +12,9 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Optional;
 
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static energy.eddie.core.dataneeds.DataNeedEntityTest.EXAMPLE_DATA_NEED;
 import static energy.eddie.core.dataneeds.DataNeedEntityTest.EXAMPLE_DATA_NEED_KEY;
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;

--- a/core/src/test/java/energy/eddie/core/dataneeds/DataNeedsManagementControllerTest.java
+++ b/core/src/test/java/energy/eddie/core/dataneeds/DataNeedsManagementControllerTest.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static energy.eddie.core.dataneeds.DataNeedEntityTest.*;
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;

--- a/core/src/test/java/energy/eddie/spring/regionconnector/RegionConnectorsCommonControllerAdviceCorrectlyRegisteredTest.java
+++ b/core/src/test/java/energy/eddie/spring/regionconnector/RegionConnectorsCommonControllerAdviceCorrectlyRegisteredTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/region-connectors/region-connector-aiida/src/test/java/energy/eddie/regionconnector/aiida/web/PermissionRequestControllerTest.java
+++ b/region-connectors/region-connector-aiida/src/test/java/energy/eddie/regionconnector/aiida/web/PermissionRequestControllerTest.java
@@ -18,8 +18,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.util.UriTemplate;
 
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_STATUS_WITH_PATH_PARAM;
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.mockito.ArgumentMatchers.any;

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/web/PermissionRequestControllerTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/web/PermissionRequestControllerTest.java
@@ -30,8 +30,8 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_STATUS_WITH_PATH_PARAM;
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/web/PermissionRequestControllerTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/web/PermissionRequestControllerTest.java
@@ -30,8 +30,8 @@ import reactor.core.publisher.Flux;
 import java.util.Optional;
 import java.util.UUID;
 
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_STATUS_WITH_PATH_PARAM;
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/web/PermissionControllerTest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/web/PermissionControllerTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.Optional;
 
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/web/PermissionRequestControllerTest.java
+++ b/region-connectors/region-connector-fr-enedis/src/test/java/energy/eddie/regionconnector/fr/enedis/web/PermissionRequestControllerTest.java
@@ -25,8 +25,8 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_JSON_PATH;
 import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_STATUS_WITH_PATH_PARAM;
-import static energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice.ERRORS_JSON_PATH;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/region-connectors/shared/src/main/java/energy/eddie/spring/regionconnector/extensions/RegionConnectorsCommonControllerAdvice.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/spring/regionconnector/extensions/RegionConnectorsCommonControllerAdvice.java
@@ -30,7 +30,6 @@ import static energy.eddie.api.agnostic.GlobalConfig.ERRORS_PROPERTY_NAME;
 @RegionConnectorExtension
 @RestControllerAdvice
 public class RegionConnectorsCommonControllerAdvice {
-    public static final String ERRORS_JSON_PATH = "$." + ERRORS_PROPERTY_NAME;
     private static final Logger LOGGER = LoggerFactory.getLogger(RegionConnectorsCommonControllerAdvice.class);
 
     /**


### PR DESCRIPTION
Global configurations or e.g. names should be accessible to all modules via the api module and not the shared region connector module.