### PR TITLE
NOISSUE Stop log spamming for AIIDA country code exception

### DIFF
--- a/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/extensions/v0_82/IntermediateConsentMarketDocument.java
+++ b/region-connectors/shared/src/main/java/energy/eddie/regionconnector/shared/permission/requests/extensions/v0_82/IntermediateConsentMarketDocument.java
@@ -123,7 +123,9 @@ public class IntermediateConsentMarketDocument<T extends PermissionRequest> {
         try {
             return CodingSchemeTypeList.fromValue("N" + permissionRequest.dataSourceInformation().countryCode());
         } catch (IllegalArgumentException e) {
-            LOGGER.warn("Unknown country code.", e);
+            // prevent exception spamming until GH-638 is implemented
+            if (!permissionRequest.dataSourceInformation().countryCode().equalsIgnoreCase("aiida"))
+                LOGGER.warn("Unknown country code.", e);
             return null;
         }
     }


### PR DESCRIPTION
The exception being logged all the time and at least 3 times per permission request just fills up the log and makes it harder to find actual useful log information.

Will be solved in #638, but this may still take a while.