### PR TITLE
NOISSUE Fix swagger documentation

### DIFF
--- a/core/src/main/java/energy/eddie/OpenApiDocs.java
+++ b/core/src/main/java/energy/eddie/OpenApiDocs.java
@@ -13,12 +13,13 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static energy.eddie.regionconnector.shared.utils.CommonPaths.ALL_REGION_CONNECTORS_BASE_URL_PATH;
+import static energy.eddie.regionconnector.shared.web.RestApiPaths.SWAGGER_DOC_PATH;
 import static energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor.ENABLED_REGION_CONNECTOR_BEAN_NAME;
 
 /**
  * Adds the OpenAPI documentation URLs of all enabled region connectors to the OpenAPI documentation in the current
- * context, so that they can be accessed in the "Select a definition" drop down menu.
- * Additionally, it also adds the API documentation for the European MasterData.
+ * context, so that they can be accessed in the "Select a definition" drop down menu. Additionally, it also adds the API
+ * documentation for the European MasterData.
  */
 public class OpenApiDocs {
     @Bean
@@ -28,8 +29,6 @@ public class OpenApiDocs {
             @Value("${server.port}") int serverPort,
             @Qualifier(ENABLED_REGION_CONNECTOR_BEAN_NAME) List<String> enabledRegionConnectors
     ) {
-        final String docPath = "v3/api-docs";
-
         var swaggerUrls = enabledRegionConnectors
                 .stream()
                 .map(name -> {
@@ -41,7 +40,7 @@ public class OpenApiDocs {
                             .port(serverPort)
                             .pathSegment(ALL_REGION_CONNECTORS_BASE_URL_PATH)
                             .pathSegment(name)
-                            .path(docPath)
+                            .path(SWAGGER_DOC_PATH)
                             .toUriString();
 
                     return new AbstractSwaggerUiConfigProperties.SwaggerUrl("region-connector-" + name,
@@ -50,22 +49,19 @@ public class OpenApiDocs {
                 })
                 .collect(Collectors.toSet());
 
-        swaggerUrls.add(getEuropeanMasterDataSwaggerUrl(serverPort, docPath));
+        swaggerUrls.add(getEuropeanMasterDataSwaggerUrl(serverPort));
         config.setUrls(swaggerUrls);
         return config;
     }
 
-    private static AbstractSwaggerUiConfigProperties.SwaggerUrl getEuropeanMasterDataSwaggerUrl(
-            int serverPort,
-            String docPath
-    ) {
+    private static AbstractSwaggerUiConfigProperties.SwaggerUrl getEuropeanMasterDataSwaggerUrl(int serverPort) {
         var url = UriComponentsBuilder
                 .newInstance()
                 .scheme("http")
                 .host("localhost")
                 .port(serverPort)
                 .pathSegment("european-masterdata")
-                .path(docPath)
+                .path(SWAGGER_DOC_PATH)
                 .toUriString();
 
         return new AbstractSwaggerUiConfigProperties.SwaggerUrl("european-masterdata",

--- a/core/src/main/java/energy/eddie/spring/RegionConnectorRegistrationBeanPostProcessor.java
+++ b/core/src/main/java/energy/eddie/spring/RegionConnectorRegistrationBeanPostProcessor.java
@@ -206,9 +206,9 @@ public class RegionConnectorRegistrationBeanPostProcessor implements BeanDefinit
             List<String> enabledRegionConnectorNames
     ) {
         // copy list to prevent that modifications of enabledRegionConnectorNames influence the Bean and thereby other application parts
-        List<String> unmodifiableCopy = enabledRegionConnectorNames.stream().toList();
+        List<String> copy = new ArrayList<>(enabledRegionConnectorNames);
         AbstractBeanDefinition beanDefinition = BeanDefinitionBuilder
-                .genericBeanDefinition(List.class, () -> unmodifiableCopy)
+                .genericBeanDefinition(List.class, () -> copy)
                 .getBeanDefinition();
         registry.registerBeanDefinition(ENABLED_REGION_CONNECTOR_BEAN_NAME, beanDefinition);
     }

--- a/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisSecurityConfig.java
+++ b/region-connectors/region-connector-es-datadis/src/main/java/energy/eddie/regionconnector/es/datadis/DatadisSecurityConfig.java
@@ -24,8 +24,7 @@ import static energy.eddie.regionconnector.es.datadis.web.PermissionController.P
 import static energy.eddie.regionconnector.es.datadis.web.PermissionController.PATH_PERMISSION_REJECTED;
 import static energy.eddie.regionconnector.shared.utils.CommonPaths.ALL_REGION_CONNECTORS_BASE_URL_PATH;
 import static energy.eddie.regionconnector.shared.utils.CommonPaths.CE_FILE_NAME;
-import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_REQUEST;
-import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_STATUS_WITH_PATH_PARAM;
+import static energy.eddie.regionconnector.shared.web.RestApiPaths.*;
 
 @RegionConnectorSecurityConfig
 public class DatadisSecurityConfig {
@@ -63,6 +62,7 @@ public class DatadisSecurityConfig {
                         .requestMatchers(datadisMvcRequestMatcher.pattern(PATH_PERMISSION_ACCEPTED)).access(datadisAuthorizationManager)
                         .requestMatchers(datadisMvcRequestMatcher.pattern(PATH_PERMISSION_REJECTED)).access(datadisAuthorizationManager)
                         .requestMatchers(datadisMvcRequestMatcher.pattern("/" + CE_FILE_NAME)).permitAll()
+                        .requestMatchers(datadisMvcRequestMatcher.pattern("/" + SWAGGER_DOC_PATH)).permitAll()
                         .anyRequest().denyAll()
 // @formatter:on
                 )

--- a/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/web/RestApiPaths.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/web/RestApiPaths.java
@@ -9,4 +9,5 @@ public final class RestApiPaths {
     public static final String PATH_PERMISSION_REQUEST = "/permission-request";
     @SuppressWarnings("java:S1075")
     public static final String PATH_PERMISSION_STATUS_WITH_PATH_PARAM = "/permission-status/{permissionId}";
+    public static final String SWAGGER_DOC_PATH = "v3/api-docs";
 }


### PR DESCRIPTION
Prevent modifications of the list of enabled region connectors to influence the bean and thereby other parts of the application.
E.g. the OpenApi documentation uses the `enabledRegionConnectorsList` Bean to add their Swagger documentation to the dropdown menu in the top right corner.
As `core` and `data-needs` are added (for flyway to work) to the `enabledRegionConnectorsList` after it was registered as bean, they are also displayed in the OpenApi doc, although they shouldn't.

![image](https://github.com/eddie-energy/eddie/assets/123056348/9152a088-bc94-4510-8373-72638dc857d5)


Also allow access to OpenApi docs without authentication for es-datadis to be able to display it in Swagger.