### PR TITLE
NOISSUE Update dk-energinet earliest and latest supported period

### DIFF
--- a/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/EnerginetRegionConnectorMetadata.java
+++ b/region-connectors/region-connector-dk-energinet/src/main/java/energy/eddie/regionconnector/dk/energinet/EnerginetRegionConnectorMetadata.java
@@ -13,8 +13,8 @@ import java.util.List;
 public class EnerginetRegionConnectorMetadata implements RegionConnectorMetadata {
     public static final String REGION_CONNECTOR_ID = "dk-energinet";
     public static final ZoneId DK_ZONE_ID = ZoneId.of("Europe/Copenhagen");
-    public static final Period PERIOD_EARLIEST_START = Period.ofYears(-2);
-    public static final Period PERIOD_LATEST_END = Period.ofYears(2);
+    public static final Period PERIOD_EARLIEST_START = Period.ofYears(-4);
+    public static final Period PERIOD_LATEST_END = Period.ofYears(3);
     public static final List<Granularity> SUPPORTED_GRANULARITIES = List.of(Granularity.PT15M,
                                                                             Granularity.PT1H,
                                                                             Granularity.P1D,


### PR DESCRIPTION
According to this document, energinet supports data for 4 years in the past and 2 years into the future:
https://energinet.dk/media/i3gf2w3w/deling-af-egne-data-via-fuldmagt.pdf