### PR TITLE
NOISSUE Indicate length of metering point ID in popup

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/web/permission-request-form.js
+++ b/region-connectors/region-connector-at-eda/src/main/web/permission-request-form.js
@@ -174,11 +174,11 @@ class PermissionRequestForm extends PermissionRequestFormBase {
             type="text"
             .helpText=${this.accountingPointId
               ? "The service has already provided a Zählpunktnummer. If this value is incorrect, please contact the service provider."
-              : "Enter your Zählpunktnummer for the request to show up in your DSO portal. Leave blank to search for the generated Consent Request ID."}
+              : "Enter your 33-character Zählpunktnummer for the request to show up in your DSO portal. Leave blank to search for the generated Consent Request ID."}
             name="meteringPointId"
             minlength="33"
             maxlength="33"
-            placeholder="${this.companyId}"
+            placeholder="${this.companyId}..."
             .value="${this.accountingPointId
               ? this.accountingPointId
               : nothing}"
@@ -203,8 +203,8 @@ class PermissionRequestForm extends PermissionRequestFormBase {
                 <sl-icon slot="icon" name="info-circle"></sl-icon>
                 <p>Your permission request is being processed.</p>
                 <p>
-                  Please wait for the request to finish. 
-                  This process may take several minutes!
+                  Please wait for the request to finish. This process may take
+                  several minutes!
                 </p>
               </sl-alert>`
           : ""}


### PR DESCRIPTION
In yesterday's meeting, I noticed that it might be a helpful hint for customers to know how long the metering point ID should be.

![image](https://github.com/eddie-energy/eddie/assets/123056348/fe9926c0-a7d6-4f86-9e2a-3e0d9374286c)
