### PR TITLE
GH-752 Improve handling of EDA ResponseCodes

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/models/ResponseCode.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/models/ResponseCode.java
@@ -1,0 +1,41 @@
+package energy.eddie.regionconnector.at.eda.models;
+
+/**
+ * This record represents a response code from EDA in the context of "Consent Management". The documentation for the
+ * response codes can be found <a href="https://www.ebutilities.at/responsecodes">here</a>
+ *
+ * @param responseCode The response code
+ * @param message      The message associated with the response code
+ */
+public record ResponseCode(int responseCode, String message) {
+
+    public ResponseCode(int responseCode) {
+        this(responseCode, getMessage(responseCode));
+    }
+
+    private static String getMessage(int responseCode) {
+        return switch (responseCode) {
+            case 56 -> "Metering point not found";
+            case 57 -> "Metering point not supplied";
+            case 76 -> "Invalid request data";
+            case 82 -> "Invalid dates";
+            case 99 -> "Message received";
+            case 172 -> "Customer rejected the request";
+            case 173 -> "Time-out";
+            case 174 -> "Requested data not deliverable";
+            case 175 -> "Customer accepted the request";
+            case 176 -> "Consent successfully withdrawn";
+            case 177 -> "No data sharing available";
+            case 178 -> "Consent already exists";
+            case 179 -> "ConsentId already exists";
+            case 180 -> "ConsentId expired";
+            case 187 -> "ConsentId and MeteringPointId are not associated";
+            default -> "Unknown response code";
+        };
+    }
+
+    @Override
+    public String toString() {
+        return message + " (response code " + responseCode + ")";
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapter.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapter.java
@@ -1,6 +1,7 @@
 package energy.eddie.regionconnector.at.eda.ponton;
 
 import at.ebutilities.schemata.customerconsent.cmnotification._01p11.CMNotification;
+import at.ebutilities.schemata.customerconsent.cmnotification._01p11.ResponseDataType;
 import at.ebutilities.schemata.customerconsent.cmrequest._01p10.CMRequest;
 import at.ebutilities.schemata.customerconsent.cmrevoke._01p00.CMRevoke;
 import at.ebutilities.schemata.customerprocesses.consumptionrecord._01p31.ConsumptionRecord;
@@ -17,6 +18,8 @@ import energy.eddie.regionconnector.at.eda.EdaAdapter;
 import energy.eddie.regionconnector.at.eda.TransmissionException;
 import energy.eddie.regionconnector.at.eda.models.CMRequestStatus;
 import energy.eddie.regionconnector.at.eda.models.MessageCodes;
+import energy.eddie.regionconnector.at.eda.models.ResponseCode;
+import jakarta.validation.constraints.NotNull;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
@@ -29,6 +32,7 @@ import reactor.core.publisher.Sinks;
 import java.io.*;
 import java.net.InetAddress;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -48,7 +52,12 @@ public class PontonXPAdapter implements EdaAdapter {
 
     public PontonXPAdapter(PontonXPAdapterConfiguration config) throws IOException, ConnectionException, JAXBException {
         this.config = config;
-        JAXBContext context = JAXBContext.newInstance(CMRequest.class, ConsumptionRecord.class, CMNotification.class, CMRevoke.class, MasterData.class, CMRevoke.class);
+        JAXBContext context = JAXBContext.newInstance(CMRequest.class,
+                                                      ConsumptionRecord.class,
+                                                      CMNotification.class,
+                                                      CMRevoke.class,
+                                                      MasterData.class,
+                                                      CMRevoke.class);
         marshaller = context.createMarshaller();
         unmarshaller = context.createUnmarshaller();
         final String adapterId = config.adapterId();
@@ -62,49 +71,27 @@ public class PontonXPAdapter implements EdaAdapter {
         }
 
         final AdapterInfo adapterInfo = AdapterInfo.newBuilder()
-                .setAdapterId(adapterId)
-                .setAdapterVersion(adapterVersion)
-                .build();
+                                                   .setAdapterId(adapterId)
+                                                   .setAdapterVersion(adapterVersion)
+                                                   .build();
 
         this.messengerConnection = MessengerConnection.newBuilder()
-                .setWorkFolder(workFolder)
-                .setAdapterInfo(adapterInfo)
-                .addMessengerInstance(MessengerInstance.create(hostname, port))
-                .onMessageReceive(this::inboundMessageHandler)
-                .onMessageStatusUpdate(this::outboundMessageStatusUpdateHandler)
-                .onAdapterStatusRequest(() -> adapterId + " " + adapterVersion + " is running.")
-                .build();
-    }
-
-    @Override
-    public void start() throws TransmissionException {
-        try {
-            messengerConnection.start();
-            LOGGER.info("Ponton XP adapter started.");
-        } catch (de.ponton.xp.adapter.api.TransmissionException e) {
-            throw new TransmissionException(e);
-        }
-    }
-
-    private void outboundMessageStatusUpdateHandler(OutboundMessageStatusUpdate outboundMessageStatusUpdate) {
-        var conversationId = outboundMessageStatusUpdate.getStatusMetaData().getConversationId().getValue();
-
-        LOGGER.info("Received status update for ConversationId: '{}' with result: '{}'", conversationId, outboundMessageStatusUpdate.getResult());
-        switch (outboundMessageStatusUpdate.getResult()) {
-            case SUCCESS ->  // success just indicates that the message was received by the other party (dso)
-                    requestStatusSink.tryEmitNext(new CMRequestStatus(CMRequestStatus.Status.RECEIVED, outboundMessageStatusUpdate.getDetailText(), conversationId));
-            case CONFIG_ERROR, CONTENT_ERROR, TRANSMISSION_ERROR, FAILED ->
-                    requestStatusSink.tryEmitNext(new CMRequestStatus(CMRequestStatus.Status.ERROR, outboundMessageStatusUpdate.getDetailText(), conversationId));
-            default -> {
-                // Ignore the other status updates
-            }
-        }
+                                                      .setWorkFolder(workFolder)
+                                                      .setAdapterInfo(adapterInfo)
+                                                      .addMessengerInstance(MessengerInstance.create(hostname, port))
+                                                      .onMessageReceive(this::inboundMessageHandler)
+                                                      .onMessageStatusUpdate(this::outboundMessageStatusUpdateHandler)
+                                                      .onAdapterStatusRequest(() -> adapterId + " " + adapterVersion + " is running.")
+                                                      .build();
     }
 
     private InboundMessageStatusUpdate inboundMessageHandler(InboundMessage inboundMessage) {
         var messageType = inboundMessage.getInboundMetaData().getMessageType().getName().getValue();
         var messageVersion = inboundMessage.getInboundMetaData().getMessageType().getVersion().getValue();
-        LOGGER.info("Received message type: '{}' (version '{}') with ConversationId: '{}'", messageType, messageVersion, inboundMessage.getInboundMetaData().getConversationId().getValue());
+        LOGGER.info("Received message type: '{}' (version '{}') with ConversationId: '{}'",
+                    messageType,
+                    messageVersion,
+                    inboundMessage.getInboundMetaData().getConversationId().getValue());
 
         try {
             return switch (messageType) {
@@ -115,28 +102,54 @@ public class PontonXPAdapter implements EdaAdapter {
                 case MessageCodes.CONSUMPTION_RECORD -> handleConsumptionRecordMessage(inboundMessage);
                 case MessageCodes.Revoke.CUSTOMER, MessageCodes.Revoke.IMPLICIT -> handleRevokeMessage(inboundMessage);
                 default -> {
-                    LOGGER.warn("Received message type '{}' (version '{}') is not supported.", messageType, messageVersion);
+                    LOGGER.warn("Received message type '{}' (version '{}') is not supported.",
+                                messageType,
+                                messageVersion);
                     yield InboundMessageStatusUpdate.newBuilder()
-                            .setInboundMessage(inboundMessage)
-                            .setStatus(InboundStatusEnum.REJECTED)
-                            .setStatusText("message type " + messageType + " version " + messageVersion + " is not supported.")
-                            .build();
+                                                    .setInboundMessage(inboundMessage)
+                                                    .setStatus(InboundStatusEnum.REJECTED)
+                                                    .setStatusText("message type " + messageType + " version " + messageVersion + " is not supported.")
+                                                    .build();
                 }
             };
         } catch (JAXBException e) {
-            LOGGER.error("Error while trying to unmarshal contents of message type '{}' in schema-version '{}'", messageType, messageVersion, e);
+            LOGGER.error("Error while trying to unmarshal contents of message type '{}' in schema-version '{}'",
+                         messageType,
+                         messageVersion,
+                         e);
             return InboundMessageStatusUpdate.newBuilder()
-                    .setInboundMessage(inboundMessage)
-                    .setStatus(InboundStatusEnum.REJECTED)
-                    .setStatusText(e.getMessage())
-                    .build();
+                                             .setInboundMessage(inboundMessage)
+                                             .setStatus(InboundStatusEnum.REJECTED)
+                                             .setStatusText(e.getMessage())
+                                             .build();
         } catch (IOException e) {
             LOGGER.error("Error while reading input stream of message", e);
             return InboundMessageStatusUpdate.newBuilder()
-                    .setInboundMessage(inboundMessage)
-                    .setStatus(InboundStatusEnum.TEMPORARY_ERROR)
-                    .setStatusText(e.getMessage())
-                    .build();
+                                             .setInboundMessage(inboundMessage)
+                                             .setStatus(InboundStatusEnum.TEMPORARY_ERROR)
+                                             .setStatusText(e.getMessage())
+                                             .build();
+        }
+    }
+
+    private void outboundMessageStatusUpdateHandler(OutboundMessageStatusUpdate outboundMessageStatusUpdate) {
+        var conversationId = outboundMessageStatusUpdate.getStatusMetaData().getConversationId().getValue();
+
+        LOGGER.info("Received status update for ConversationId: '{}' with result: '{}'",
+                    conversationId,
+                    outboundMessageStatusUpdate.getResult());
+        switch (outboundMessageStatusUpdate.getResult()) {
+            case SUCCESS ->  // success just indicates that the message was received by the other party (dso)
+                    requestStatusSink.tryEmitNext(new CMRequestStatus(CMRequestStatus.Status.RECEIVED,
+                                                                      outboundMessageStatusUpdate.getDetailText(),
+                                                                      conversationId));
+            case CONFIG_ERROR, CONTENT_ERROR, TRANSMISSION_ERROR, FAILED ->
+                    requestStatusSink.tryEmitNext(new CMRequestStatus(CMRequestStatus.Status.ERROR,
+                                                                      outboundMessageStatusUpdate.getDetailText(),
+                                                                      conversationId));
+            default -> {
+                // Ignore the other status updates
+            }
         }
     }
 
@@ -144,95 +157,103 @@ public class PontonXPAdapter implements EdaAdapter {
         try (InputStream inputStream = inboundMessage.createInputStream()) {
             var notification = (CMNotification) unmarshaller.unmarshal(inputStream);
             var cmRequestId = notification.getProcessDirectory().getCMRequestId();
-            var meteringPoint = notification.getProcessDirectory().getResponseData().getFirst().getMeteringPoint();
+            ResponseDataType responseData = notification.getProcessDirectory().getResponseData().getFirst();
+            var meteringPoint = responseData.getMeteringPoint();
+            var responseCodes = responseData.getResponseCode();
 
-            var status = new CMRequestStatus(CMRequestStatus.Status.DELIVERED, "CCMO request has been delivered.", notification.getProcessDirectory().getConversationId());
+            var status = new CMRequestStatus(CMRequestStatus.Status.DELIVERED,
+                                             responseCodesToMessage(responseCodes, "CCMO request has been delivered."),
+                                             notification.getProcessDirectory().getConversationId());
             status.setCmRequestId(cmRequestId);
             status.setMeteringPoint(meteringPoint);
 
             requestStatusSink.tryEmitNext(status);
-            LOGGER.info("Received CMNotification '{}' for CMRequestId '{}' with ConversationId '{}'", status.getStatus(), cmRequestId, status.getConversationId());
+            LOGGER.info("Received CMNotification '{}' for CMRequestId '{}' with ConversationId '{}'",
+                        status.getStatus(),
+                        cmRequestId,
+                        status.getConversationId());
 
             return InboundMessageStatusUpdate.newBuilder()
-                    .setInboundMessage(inboundMessage)
-                    .setStatus(InboundStatusEnum.SUCCESS)
-                    .setStatusText(CM_NOTIFICATION_PROCESSED)
-                    .build();
+                                             .setInboundMessage(inboundMessage)
+                                             .setStatus(InboundStatusEnum.SUCCESS)
+                                             .setStatusText(CM_NOTIFICATION_PROCESSED)
+                                             .build();
         }
     }
 
     private InboundMessageStatusUpdate handleCMAcceptNotificationMessage(InboundMessage inboundMessage) throws IOException, JAXBException {
         try (InputStream inputStream = inboundMessage.createInputStream()) {
             var notification = (CMNotification) unmarshaller.unmarshal(inputStream);
-            var consentId = notification.getProcessDirectory().getResponseData().getFirst().getConsentId();
             var cmRequestId = notification.getProcessDirectory().getCMRequestId();
-            var meteringPoint = notification.getProcessDirectory().getResponseData().getFirst().getMeteringPoint();
+            ResponseDataType responseData = notification.getProcessDirectory().getResponseData().getFirst();
+            var consentId = responseData.getConsentId();
+            var meteringPoint = responseData.getMeteringPoint();
+            var responseCodes = responseData.getResponseCode();
 
-            var status = new CMRequestStatus(CMRequestStatus.Status.ACCEPTED, "CCMO request has been accepted.", notification.getProcessDirectory().getConversationId());
+            var status = new CMRequestStatus(CMRequestStatus.Status.ACCEPTED,
+                                             responseCodesToMessage(responseCodes, "CCMO request has been accepted."),
+                                             notification.getProcessDirectory().getConversationId());
             status.setCmConsentId(consentId);
             status.setCmRequestId(cmRequestId);
             status.setMeteringPoint(meteringPoint);
 
             requestStatusSink.tryEmitNext(status);
-            LOGGER.info("Received CMNotification: ACCEPTED for CMRequestId '{}' with ConversationId '{}' and ConsentId: '{}'", cmRequestId, status.getConversationId(), consentId);
+            LOGGER.info(
+                    "Received CMNotification: ACCEPTED for CMRequestId '{}' with ConversationId '{}' and ConsentId: '{}'",
+                    cmRequestId,
+                    status.getConversationId(),
+                    consentId);
 
             return InboundMessageStatusUpdate.newBuilder()
-                    .setInboundMessage(inboundMessage)
-                    .setStatus(InboundStatusEnum.SUCCESS)
-                    .setStatusText(CM_NOTIFICATION_PROCESSED)
-                    .build();
+                                             .setInboundMessage(inboundMessage)
+                                             .setStatus(InboundStatusEnum.SUCCESS)
+                                             .setStatusText(CM_NOTIFICATION_PROCESSED)
+                                             .build();
         }
     }
 
     private InboundMessageStatusUpdate handleCMRejectNotificationMessage(InboundMessage inboundMessage) throws IOException, JAXBException {
         try (InputStream inputStream = inboundMessage.createInputStream()) {
             var notification = (CMNotification) unmarshaller.unmarshal(inputStream);
-            var responseCode = notification.getProcessDirectory().getResponseData().getFirst().getResponseCode().getFirst();
             var cmRequestId = notification.getProcessDirectory().getCMRequestId();
             var meteringPoint = notification.getProcessDirectory().getResponseData().getFirst().getMeteringPoint();
 
-            // maybe turn this into an enum that handles the mapping
-            var reason = switch (responseCode) {
-                case 56 -> "Metering point not found";
-                case 178 -> "Consent already exists";
-                case 174 -> "Requested data not deliverable";
-                case 173 -> "Time-out";
-                case 172 -> "Customer rejected the request";
-                case 82 -> "Invalid dates";
-                case 76 -> "Invalid request data";
-                case 57 -> "Metering point not supplied";
-                case 179 -> "ConsentId already exists";
-                default -> responseCode + " - Unknown response code";
-            };
+            var responseCodes = notification.getProcessDirectory().getResponseData().getFirst().getResponseCode();
+            var reason = responseCodesToMessage(responseCodes, "DSO provided no reason for rejection.");
 
-            var status = new CMRequestStatus(CMRequestStatus.Status.REJECTED, reason, notification.getProcessDirectory().getConversationId());
+            var status = new CMRequestStatus(CMRequestStatus.Status.REJECTED,
+                                             reason,
+                                             notification.getProcessDirectory().getConversationId());
             status.setCmRequestId(cmRequestId);
             status.setMeteringPoint(meteringPoint);
 
             requestStatusSink.tryEmitNext(status);
-            LOGGER.info("Received CMNotification: REJECTED for CMRequestId '{}' with  ConversationId '{}', reason '{}'", cmRequestId, status.getConversationId(), reason);
+            LOGGER.info("Received CMNotification: REJECTED for CMRequestId '{}' with  ConversationId '{}', reason '{}'",
+                        cmRequestId,
+                        status.getConversationId(),
+                        reason);
 
             return InboundMessageStatusUpdate.newBuilder()
-                    .setInboundMessage(inboundMessage)
-                    .setStatus(InboundStatusEnum.SUCCESS)
-                    .setStatusText(CM_NOTIFICATION_PROCESSED)
-                    .build();
+                                             .setInboundMessage(inboundMessage)
+                                             .setStatus(InboundStatusEnum.SUCCESS)
+                                             .setStatusText(CM_NOTIFICATION_PROCESSED)
+                                             .build();
         }
     }
-
 
     private InboundMessageStatusUpdate handleMasterDataMessage(InboundMessage inboundMessage) throws IOException, JAXBException {
         try (InputStream inputStream = inboundMessage.createInputStream()) {
             var masterData = (MasterData) unmarshaller.unmarshal(inputStream);
             masterDataSink.tryEmitNext(masterData);
 
-            LOGGER.info("Received master data with ConversationId '{}'", masterData.getProcessDirectory().getConversationId());
+            LOGGER.info("Received master data with ConversationId '{}'",
+                        masterData.getProcessDirectory().getConversationId());
 
             return InboundMessageStatusUpdate.newBuilder()
-                    .setInboundMessage(inboundMessage)
-                    .setStatus(InboundStatusEnum.SUCCESS)
-                    .setStatusText("Master data successfully delivered to backend.")
-                    .build();
+                                             .setInboundMessage(inboundMessage)
+                                             .setStatus(InboundStatusEnum.SUCCESS)
+                                             .setStatusText("Master data successfully delivered to backend.")
+                                             .build();
         }
     }
 
@@ -242,13 +263,14 @@ public class PontonXPAdapter implements EdaAdapter {
             // the process is documented here https://www.ebutilities.at/prozesse/230
             // we might have to create a ABLEHNUNG_CRMSG (CPNotification) if the message was not valid, see https://www.ebutilities.at/prozesse/230/marktnachrichten/615
             consumptionRecordSink.tryEmitNext(consumptionRecord);
-            LOGGER.info("Received consumption record with ConversationId '{}'", consumptionRecord.getProcessDirectory().getConversationId());
+            LOGGER.info("Received consumption record with ConversationId '{}'",
+                        consumptionRecord.getProcessDirectory().getConversationId());
 
             return InboundMessageStatusUpdate.newBuilder()
-                    .setInboundMessage(inboundMessage)
-                    .setStatus(InboundStatusEnum.SUCCESS)
-                    .setStatusText("ConsumptionRecord successfully delivered to backend.")
-                    .build();
+                                             .setInboundMessage(inboundMessage)
+                                             .setStatus(InboundStatusEnum.SUCCESS)
+                                             .setStatusText("ConsumptionRecord successfully delivered to backend.")
+                                             .build();
         }
     }
 
@@ -259,91 +281,24 @@ public class PontonXPAdapter implements EdaAdapter {
 
             cmRevokeSink.tryEmitNext(cmRevoke);
             LOGGER.info("Received revoke message for ConsentId '{}' with ConversationId '{}'",
-                    cmRevoke.getProcessDirectory().getMeteringPoint(), cmRevoke.getProcessDirectory().getConversationId());
+                        cmRevoke.getProcessDirectory().getMeteringPoint(),
+                        cmRevoke.getProcessDirectory().getConversationId());
 
             return InboundMessageStatusUpdate.newBuilder()
-                    .setInboundMessage(inboundMessage)
-                    .setStatus(InboundStatusEnum.SUCCESS)
-                    .setStatusText("CMRevoke successfully delivered to backend.")
-                    .build();
+                                             .setInboundMessage(inboundMessage)
+                                             .setStatus(InboundStatusEnum.SUCCESS)
+                                             .setStatusText("CMRevoke successfully delivered to backend.")
+                                             .build();
         }
     }
 
-    @Override
-    public void sendCMRequest(CMRequest request) throws TransmissionException, JAXBException {
-        // convert request to XML
-        var outputStream = new ByteArrayOutputStream();
-        marshaller.marshal(request, outputStream);
-        InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
-
-        final OutboundMetaData outboundMetaData = OutboundMetaData.newBuilder()
-                .setSenderId(new SenderId(request.getMarketParticipantDirectory().getRoutingHeader().getSender().getMessageAddress()))
-                .setReceiverId(new ReceiverId(request.getMarketParticipantDirectory().getRoutingHeader().getReceiver().getMessageAddress()))
-                .setMessageType(new MessageType.MessageTypeBuilder()
-                        .setSchemaSet(new SchemaSet(MessageCodes.Request.SCHEMA))
-                        .setVersion(new MessageTypeVersion(MessageCodes.Request.VERSION))
-                        .setName(new MessageTypeName(MessageCodes.Request.CODE))
-                        .setMimeType(new MimeType("text/xml"))
-                        .build())
-                .build();
-
-        final OutboundMessage outboundMessage = OutboundMessage.newBuilder()
-                .setInputStream(inputStream)
-                .setOutboundMetaData(outboundMetaData)
-                .build();
-
-        try {
-            LOGGER.info("Sending CCMO request to DSO '{}' with RequestID '{}'", request.getMarketParticipantDirectory().getRoutingHeader().getReceiver().getMessageAddress(), request.getProcessDirectory().getCMRequestId());
-            messengerConnection.sendMessage(outboundMessage);
-        } catch (de.ponton.xp.adapter.api.TransmissionException e) {
-            throw new TransmissionException(e);
-        }
-
-        requestStatusSink.tryEmitNext(new CMRequestStatus(CMRequestStatus.Status.SENT, "CCMO request has been sent", request.getProcessDirectory().getConversationId()));
-    }
-
-
-    @Override
-    public void sendCMRevoke(CMRevoke revoke) throws TransmissionException, JAXBException {
-        // convert revoke to XML
-        var outputStream = new ByteArrayOutputStream();
-        marshaller.marshal(revoke, outputStream);
-        InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
-        final OutboundMetaData outboundMetaData = OutboundMetaData.newBuilder()
-                .setSenderId(new SenderId(revoke.getMarketParticipantDirectory().getRoutingHeader().getSender().getMessageAddress()))
-                .setReceiverId(new ReceiverId(revoke.getMarketParticipantDirectory().getRoutingHeader().getReceiver().getMessageAddress()))
-                .setMessageType(new MessageType.MessageTypeBuilder()
-                        .setSchemaSet(new SchemaSet(MessageCodes.Revoke.EligibleParty.SCHEMA))
-                        .setVersion(new MessageTypeVersion(MessageCodes.Revoke.EligibleParty.VERSION))
-                        .setName(new MessageTypeName(MessageCodes.Revoke.EligibleParty.REVOKE))
-                        .setMimeType(new MimeType("text/xml"))
-                        .build())
-                .build();
-
-        final OutboundMessage outboundMessage = OutboundMessage.newBuilder()
-                .setInputStream(inputStream)
-                .setOutboundMetaData(outboundMetaData)
-                .build();
-
-        try {
-            LOGGER.info("Sending CMRevoke to DSO '{}' with ConsentId '{}'", revoke.getMarketParticipantDirectory().getRoutingHeader().getReceiver().getMessageAddress(), revoke.getProcessDirectory().getConsentId());
-            messengerConnection.sendMessage(outboundMessage);
-        } catch (de.ponton.xp.adapter.api.TransmissionException e) {
-            throw new TransmissionException(e);
-        }
-    }
-
-    @Override
-    public Map<String, HealthState> health() {
-        Map<String, HealthState> healthChecks = new HashMap<>();
-        try {
-            InetAddress address = InetAddress.getByName(config.hostname());
-            healthChecks.put(PONTON_HOST, address.isReachable(PING_TIMEOUT) ? HealthState.UP : HealthState.DOWN);
-        } catch (IOException e) {
-            LOGGER.warn("Ponton  XP Messenger Host not reachable", e);
-            healthChecks.put(PONTON_HOST, HealthState.DOWN);
-        }
-        return healthChecks;
+    @NotNull
+    private static String responseCodesToMessage(List<Integer> responseCodes, String defaultMessage) {
+        return responseCodes.stream()
+                            .map(ResponseCode::new)
+                            .map(ResponseCode::toString)
+                            .reduce((a, b) -> a + ", " + b)
+                            .orElse(defaultMessage);
     }
 
     @Override
@@ -373,5 +328,117 @@ public class PontonXPAdapter implements EdaAdapter {
     @Override
     public Flux<MasterData> getMasterDataStream() {
         return masterDataSink.asFlux();
+    }
+
+    @Override
+    public void sendCMRequest(CMRequest request) throws TransmissionException, JAXBException {
+        // convert request to XML
+        var outputStream = new ByteArrayOutputStream();
+        marshaller.marshal(request, outputStream);
+        InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+
+        final OutboundMetaData outboundMetaData = OutboundMetaData.newBuilder()
+                                                                  .setSenderId(new SenderId(request.getMarketParticipantDirectory()
+                                                                                                   .getRoutingHeader()
+                                                                                                   .getSender()
+                                                                                                   .getMessageAddress()))
+                                                                  .setReceiverId(new ReceiverId(request.getMarketParticipantDirectory()
+                                                                                                       .getRoutingHeader()
+                                                                                                       .getReceiver()
+                                                                                                       .getMessageAddress()))
+                                                                  .setMessageType(new MessageType.MessageTypeBuilder()
+                                                                                          .setSchemaSet(new SchemaSet(
+                                                                                                  MessageCodes.Request.SCHEMA))
+                                                                                          .setVersion(new MessageTypeVersion(
+                                                                                                  MessageCodes.Request.VERSION))
+                                                                                          .setName(new MessageTypeName(
+                                                                                                  MessageCodes.Request.CODE))
+                                                                                          .setMimeType(new MimeType(
+                                                                                                  "text/xml"))
+                                                                                          .build())
+                                                                  .build();
+
+        final OutboundMessage outboundMessage = OutboundMessage.newBuilder()
+                                                               .setInputStream(inputStream)
+                                                               .setOutboundMetaData(outboundMetaData)
+                                                               .build();
+
+        try {
+            LOGGER.info("Sending CCMO request to DSO '{}' with RequestID '{}'",
+                        request.getMarketParticipantDirectory().getRoutingHeader().getReceiver().getMessageAddress(),
+                        request.getProcessDirectory().getCMRequestId());
+            messengerConnection.sendMessage(outboundMessage);
+        } catch (de.ponton.xp.adapter.api.TransmissionException e) {
+            throw new TransmissionException(e);
+        }
+
+        requestStatusSink.tryEmitNext(new CMRequestStatus(CMRequestStatus.Status.SENT,
+                                                          "CCMO request has been sent",
+                                                          request.getProcessDirectory().getConversationId()));
+    }
+
+    @Override
+    public void sendCMRevoke(CMRevoke revoke) throws TransmissionException, JAXBException {
+        // convert revoke to XML
+        var outputStream = new ByteArrayOutputStream();
+        marshaller.marshal(revoke, outputStream);
+        InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+        final OutboundMetaData outboundMetaData = OutboundMetaData.newBuilder()
+                                                                  .setSenderId(new SenderId(revoke.getMarketParticipantDirectory()
+                                                                                                  .getRoutingHeader()
+                                                                                                  .getSender()
+                                                                                                  .getMessageAddress()))
+                                                                  .setReceiverId(new ReceiverId(revoke.getMarketParticipantDirectory()
+                                                                                                      .getRoutingHeader()
+                                                                                                      .getReceiver()
+                                                                                                      .getMessageAddress()))
+                                                                  .setMessageType(new MessageType.MessageTypeBuilder()
+                                                                                          .setSchemaSet(new SchemaSet(
+                                                                                                  MessageCodes.Revoke.EligibleParty.SCHEMA))
+                                                                                          .setVersion(new MessageTypeVersion(
+                                                                                                  MessageCodes.Revoke.EligibleParty.VERSION))
+                                                                                          .setName(new MessageTypeName(
+                                                                                                  MessageCodes.Revoke.EligibleParty.REVOKE))
+                                                                                          .setMimeType(new MimeType(
+                                                                                                  "text/xml"))
+                                                                                          .build())
+                                                                  .build();
+
+        final OutboundMessage outboundMessage = OutboundMessage.newBuilder()
+                                                               .setInputStream(inputStream)
+                                                               .setOutboundMetaData(outboundMetaData)
+                                                               .build();
+
+        try {
+            LOGGER.info("Sending CMRevoke to DSO '{}' with ConsentId '{}'",
+                        revoke.getMarketParticipantDirectory().getRoutingHeader().getReceiver().getMessageAddress(),
+                        revoke.getProcessDirectory().getConsentId());
+            messengerConnection.sendMessage(outboundMessage);
+        } catch (de.ponton.xp.adapter.api.TransmissionException e) {
+            throw new TransmissionException(e);
+        }
+    }
+
+    @Override
+    public void start() throws TransmissionException {
+        try {
+            messengerConnection.start();
+            LOGGER.info("Ponton XP adapter started.");
+        } catch (de.ponton.xp.adapter.api.TransmissionException e) {
+            throw new TransmissionException(e);
+        }
+    }
+
+    @Override
+    public Map<String, HealthState> health() {
+        Map<String, HealthState> healthChecks = new HashMap<>();
+        try {
+            InetAddress address = InetAddress.getByName(config.hostname());
+            healthChecks.put(PONTON_HOST, address.isReachable(PING_TIMEOUT) ? HealthState.UP : HealthState.DOWN);
+        } catch (IOException e) {
+            LOGGER.warn("Ponton XP Messenger Host not reachable", e);
+            healthChecks.put(PONTON_HOST, HealthState.DOWN);
+        }
+        return healthChecks;
     }
 }


### PR DESCRIPTION
Adds a ResponseCode record to better handle response codes.

This class is not limited to CCMO_REQ_ONL, but can handle all messages that are sent in the context of "Consent Management" see [this](https://www.ebutilities.at/responsecodes) and filter accordingly.

If we were to receive multiple response codes, the PontonXPAdapter now concatinates all messages