### PR TITLE
NOISSUE Run image build on GitHub hosted runners

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
 
-    runs-on: [ self-hosted, fh-server ]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -72,7 +72,7 @@ jobs:
         run: rm $HOME/.docker/config.json
 
   build-aiida:
-    runs-on: [ self-hosted, fh-server ]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-commit-message:
     name: Check Commit Message
-    runs-on: [ self-hosted, fh-server ]
+    runs-on: ubuntu-latest
     steps:
       - name: Check for referenced issue
         uses: gsactions/commit-message-checker@v2


### PR DESCRIPTION
Takes some workload off of our server and the free minutes should suffice for these workflows.