### PR TITLE
GH-399 Add ValidatedHistoricalDataMarketDocument mapping for Datadis

### DIFF
--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/DatadisEddieValidatedHistoricalDataMarketDocumentProvider.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/DatadisEddieValidatedHistoricalDataMarketDocumentProvider.java
@@ -1,0 +1,33 @@
+package energy.eddie.regionconnector.es.datadis.providers.v0_82;
+
+import energy.eddie.api.v0_82.EddieValidatedHistoricalDataMarketDocumentProvider;
+import energy.eddie.api.v0_82.cim.EddieValidatedHistoricalDataMarketDocument;
+import energy.eddie.regionconnector.es.datadis.providers.agnostic.IdentifiableMeteringData;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+@Component
+public class DatadisEddieValidatedHistoricalDataMarketDocumentProvider implements EddieValidatedHistoricalDataMarketDocumentProvider {
+
+    private final Flux<IdentifiableMeteringData> identifiableMeterReadings;
+    private final IntermediateVHDFactory intermediateVHDFactory;
+
+    public DatadisEddieValidatedHistoricalDataMarketDocumentProvider(
+            Flux<IdentifiableMeteringData> identifiableMeterReadings,
+            IntermediateVHDFactory intermediateVHDFactory) {
+        this.identifiableMeterReadings = identifiableMeterReadings;
+        this.intermediateVHDFactory = intermediateVHDFactory;
+    }
+
+    @Override
+    public Flux<EddieValidatedHistoricalDataMarketDocument> getEddieValidatedHistoricalDataMarketDocumentStream() {
+        return identifiableMeterReadings
+                .map(intermediateVHDFactory::create)
+                .map(IntermediateValidatedHistoricalDocument::eddieValidatedHistoricalDataMarketDocument);
+    }
+
+    @Override
+    public void close() throws Exception {
+        // No-Op
+    }
+}

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/IntermediateVHDFactory.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/IntermediateVHDFactory.java
@@ -1,0 +1,22 @@
+package energy.eddie.regionconnector.es.datadis.providers.v0_82;
+
+import energy.eddie.api.v0_82.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.regionconnector.es.datadis.config.DatadisConfig;
+import energy.eddie.regionconnector.es.datadis.providers.agnostic.IdentifiableMeteringData;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IntermediateVHDFactory {
+    private final DatadisConfig datadisConfig;
+    private final CommonInformationModelConfiguration cimConfiguration;
+
+    public IntermediateVHDFactory(DatadisConfig datadisConfig,
+                                  CommonInformationModelConfiguration cimConfiguration) {
+        this.datadisConfig = datadisConfig;
+        this.cimConfiguration = cimConfiguration;
+    }
+
+    public IntermediateValidatedHistoricalDocument create(IdentifiableMeteringData meteringData) {
+        return new IntermediateValidatedHistoricalDocument(meteringData, cimConfiguration, datadisConfig);
+    }
+}

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/IntermediateValidatedHistoricalDocument.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/IntermediateValidatedHistoricalDocument.java
@@ -1,0 +1,150 @@
+package energy.eddie.regionconnector.es.datadis.providers.v0_82;
+
+import energy.eddie.api.CommonInformationModelVersions;
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.v0_82.cim.EddieValidatedHistoricalDataMarketDocument;
+import energy.eddie.api.v0_82.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.cim.v0_82.vhd.*;
+import energy.eddie.regionconnector.es.datadis.api.MeasurementType;
+import energy.eddie.regionconnector.es.datadis.config.DatadisConfig;
+import energy.eddie.regionconnector.es.datadis.dtos.MeteringData;
+import energy.eddie.regionconnector.es.datadis.permission.request.DistributorCode;
+import energy.eddie.regionconnector.es.datadis.providers.agnostic.IdentifiableMeteringData;
+import energy.eddie.regionconnector.shared.utils.EsmpDateTime;
+import energy.eddie.regionconnector.shared.utils.EsmpTimeInterval;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public final class IntermediateValidatedHistoricalDocument {
+    private static final TimeSeriesComplexType.ReasonList REASON_LIST = new TimeSeriesComplexType.ReasonList()
+            .withReasons(
+                    new ReasonComplexType()
+                            .withCode(ReasonCodeTypeList.ERRORS_NOT_SPECIFICALLY_IDENTIFIED)
+            );
+    private final ValidatedHistoricalDataMarketDocument vhd = new ValidatedHistoricalDataMarketDocument()
+            .withMRID(UUID.randomUUID().toString())
+            .withRevisionNumber(CommonInformationModelVersions.V0_82.version())
+            .withType(MessageTypeList.MEASUREMENT_VALUE_DOCUMENT)
+            .withSenderMarketParticipantMarketRoleType(RoleTypeList.METERING_POINT_ADMINISTRATOR)
+            .withReceiverMarketParticipantMarketRoleType(RoleTypeList.CONSUMER)
+            .withProcessProcessType(ProcessTypeList.REALISED);
+    private final CommonInformationModelConfiguration cimConfig;
+    private final DatadisConfig datadisConfig;
+    private final IdentifiableMeteringData identifiableMeteringData;
+
+    IntermediateValidatedHistoricalDocument(IdentifiableMeteringData identifiableMeteringData,
+                                            CommonInformationModelConfiguration cimConfig,
+                                            DatadisConfig datadisConfig) {
+        this.identifiableMeteringData = identifiableMeteringData;
+        this.cimConfig = cimConfig;
+        this.datadisConfig = datadisConfig;
+    }
+
+    /**
+     * Maps the metering data obtain method to a {@link QualityTypeList}.
+     *
+     * @param meteringData the metering data
+     * @return {@link QualityTypeList#ESTIMATED} if the obtain method is "Estimada", otherwise {@link QualityTypeList#AS_PROVIDED}
+     */
+    private static QualityTypeList qualityTypeList(MeteringData meteringData) {
+        return switch (meteringData.obtainMethod()) {
+            case ESTIMATED -> QualityTypeList.ESTIMATED;
+            case REAL -> QualityTypeList.AS_PROVIDED;
+            case UNKNOWN -> QualityTypeList.NOT_AVAILABLE;
+        };
+    }
+
+    public EddieValidatedHistoricalDataMarketDocument eddieValidatedHistoricalDataMarketDocument() {
+        var timeframe = new EsmpTimeInterval(
+                identifiableMeteringData.intermediateMeteringData().start(),
+                identifiableMeteringData.intermediateMeteringData().end()
+        );
+
+        vhd
+                .withSenderMarketParticipantMRID(
+                        new PartyIDStringComplexType()
+                                .withCodingScheme(CodingSchemeTypeList.SPAIN_NATIONAL_CODING_SCHEME)
+                                .withValue(identifiableMeteringData.permissionRequest().distributorCode().map(DistributorCode::name).orElse("Datadis"))
+                )
+                .withCreatedDateTime(EsmpDateTime.now().toString())
+                .withReceiverMarketParticipantMRID(
+                        new PartyIDStringComplexType()
+                                .withCodingScheme(cimConfig.eligiblePartyNationalCodingScheme())
+                                .withValue(datadisConfig.username())
+                )
+                .withPeriodTimeInterval(
+                        new ESMPDateTimeIntervalComplexType()
+                                .withStart(timeframe.start())
+                                .withEnd(timeframe.end())
+                )
+                .withTimeSeriesList(timeSeriesList(timeframe));
+        var permissionRequest = identifiableMeteringData.permissionRequest();
+        return new EddieValidatedHistoricalDataMarketDocument(
+                Optional.of(permissionRequest.connectionId()),
+                Optional.of(permissionRequest.permissionId()),
+                Optional.of(permissionRequest.dataNeedId()),
+                vhd
+        );
+    }
+
+    private ValidatedHistoricalDataMarketDocument.TimeSeriesList timeSeriesList(EsmpTimeInterval timeframe) {
+        TimeSeriesComplexType reading = new TimeSeriesComplexType()
+                .withMRID(UUID.randomUUID().toString())
+                .withBusinessType(BusinessTypeList.CONSUMPTION)
+                .withProduct(EnergyProductTypeList.ACTIVE_ENERGY)
+                .withFlowDirectionDirection(DirectionTypeList.DOWN)
+                .withMarketEvaluationPointMeterReadingsReadingsReadingTypeAggregation(AggregateKind.SUM)
+                .withMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity(CommodityKind.ELECTRICITYPRIMARYMETERED) // No mapping available
+                .withEnergyMeasurementUnitName(UnitOfMeasureTypeList.KILOWATT_HOUR)
+                .withMarketEvaluationPointMRID(
+                        new MeasurementPointIDStringComplexType()
+                                .withCodingScheme(CodingSchemeTypeList.SPAIN_NATIONAL_CODING_SCHEME)
+                                .withValue(identifiableMeteringData.permissionRequest().meteringPointId())
+                )
+                .withReasonList(REASON_LIST)
+                .withRegisteredResource(
+                        new RegisteredResourceComplexType()
+                                .withMRID(identifiableMeteringData.permissionRequest().meteringPointId())
+                )
+                .withSeriesPeriodList(
+                        new TimeSeriesComplexType.SeriesPeriodList()
+                                .withSeriesPeriods(seriesPeriods(timeframe))
+                );
+        return new ValidatedHistoricalDataMarketDocument.TimeSeriesList()
+                .withTimeSeries(List.of(reading));
+    }
+
+    private List<SeriesPeriodComplexType> seriesPeriods(EsmpTimeInterval timeInterval) {
+        List<PointComplexType> consumptionPoints = new ArrayList<>();
+        int position = 0;
+        for (MeteringData meteringData
+                : identifiableMeteringData.intermediateMeteringData().meteringData()) {
+            QualityTypeList qualityTypeList = qualityTypeList(meteringData);
+            PointComplexType consumptionPoint = new PointComplexType()
+                    .withPosition(String.valueOf(position))
+                    .withEnergyQuantityQuantity(BigDecimal.valueOf(meteringData.consumptionKWh()))
+                    .withEnergyQuantityQuality(qualityTypeList);
+            consumptionPoints.add(consumptionPoint);
+            position++;
+        }
+
+        var seriesPeriod = new SeriesPeriodComplexType()
+                .withResolution(switch (identifiableMeteringData.permissionRequest().measurementType()) {
+                    case MeasurementType.QUARTER_HOURLY -> Granularity.PT15M.name();
+                    case MeasurementType.HOURLY -> Granularity.PT1H.name();
+                })
+                .withTimeInterval(new ESMPDateTimeIntervalComplexType()
+                        .withStart(timeInterval.start())
+                        .withEnd(timeInterval.end())
+                )
+                .withPointList(
+                        new SeriesPeriodComplexType.PointList()
+                                .withPoints(consumptionPoints)
+                );
+        return new ArrayList<>(List.of(seriesPeriod));
+    }
+}

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/DatadisEddieValidatedHistoricalDataMarketDocumentProviderTest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/DatadisEddieValidatedHistoricalDataMarketDocumentProviderTest.java
@@ -1,0 +1,36 @@
+package energy.eddie.regionconnector.es.datadis.providers.v0_82;
+
+import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
+import energy.eddie.regionconnector.es.datadis.config.PlainDatadisConfiguration;
+import energy.eddie.regionconnector.es.datadis.providers.agnostic.IdentifiableMeteringData;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
+
+class DatadisEddieValidatedHistoricalDataMarketDocumentProviderTest {
+
+    @Test
+    void testGetEddieValidatedHistoricalDataMarketDocumentStream_publishesDocuments() throws Exception {
+        // Given
+        TestPublisher<IdentifiableMeteringData> testPublisher = TestPublisher.create();
+        PlainDatadisConfiguration datadisConfig = new PlainDatadisConfiguration("clientId", "clientSecret", "basepath");
+        IntermediateVHDFactory factory = new IntermediateVHDFactory(
+                datadisConfig,
+                () -> CodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME
+        );
+        IdentifiableMeteringData identifiableMeteringData = IntermediateValidatedHistoricalDocumentTest.identifiableMeterReading();
+        var provider = new DatadisEddieValidatedHistoricalDataMarketDocumentProvider(testPublisher.flux(), factory);
+
+        // When
+        StepVerifier.create(provider.getEddieValidatedHistoricalDataMarketDocumentStream())
+                .then(() -> {
+                    testPublisher.emit(identifiableMeteringData);
+                    testPublisher.complete();
+                })
+                .expectNextCount(1)
+                .verifyComplete();
+
+        // Clean-Up
+        provider.close();
+    }
+}

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/IntermediateVHDFactoryTest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/IntermediateVHDFactoryTest.java
@@ -1,0 +1,28 @@
+package energy.eddie.regionconnector.es.datadis.providers.v0_82;
+
+import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
+import energy.eddie.regionconnector.es.datadis.config.PlainDatadisConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class IntermediateVHDFactoryTest {
+
+    @Test
+    void testCreate_returnsValidatedHistoricalDocument() throws IOException {
+        // Given
+        PlainDatadisConfiguration datadisConfig = new PlainDatadisConfiguration("clientId", "clientSecret", "basepath");
+        IntermediateVHDFactory factory = new IntermediateVHDFactory(
+                datadisConfig,
+                () -> CodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME
+        );
+
+        // When
+        var res = factory.create(IntermediateValidatedHistoricalDocumentTest.identifiableMeterReading());
+
+        // Then
+        assertNotNull(res);
+    }
+}

