### PR TITLE
NOISSUE Use GitHub-hosted runners as fallback

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -72,7 +72,7 @@ jobs:
         run: rm $HOME/.docker/config.json
 
   build-aiida:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [ push ]
 jobs:
   build:
     name: Build and analyze
-    runs-on: [ self-hosted, fh-server ]
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-commit-message:
     name: Check Commit Message
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check for referenced issue
         uses: gsactions/commit-message-checker@v2

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -33,8 +33,10 @@ whole test report as HTML file are uploaded as artifacts and attached to the wor
 A self-hosted runner that is on the FH network is used so that the Ponton XP messenger can be accessed.
 The self-hosted runner is started in a docker container, which shares its working directory as a volume with the host.
 Currently, only one runner is available at the same time, therefore only 1 job can be processed simultaneously.
-For a workflow to run on a self-hosted runner, `runs-on: [ self-hosted, fh-server ]` has to be used in the workflow
-definition.
+For a workflow to run on a self-hosted runner, the corresponding labels of the runner have to be specified in the
+workflow file, e.g. `runs-on: [ self-hosted, fh-server ]`. If one uses a label, that is used by a self-hosted as well as
+a GitHub-hosted runner, e.g. `ubuntu-22.04`, then GitHub will send the job to a self-hosted runner if one is available,
+and otherwise will use a GitHub-hosted one.
 
 It would also be possible to not use a volume and make the runner completely ephemeral. However, this is not feasible
 with our test setup, as the *eddie core* container needs secrets written to files to work properly. These GitHub secrets
@@ -94,4 +96,3 @@ mkdir -p $GITHUB_WORKSPACE
 ```
 
 Could use playwright image which has dependencies pre-installed but then need to mount again the source files, etc...
-


### PR DESCRIPTION
I think this is the best compromise: By specifying a label that both, the self-hosted and the GitHub-hosted runners, have, GitHub should automatically send the job to a self-hosted runner if one is available, otherwise it will send it to a GitHub hosted one.

With this mixed approach, I think we should not run out of minutes so easily, while still ensuring that the execution of a workflow is delayed by no runner being available. 