### PR TITLE
GH-878 Move long-running send process to virtual thread

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/at/AtEdaTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/at/AtEdaTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test;
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
 class AtEdaTest extends E2eTestSetup {
+
+    private static final String SENT_TO_PERMISSION_ADMINISTRATOR = "SENT_TO_PERMISSION_ADMINISTRATOR";
+
     @Test
     void buttonClick_statusIsPending() {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect with EDDIE")).nth(1).click();
@@ -19,7 +22,9 @@ class AtEdaTest extends E2eTestSetup {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
         assertThat(page.locator("sl-alert").filter(new Locator.FilterOptions().setHasText("Permission request created!")).locator("div").nth(2)).isVisible();
         assertThat(page.locator("at-eda-pa-ce")).containsText("The Consent Request ID for this connection is: ");
-        // could be either SENT_TO_PERMISSION_ADMINISTRATOR if very fast, otherwise it would be PENDING_PERMISSION_ADMINISTRATOR_ACKNOWLEDGEMENT
-        assertThat(page.locator("at-eda-pa-ce")).containsText("PERMISSION_ADMINISTRATOR");
+        var locator = page.locator("at-eda-pa-ce",
+                                   new Page.LocatorOptions().setHasText(SENT_TO_PERMISSION_ADMINISTRATOR));
+        locator.waitFor(new Locator.WaitForOptions());
+        assertThat(page.locator("at-eda-pa-ce")).containsText(SENT_TO_PERMISSION_ADMINISTRATOR);
     }
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/handlers/SendingEventHandler.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/handlers/SendingEventHandler.java
@@ -42,7 +42,7 @@ public class SendingEventHandler implements EventHandler<PermissionEvent> {
         this.repository = repository;
         this.outbox = outbox;
         eventBus.filteredFlux(PermissionProcessStatus.VALIDATED)
-                .subscribe(this::accept);
+                .subscribe(this::threadedAccept);
     }
 
     @Override
@@ -69,5 +69,9 @@ public class SendingEventHandler implements EventHandler<PermissionEvent> {
         } catch (TransmissionException e) {
             outbox.commit(new ExceptionEvent(permissionId, PermissionProcessStatus.UNABLE_TO_SEND, e));
         }
+    }
+
+    private void threadedAccept(PermissionEvent permissionEvent) {
+        Thread.startVirtualThread(() -> accept(permissionEvent));
     }
 }


### PR DESCRIPTION
Closes #878 

The long running send process is moved to a virtual thread.
Now, when one send blocks and another message needs to be send, the ponton adapter will throw following exception:

