### PR TITLE
NOISSUE Use random Austrian DSO for E2E test

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/at/AtEdaTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/at/AtEdaTest.java
@@ -1,11 +1,13 @@
 package energy.eddie.tests.e2e.at;
 
+import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
 import energy.eddie.tests.e2e.E2eTestSetup;
 import org.junit.jupiter.api.Test;
 
+import java.util.Random;
 import java.util.regex.Pattern;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
@@ -18,10 +20,11 @@ class AtEdaTest extends E2eTestSetup {
 
         page.getByRole(AriaRole.OPTION, new Page.GetByRoleOptions().setName("Austria")).locator("slot").nth(1).click();
         page.getByRole(AriaRole.COMBOBOX, new Page.GetByRoleOptions().setName("Permission Administrator")).click();
-        page.getByRole(AriaRole.OPTION, new Page.GetByRoleOptions().setName("Netz Niederösterreich GmbH"))
-            .locator("slot")
-            .nth(1)
-            .click();
+
+        var allAustrianDso = page.querySelectorAll("sl-option[value^='AT']");
+        ElementHandle randomDsoToUse = allAustrianDso.get(new Random().nextInt(allAustrianDso.size()));
+        randomDsoToUse.click();
+
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 
         assertThat(page.locator("at-eda-pa-ce")).containsText(Pattern.compile(


### PR DESCRIPTION
Reduce spamming of one certain DSO.


I don't know how smart it is to do it randomly, because the E2E test could then fail if a DSO is selected, which takes a long time to respond.