### PR TITLE
GH-769 Ensure that all ZonedDateTimes that are converted to LocalDate have the correct timezone

### DIFF
--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/services/PollingService.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/services/PollingService.java
@@ -46,8 +46,8 @@ public class PollingService implements AutoCloseable {
     }
 
     private static boolean isActiveAndNeedsToBePolled(DkEnerginetCustomerPermissionRequest permissionRequest, LocalDate today) {
-        LocalDate permissionStart = permissionRequest.start().toLocalDate();
-        var lastPolled = permissionRequest.lastPolled().toLocalDate();
+        LocalDate permissionStart = permissionRequest.start().withZoneSameInstant(DK_ZONE_ID).toLocalDate();
+        var lastPolled = permissionRequest.lastPolled().withZoneSameInstant(DK_ZONE_ID).toLocalDate();
         return permissionStart.isBefore(today)
                 && (lastPolled.isBefore(today) || lastPolled.isEqual(today));
     }
@@ -96,8 +96,9 @@ public class PollingService implements AutoCloseable {
         meteringPoints.addMeteringPointItem(permissionRequest.meteringPoint());
         MeteringPointsRequest meteringPointsRequest = new MeteringPointsRequest().meteringPoints(meteringPoints);
 
-        LocalDate dateFrom = permissionRequest.lastPolled().toLocalDate();
+        LocalDate dateFrom = permissionRequest.lastPolled().withZoneSameInstant(DK_ZONE_ID).toLocalDate();
         LocalDate dateTo = Optional.ofNullable(permissionRequest.end())
+                .map(end -> end.withZoneSameInstant(DK_ZONE_ID))
                 .map(ZonedDateTime::toLocalDate)
                 .filter(d -> d.isBefore(today))
                 .map(d -> d.plusDays(1)) // The Energinet API is inclusive on the start date and exclusive on the end date so we need to add one day if the end date is before today


### PR DESCRIPTION
Apparrently the time zone information is lost when `ZonedDateTimes` are stored in the Database. This causes unexpected behaviour when converting to `LocalDate`