### PR TITLE
NOISSUE Run all workflows on self-hosted GitHub runner

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, fh-server ]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [ push ]
 jobs:
   build:
     name: Build and analyze
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, fh-server ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-commit-message:
     name: Check Commit Message
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, fh-server ]
     steps:
       - name: Check for referenced issue
         uses: gsactions/commit-message-checker@v2

--- a/.github/workflows/run-playwright-e2e-tests.yml
+++ b/.github/workflows/run-playwright-e2e-tests.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   e2e-tests:
     name: Build and run E2E tests
-    runs-on: [ self-hosted, fh-server ]
+    runs-on: [ self-hosted, fh-server-e2e ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/e2e-tests/docker/docker-compose.yml
+++ b/e2e-tests/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./create-example-app-db.sql:/docker-entrypoint-initdb.d/create_database.sql
 
   eddie:
-    image: ghcr.io/eddie-energy/eddie:latest
+    image: ghcr.io/eddie-energy/eddie:e2e-test
     build:
       dockerfile: src/main/docker/Dockerfile
       context: ../../core
@@ -27,7 +27,7 @@ services:
       - db
 
   eddie-example-app:
-    image: ghcr.io/eddie-energy/eddie-example-app:latest
+    image: ghcr.io/eddie-energy/eddie-example-app:e2e-test
     build:
       dockerfile: src/main/docker/Dockerfile
       context: ../../examples/example-app


### PR DESCRIPTION
Rename the tag of the images built in the E2E workflow to ensure that the runner cleanup removes only the built images.
Use dedicated runner for E2E tests, because it requires special network configuration.

Updated the FH-server's firewall to allow testcontainers to access the `Ryuk` container they require.

Created a docker compose on the server that can be scaled for multiple simultaneously running runners. It's unclear how performant this will be.