### PR TITLE
GH-939 Create interface for ConsentMarketDocumentService

### DIFF
--- a/api/src/main/java/energy/eddie/api/v0_82/ConsentMarketDocumentServiceInterface.java
+++ b/api/src/main/java/energy/eddie/api/v0_82/ConsentMarketDocumentServiceInterface.java
@@ -1,0 +1,8 @@
+package energy.eddie.api.v0_82;
+
+import energy.eddie.cim.v0_82.cmd.ConsentMarketDocument;
+import reactor.core.publisher.Flux;
+
+public interface ConsentMarketDocumentServiceInterface {
+    Flux<ConsentMarketDocument> getConsentMarketDocumentStream();
+}

--- a/core/src/main/java/energy/eddie/core/services/ConsentMarketDocumentService.java
+++ b/core/src/main/java/energy/eddie/core/services/ConsentMarketDocumentService.java
@@ -1,6 +1,7 @@
 package energy.eddie.core.services;
 
 import energy.eddie.api.v0_82.ConsentMarketDocumentProvider;
+import energy.eddie.api.v0_82.ConsentMarketDocumentServiceInterface;
 import energy.eddie.cim.v0_82.cmd.ConsentMarketDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,16 +10,18 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
 @Service
-public class ConsentMarketDocumentService {
+public class ConsentMarketDocumentService implements ConsentMarketDocumentServiceInterface {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsentMarketDocumentService.class);
-    private final Sinks.Many<ConsentMarketDocument> consentMarketDocumentSink = Sinks.many().multicast().onBackpressureBuffer();
+    private final Sinks.Many<ConsentMarketDocument> consentMarketDocumentSink = Sinks.many()
+                                                                                     .multicast()
+                                                                                     .onBackpressureBuffer();
 
     public void registerProvider(ConsentMarketDocumentProvider statusMessageProvider) {
         LOGGER.info("PermissionService: Registering {}", statusMessageProvider.getClass().getName());
         statusMessageProvider.getConsentMarketDocumentStream()
-                .doOnNext(consentMarketDocumentSink::tryEmitNext)
-                .doOnError(consentMarketDocumentSink::tryEmitError)
-                .subscribe();
+                             .doOnNext(consentMarketDocumentSink::tryEmitNext)
+                             .doOnError(consentMarketDocumentSink::tryEmitError)
+                             .subscribe();
     }
 
     public Flux<ConsentMarketDocument> getConsentMarketDocumentStream() {


### PR DESCRIPTION
This way it can be accessed from other modules (e.g. the admin-console) without having the problem of a circular dependency that would be needed without the interface.