```
2024-04-26T10:28:59.550+02:00  INFO 1735741 --- [               ] e.e.r.at.eda.ponton.PontonXPAdapter      : Sending CCMO request to DSO 'AT006250' with RequestID 'B3IYVMID'
2024-04-26T10:29:01.416+02:00  INFO 1735741 --- [nio-8080-exec-2] e.e.r.a.e.w.PermissionRequestController  : Creating new permission request
2024-04-26T10:29:01.434+02:00  INFO 1735741 --- [               ] e.e.r.at.eda.ponton.PontonXPAdapter      : Sending CCMO request to DSO 'AT006250' with RequestID 'T36VGSIL'
2024-04-26T10:29:03.435+02:00 ERROR 1735741 --- [               ] .r.a.e.p.m.PontonMessengerConnectionImpl : Error while sending message to Ponton XP Messenger

de.ponton.xp.adapter.api.TransmissionException: No connection available.
	at de.ponton.xp.adapter.api.internal.WebSocketConnectionPool.borrowConnection(WebSocketConnectionPool.java:94) ~[adapterapi2.jar:na]
	at de.ponton.xp.adapter.api.internal.WebSocketConnectionBundle.sendMessage(WebSocketConnectionBundle.java:45) ~[adapterapi2.jar:na]
	at de.ponton.xp.adapter.api.MessengerConnection.sendMessage(MessengerConnection.java:197) ~[adapterapi2.jar:na]
	at energy.eddie.regionconnector.at.eda.ponton.messenger.PontonMessengerConnectionImpl.sendMessage(PontonMessengerConnectionImpl.java:224) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at energy.eddie.regionconnector.at.eda.ponton.messenger.PontonMessengerConnectionImpl.sendCMRequest(PontonMessengerConnectionImpl.java:250) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapter.sendCMRequest(PontonXPAdapter.java:219) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at energy.eddie.regionconnector.at.eda.handlers.SendingEventHandler.accept(SendingEventHandler.java:68) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at energy.eddie.regionconnector.at.eda.handlers.SendingEventHandler.lambda$threadedAccept$0(SendingEventHandler.java:75) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:309) ~[na:na]

2024-04-26T10:44:47.347+02:00 ERROR 1735741 --- [               ] .r.a.e.p.m.PontonMessengerConnectionImpl : Error while sending message to Ponton XP Messenger

de.ponton.xp.adapter.api.TransmissionException: could not transmit message
	at de.ponton.xp.adapter.api.internal.OutboundWebSocketConnection.sendMessage(OutboundWebSocketConnection.java:94) ~[adapterapi2.jar:na]
	at de.ponton.xp.adapter.api.internal.WebSocketConnectionBundle.sendMessage(WebSocketConnectionBundle.java:47) ~[adapterapi2.jar:na]
	at de.ponton.xp.adapter.api.MessengerConnection.sendMessage(MessengerConnection.java:197) ~[adapterapi2.jar:na]
	at energy.eddie.regionconnector.at.eda.ponton.messenger.PontonMessengerConnectionImpl.sendMessage(PontonMessengerConnectionImpl.java:224) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at energy.eddie.regionconnector.at.eda.ponton.messenger.PontonMessengerConnectionImpl.sendCMRequest(PontonMessengerConnectionImpl.java:250) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapter.sendCMRequest(PontonXPAdapter.java:219) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at energy.eddie.regionconnector.at.eda.handlers.SendingEventHandler.accept(SendingEventHandler.java:68) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at energy.eddie.regionconnector.at.eda.handlers.SendingEventHandler.lambda$threadedAccept$0(SendingEventHandler.java:75) ~[region-connector-at-eda-1.0.0-plain.jar:na]
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:309) ~[na:na]
Caused by: java.util.concurrent.ExecutionException: de.ponton.xp.adapter.api.ConnectionException: java.io.IOException: Connection timed out (1000)
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[na:na]
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[na:na]
	at de.ponton.xp.adapter.api.internal.OutboundWebSocketConnection.sendMessage(OutboundWebSocketConnection.java:80) ~[adapterapi2.jar:na]
	... 8 common frames omitted
Caused by: de.ponton.xp.adapter.api.ConnectionException: java.io.IOException: Connection timed out (1000)
	at de.ponton.xp.adapter.api.internal.OutboundWebSocketEndpoint.handleOnClose(OutboundWebSocketEndpoint.java:66) ~[adapterapi2.jar:na]
	at de.ponton.xp.adapter.api.internal.AbstractWebSocketEndpoint.onClose(AbstractWebSocketEndpoint.java:154) ~[adapterapi2.jar:na]
	at de.ponton.xp.adapter.api.internal.AbstractWebSocketEndpoint.onError(AbstractWebSocketEndpoint.java:167) ~[adapterapi2.jar:na]
Caused by: java.util.concurrent.ExecutionException: de.ponton.xp.adapter.api.ConnectionException: java.io.IOException: Connection timed out (1000)

	at java.net.http/jdk.internal.net.http.websocket.WebSocketImpl$ReceiveTask.processError(WebSocketImpl.java:508) ~[java.net.http:na]
	at java.net.http/jdk.internal.net.http.websocket.WebSocketImpl$ReceiveTask.run(WebSocketImpl.java:462) ~[java.net.http:na]
Caused by: de.ponton.xp.adapter.api.ConnectionException: java.io.IOException: Connection timed out (1000)

	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$CompleteRestartableTask.run(SequentialScheduler.java:149) ~[java.net.http:na]
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(SequentialScheduler.java:207) ~[java.net.http:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na
```

This moves the second permission request immediately to the unable-to-send state, which indicates that there is a problem with the connection to the messenger.
The first message is stuck until a timeout exception is thrown.