### PR TITLE
NOISSUE Only re-run workflow on code changes

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
   push:

--- a/.github/workflows/run-playwright-e2e-tests.yml
+++ b/.github/workflows/run-playwright-e2e-tests.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
   push:


### PR DESCRIPTION
Our playwright tests and commit message check should not be run when someone just changes the text of a PR, but only on code changes.