### PR TITLE
GH-785 Add EnerginetResolution to handle invalid ISO 8601 Durations

### DIFF
--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/filter/EnerginetResolution.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/filter/EnerginetResolution.java
@@ -1,0 +1,17 @@
+package energy.eddie.regionconnector.dk.energinet.filter;
+
+public record EnerginetResolution(String resolution) {
+
+    /**
+     * Converts the resolution returned by Energinet to ISO 8601 compliant duration format.
+     *
+     * @return the resolution in ISO 8601 duration format
+     */
+    public String toISO8601Duration() {
+        return switch (resolution) {
+            case "PT1D" -> "P1D";
+            case "PT1Y" -> "P1Y";
+            default -> resolution;
+        };
+    }
+}

--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/providers/v0_82/builder/SeriesPeriodBuilder.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/providers/v0_82/builder/SeriesPeriodBuilder.java
@@ -3,6 +3,7 @@ package energy.eddie.regionconnector.dk.energinet.providers.v0_82.builder;
 import energy.eddie.cim.v0_82.vhd.*;
 import energy.eddie.regionconnector.dk.energinet.customer.model.Period;
 import energy.eddie.regionconnector.dk.energinet.customer.model.Point;
+import energy.eddie.regionconnector.dk.energinet.filter.EnerginetResolution;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -17,7 +18,7 @@ public class SeriesPeriodBuilder {
             var timeInterval = Objects.requireNonNull(period.getTimeInterval());
             var pointList = Objects.requireNonNull(period.getPoint());
             var periodComplexType = new SeriesPeriodComplexType()
-                    .withResolution(Objects.requireNonNull(period.getResolution()))
+                    .withResolution(new EnerginetResolution(Objects.requireNonNull(period.getResolution())).toISO8601Duration())
                     .withTimeInterval(
                             new ESMPDateTimeIntervalComplexType()
                                     .withStart(Objects.requireNonNull(timeInterval.getStart()))

--- a/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/filter/EnerginetResolutionTest.java
+++ b/region-connectors/region-connector-dk-energinet/src/test/java/energy/eddie/regionconnector/dk/energinet/filter/EnerginetResolutionTest.java
@@ -1,0 +1,22 @@
+package energy.eddie.regionconnector.dk.energinet.filter;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EnerginetResolutionTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "PT15M, PT15M",
+            "PT1H, PT1H",
+            "PT1D, P1D",
+            "P1M, P1M",
+            "PT1Y, P1Y"
+    })
+    void toISO8601Duration(String resolution, String expected) {
+        var filter = new EnerginetResolution(resolution);
+        assertEquals(expected, filter.toISO8601Duration());
+    }
+}


### PR DESCRIPTION
Adds EnerginetResolution to convert PT1D and PT1Y to valid ISO 8601 Durations (P1D and P1Y)