### PR TITLE
NOISSUE Enable SpringDoc for all region connectors DispatchServlets

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.websocket)
+    implementation(libs.spring.openapi.webmvc.ui)
     implementation(libs.reactor.core)
     implementation(libs.flyway.core)
 

--- a/core/src/main/java/energy/eddie/core/CoreSpringConfig.java
+++ b/core/src/main/java/energy/eddie/core/CoreSpringConfig.java
@@ -5,6 +5,14 @@ import energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor;
 import energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.core.properties.SwaggerUiConfigParameters;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springdoc.core.properties.SwaggerUiOAuthProperties;
+import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
+import org.springdoc.webmvc.ui.SwaggerConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -15,7 +23,20 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@SpringBootApplication
+@SpringBootApplication(
+        // do not automatically register these beans, as otherwise they are duplicate in the child context
+        // and each child context needs their own instance of them to provide openAPI doc
+        exclude = {
+                SpringDocWebMvcConfiguration.class,
+                MultipleOpenApiSupportConfiguration.class,
+                SwaggerConfig.class,
+                SwaggerUiConfigProperties.class,
+                SwaggerUiConfigParameters.class,
+                SwaggerUiOAuthProperties.class,
+                SpringDocConfiguration.class,
+                SpringDocConfigProperties.class,
+        }
+)
 @EnableConfigurationProperties(DataNeedsConfig.class)
 // required that JPA repositories in child context will be initialized correctly
 @EntityScan(basePackages = "energy.eddie")

--- a/core/src/main/java/org/springdoc/webmvc/ui/SwaggerController.java
+++ b/core/src/main/java/org/springdoc/webmvc/ui/SwaggerController.java
@@ -1,0 +1,34 @@
+package org.springdoc.webmvc.ui;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.core.properties.SwaggerUiConfigParameters;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springdoc.core.providers.SpringWebProvider;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+
+/**
+ * Overwrites the SwaggerController path to consider the url mapping of a DispatcherServlet, instead of always using the
+ * same URL.
+ */
+@Configuration
+public class SwaggerController extends SwaggerWelcomeWebMvc {
+    public SwaggerController(
+            SwaggerUiConfigProperties swaggerUiConfig,
+            SpringDocConfigProperties springDocConfigProperties,
+            SwaggerUiConfigParameters swaggerUiConfigParameters,
+            SpringWebProvider springWebProvider
+    ) {
+        super(swaggerUiConfig, springDocConfigProperties, swaggerUiConfigParameters, springWebProvider);
+    }
+
+    @Override
+    void buildFromCurrentContextPath(HttpServletRequest request) {
+        super.init();
+        // default is request.getContextPath()
+        contextPath = request.getServletPath();
+        buildConfigUrl(ServletUriComponentsBuilder.fromCurrentContextPath());
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ flyway = "10.8.1"
 
 swagger-codegen-version = "3.0.45"
 openapi-generator = "7.3.0"
+openapi-webmvc-ui = "2.3.0"
 apache-httpcomponents-version = "4.5.14"
 apache-httpcomponents-client-version = "5.2.1"
 jackson-databind-nullable-version = "0.2.6"
@@ -137,6 +138,7 @@ spring-kafka = { module = "org.springframework.kafka:spring-kafka", version.ref 
 spring-websocket = { module = "org.springframework:spring-websocket", version.ref = "spring-websocket" }
 spring-retry = { module = "org.springframework.retry:spring-retry", version.ref = "spring-retry" }
 spring-aspects = { module = "org.springframework:spring-aspects", version.ref = "spring-aspects" }
+spring-openapi-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "openapi-webmvc-ui" }
 
 hibernate-validator = { module = "org.hibernate.validator:hibernate-validator", version.ref = "hibernate-validator" }
 


### PR DESCRIPTION
Enables and automatically registers the necessary classes to generate SpringDoc from annotations and maps them under the region connectors dispatch servlets url mapping.

E.g.
http://localhost:8080/region-connectors/es-datadis/swagger-ui/index.html
http://localhost:8080/region-connectors/es-datadis/v3/api-docs