### PR TITLE
NOISSUE Persist Periods as Strings instead of byte values

### DIFF
--- a/data-needs/src/main/java/energy/eddie/dataneeds/duration/RelativeDuration.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/duration/RelativeDuration.java
@@ -1,6 +1,7 @@
 package energy.eddie.dataneeds.duration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import energy.eddie.dataneeds.persistence.PeriodConverter;
 import energy.eddie.dataneeds.validation.duration.IsValidRelativeDuration;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
@@ -20,11 +21,13 @@ public class RelativeDuration extends DataNeedDuration {
     @Column(name = "relative_start")
     @Nullable
     @JsonProperty
+    @Convert(converter = PeriodConverter.class)
     private Period start;
     @Schema(description = "ISO8601 duration string representing the period that should be added or subtracted from the current date to get the permission end date, when a new permission request for this data need is created. If not supplied, a region connector will use the latest possible date as permission request end date.", example = "P1Y4M12D", type = "string")
     @Column(name = "relative_end")
     @Nullable
     @JsonProperty
+    @Convert(converter = PeriodConverter.class)
     private Period end;
     @Schema(description = "The CalendarUnit to which the start of the relative duration should stick to. E.g., assume today is the 17.04., the relative start is -25 days and CalendarUnit is MONTH, then, for a permission request that is created today, the start date should not be the 23.03, but it should stick to the start of the CalendarUnit, and therefore be 01.03. Furthermore, for a permission request that is created on the 26.04, the start date should be the 01.04 and so forth. For the CalendarUnit WEEK, it will stick to Mondays. Note that this may lead to an earlier start date than what is passed via the start period.")
     @Enumerated(EnumType.STRING)

--- a/data-needs/src/main/java/energy/eddie/dataneeds/persistence/PeriodConverter.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/persistence/PeriodConverter.java
@@ -1,0 +1,30 @@
+package energy.eddie.dataneeds.persistence;
+
+import jakarta.annotation.Nullable;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.Period;
+
+@Converter
+public class PeriodConverter implements AttributeConverter<Period, String> {
+    @Override
+    @Nullable
+    public String convertToDatabaseColumn(Period period) {
+        if (period == null) {
+            return null;
+        }
+
+        return period.normalized().toString();
+    }
+
+    @Override
+    @Nullable
+    public Period convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return null;
+        }
+
+        return Period.parse(dbData);
+    }
+}

--- a/data-needs/src/main/resources/db/migration/data-needs/V1_0__create_data_needs_tables.sql
+++ b/data-needs/src/main/resources/db/migration/data-needs/V1_0__create_data_needs_tables.sql
@@ -36,8 +36,8 @@ CREATE TABLE generic_aiida_data_need_data_tags
 CREATE TABLE relative_duration
 (
     data_need_id   varchar(36) NOT NULL PRIMARY KEY,
-    relative_end   bytea,
-    relative_start bytea,
+    relative_end   text,
+    relative_start text,
     calendar_unit  varchar(5)
 );
 

--- a/data-needs/src/test/java/energy/eddie/dataneeds/persistence/PeriodConverterTest.java
+++ b/data-needs/src/test/java/energy/eddie/dataneeds/persistence/PeriodConverterTest.java
@@ -1,0 +1,74 @@
+package energy.eddie.dataneeds.persistence;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Period;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PeriodConverterTest {
+    private final PeriodConverter converter = new PeriodConverter();
+
+    @Test
+    void givenValidPeriod_convertToDatabaseColumn_normalizesAndConvertsToString() {
+        // Given
+        Period period = Period.parse("P13M5D");
+
+        // When
+        String dbData = converter.convertToDatabaseColumn(period);
+
+        // Then
+        assertEquals("P1Y1M5D", dbData);
+    }
+
+    @Test
+    void givenNegativeValidPeriod_convertToDatabaseColumn_normalizesAndConvertsToString() {
+        // Given
+        Period period = Period.parse("-P5Y1M6D");
+
+        // When
+        String dbData = converter.convertToDatabaseColumn(period);
+
+        // Then; at least one - should be contained to indicate a negative period
+        assertThat(dbData).contains("-");
+    }
+
+    @Test
+    void givenNull_convertToDatabaseColumn_returnsNull() {
+        // When
+        String dbData = converter.convertToDatabaseColumn(null);
+
+        // Then
+        assertNull(dbData);
+    }
+
+    @Test
+    void givenNull_convertToEntityAttribute_returnsNull() {
+        // When
+        Period period = converter.convertToEntityAttribute(null);
+
+        // Then
+        assertNull(period);
+    }
+
+    @Test
+    void givenEmptyString_convertToEntityAttribute_returnsNull() {
+        // When
+        Period period = converter.convertToEntityAttribute("");
+
+        // Then
+        assertNull(period);
+    }
+
+    @Test
+    void givenPeriodString_convertToEntityAttribute_returnsParsedPeriod() {
+        // When
+        Period period = converter.convertToEntityAttribute("-P2Y1M27D");
+
+        // Then
+        assertNotNull(period);
+        assertEquals(-25, period.toTotalMonths());
+        assertEquals(-27, period.getDays());
+    }
+}


### PR DESCRIPTION
Improves readability in the database.

Changed the SQL script, but it's fine, as this is a dev branch, you might need to nuke the data needs schema.