### PR TITLE
GH-569 Add version label to popup

### DIFF
--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -115,6 +115,12 @@ class EddieConnectButton extends LitElement {
       cursor: default;
       filter: grayscale(100%);
     }
+
+    .version-indicator {
+      font-size: var(--sl-font-size-x-small);
+      color: var(--sl-color-neutral-500);
+      padding: var(--sl-spacing-2x-small);
+    }
   `;
   dialogRef = createRef();
 
@@ -486,7 +492,11 @@ class EddieConnectButton extends LitElement {
               `}
         </div>
 
-        <br />
+        <div slot="footer">
+          <div class="version-indicator">
+            <i>EDDIE Version: __EDDIE_VERSION__</i>
+          </div>
+        </div>
       </sl-dialog>
     `;
   }

--- a/core/vite.config.js
+++ b/core/vite.config.js
@@ -1,7 +1,16 @@
 import { resolve } from "path";
 import { defineConfig } from "vite";
 
+// format current date as YYYYMMdd and use it as build version indicator (same format as Github tags)
+const currentDate = new Date();
+const formattedDate = currentDate.getFullYear().toString() +
+  (currentDate.getMonth() + 1).toString().padStart(2, "0") +
+  currentDate.getDate().toString().padStart(2, "0");
+
 export default defineConfig({
+  define: {
+    __EDDIE_VERSION__: formattedDate,
+  },
   build: {
     outDir: resolve(__dirname, "src/main/resources/public/lib"),
     assetsDir: "",


### PR DESCRIPTION
![image](https://github.com/eddie-energy/eddie/assets/123056348/8aa38c51-2f2a-4ae4-b1d7-4c5ec5a8e038)

As we are manually creating the Github releases & tags, I thought it's easier to use the same format for the version label in the popup and just generate it each build.