--- a/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/IntermediateValidatedHistoricalDocumentTest.java
+++ b/region-connectors/region-connector-es-datadis/src/test/java/energy/eddie/regionconnector/es/datadis/providers/v0_82/IntermediateValidatedHistoricalDocumentTest.java
@@ -1,0 +1,123 @@
+package energy.eddie.regionconnector.es.datadis.providers.v0_82;
+
+import energy.eddie.api.CommonInformationModelVersions;
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.v0.PermissionProcessStatus;
+import energy.eddie.cim.v0_82.vhd.*;
+import energy.eddie.regionconnector.es.datadis.MeteringDataProvider;
+import energy.eddie.regionconnector.es.datadis.config.PlainDatadisConfiguration;
+import energy.eddie.regionconnector.es.datadis.dtos.IntermediateMeteringData;
+import energy.eddie.regionconnector.es.datadis.dtos.PermissionRequestForCreation;
+import energy.eddie.regionconnector.es.datadis.permission.request.DatadisPermissionRequest;
+import energy.eddie.regionconnector.es.datadis.permission.request.DistributorCode;
+import energy.eddie.regionconnector.es.datadis.permission.request.StateBuilderFactory;
+import energy.eddie.regionconnector.es.datadis.permission.request.api.EsPermissionRequest;
+import energy.eddie.regionconnector.es.datadis.providers.agnostic.IdentifiableMeteringData;
+import energy.eddie.regionconnector.shared.utils.EsmpTimeInterval;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IntermediateValidatedHistoricalDocumentTest {
+
+    public static IdentifiableMeteringData identifiableMeterReading() throws IOException {
+        var intermediateMeteringData = IntermediateMeteringData.fromMeteringData(MeteringDataProvider.loadMeteringData());
+        StateBuilderFactory stateBuilderFactory = new StateBuilderFactory(null);
+        PermissionRequestForCreation permissionRequestForCreation = new PermissionRequestForCreation(
+                "connectionId",
+                "dataNeedId",
+                "nif",
+                "meteringPointId",
+                intermediateMeteringData.start(),
+                intermediateMeteringData.end(),
+                Granularity.PT1H);
+        EsPermissionRequest permissionRequest = new DatadisPermissionRequest("permissionId", permissionRequestForCreation, stateBuilderFactory);
+        permissionRequest.changeState(stateBuilderFactory.create(permissionRequest, PermissionProcessStatus.ACCEPTED).build());
+        permissionRequest.setDistributorCodeAndPointType(DistributorCode.ASEME, 1);
+        return new IdentifiableMeteringData(permissionRequest, intermediateMeteringData);
+    }
+
+    @SuppressWarnings("java:S5961") // Sonar complains about the nr of assertions
+    @Test
+    void eddieValidatedHistoricalDataMarketDocument() throws IOException {
+
+        IdentifiableMeteringData identifiableMeteringData = identifiableMeterReading();
+        PlainDatadisConfiguration datadisConfig = new PlainDatadisConfiguration("clientId", "clientSecret", "basepath");
+        var intermediateVHD = new IntermediateValidatedHistoricalDocument(
+                identifiableMeteringData,
+                () -> CodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME,
+                datadisConfig
+        );
+
+        var eddieMarketDocument = intermediateVHD.eddieValidatedHistoricalDataMarketDocument();
+        var marketDocument = eddieMarketDocument.marketDocument();
+
+        var timeframe = new EsmpTimeInterval(
+                identifiableMeteringData.intermediateMeteringData().start(),
+                identifiableMeteringData.intermediateMeteringData().end()
+        );
+        var timeSeries = marketDocument.getTimeSeriesList().getTimeSeries().getFirst();
+        var seriesPeriod = timeSeries.getSeriesPeriodList().getSeriesPeriods().getFirst();
+
+        assertAll(
+                // Metadata
+                () -> assertEquals(CommonInformationModelVersions.V0_82.version(), marketDocument.getRevisionNumber()),
+                () -> assertEquals(MessageTypeList.MEASUREMENT_VALUE_DOCUMENT, marketDocument.getType()),
+                () -> assertEquals(RoleTypeList.METERING_POINT_ADMINISTRATOR, marketDocument.getSenderMarketParticipantMarketRoleType()),
+                () -> assertEquals(RoleTypeList.CONSUMER, marketDocument.getReceiverMarketParticipantMarketRoleType()),
+                () -> assertEquals(ProcessTypeList.REALISED, marketDocument.getProcessProcessType()),
+                // Sender
+                () -> assertEquals(CodingSchemeTypeList.SPAIN_NATIONAL_CODING_SCHEME, marketDocument.getSenderMarketParticipantMRID().getCodingScheme()),
+                () -> assertEquals(DistributorCode.ASEME.name(), marketDocument.getSenderMarketParticipantMRID().getValue()),
+                // Receiver
+                () -> assertEquals(CodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME, marketDocument.getReceiverMarketParticipantMRID().getCodingScheme()),
+                () -> assertEquals(datadisConfig.username(), marketDocument.getReceiverMarketParticipantMRID().getValue()),
+                // Period TimeInterval
+                () -> assertEquals(timeframe.start(), marketDocument.getPeriodTimeInterval().getStart()),
+                () -> assertEquals(timeframe.end(), marketDocument.getPeriodTimeInterval().getEnd()),
+                // TimeSeries
+                () -> assertEquals(1, marketDocument.getTimeSeriesList().getTimeSeries().size()),
+                () -> assertEquals(BusinessTypeList.CONSUMPTION, timeSeries.getBusinessType()),
+                () -> assertEquals(EnergyProductTypeList.ACTIVE_ENERGY, timeSeries.getProduct()),
+                () -> assertEquals(DirectionTypeList.DOWN, timeSeries.getFlowDirectionDirection()),
+                () -> assertEquals(AggregateKind.SUM, timeSeries.getMarketEvaluationPointMeterReadingsReadingsReadingTypeAggregation()),
+                () -> assertEquals(CommodityKind.ELECTRICITYPRIMARYMETERED, timeSeries.getMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity()),
+                () -> assertEquals(CodingSchemeTypeList.SPAIN_NATIONAL_CODING_SCHEME, timeSeries.getMarketEvaluationPointMRID().getCodingScheme()),
+                () -> assertEquals(identifiableMeterReading().permissionRequest().meteringPointId(), timeSeries.getMarketEvaluationPointMRID().getValue()),
+                // Reason
+                () -> assertEquals(ReasonCodeTypeList.ERRORS_NOT_SPECIFICALLY_IDENTIFIED, timeSeries.getReasonList().getReasons().getFirst().getCode()),
+                // Resource
+                () -> assertEquals(identifiableMeterReading().permissionRequest().meteringPointId(), timeSeries.getRegisteredResource().getMRID()),
+                // SeriesPeriod
+                () -> assertEquals(1, timeSeries.getSeriesPeriodList().getSeriesPeriods().size()),
+                () -> assertEquals(timeframe.start(), seriesPeriod.getTimeInterval().getStart()),
+                () -> assertEquals(timeframe.end(), seriesPeriod.getTimeInterval().getEnd()),
+
+                () -> assertEquals(Granularity.PT1H.name(), seriesPeriod.getResolution()),
+                () -> assertEquals(identifiableMeteringData.intermediateMeteringData().meteringData().size(), seriesPeriod.getPointList().getPoints().size()),
+                () -> {
+                    // assert that all point in the array have the same value as meteringData.cunsuptionKwh
+                    for (int i = identifiableMeteringData.intermediateMeteringData().meteringData().size() - 1; i >= 0; i--) {
+                        var point = seriesPeriod.getPointList().getPoints().get(i);
+                        var meteringData = identifiableMeteringData.intermediateMeteringData().meteringData().get(i);
+                        int finalI = i;
+                        QualityTypeList expectedQuality = switch (meteringData.obtainMethod()) {
+                            case ESTIMATED -> QualityTypeList.ESTIMATED;
+                            case REAL -> QualityTypeList.AS_PROVIDED;
+                            case UNKNOWN -> QualityTypeList.NOT_AVAILABLE;
+                        };
+                        assertAll(
+                                () -> assertEquals(String.valueOf(finalI), point.getPosition()),
+                                () -> assertEquals(BigDecimal.valueOf(meteringData.consumptionKWh()), point.getEnergyQuantityQuantity()),
+                                () -> assertEquals(expectedQuality, point.getEnergyQuantityQuality())
+                        );
+                    }
+                }
+
+        );
+    }
+}

--- a/region-connectors/region-connector-es-datadis/src/test/resources/consumptionKWh.json
+++ b/region-connectors/region-connector-es-datadis/src/test/resources/consumptionKWh.json
@@ -84,7 +84,7 @@
     "date": "2023/12/01",
     "time": "11:00",
     "consumptionKWh": 4.875,
-    "obtainMethod": "",
+    "obtainMethod": "Real",
     "surplusEnergyKWh": null
   },
   {
@@ -92,7 +92,7 @@
     "date": "2023/12/01",
     "time": "12:00",
     "consumptionKWh": 5.543,
-    "obtainMethod": "",
+    "obtainMethod": "Estimada",
     "surplusEnergyKWh": null
   },
   {


### PR DESCRIPTION
This mapping currently only considers `consumptionKwh` there is already #767 that will adress this