### PR TITLE
GH-1057 Enhance log messages

### DIFF
--- a/core/src/main/resources/logback-spring.xml
+++ b/core/src/main/resources/logback-spring.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <!-- use Spring default values -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                <!-- @formatter:off Intellij adds linebreaks to the log pattern -->
+                %clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr(%applicationName[%15.15t]){faint} %clr(${LOG_CORRELATION_PATTERN:-}){faint}%clr(%logger{255}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}
+                <!-- @formatter:on -->
+            </pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Enhances the logs by extending the logger name:

```
  _____ ____  ____ ___ _____
 | ____|  _ \|  _ \_ _| ____|
 |  _| | | | | | | | ||  _|
 | |___| |_| | |_| | || |___
 |_____|____/|____/___|_____|


 
Powered by Spring Boot 3.2.4

2024-06-10T09:02:11.673+02:00  INFO 1927641 --- [           main] energy.eddie.EddieSpringApplication : Starting EddieSpringApplication using Java 21.0.2 with PID 1927641 (/home/florian/workspaces/repos/eddie/core/build/classes/java/main started by florian in /home/florian/workspaces/repos/eddie)
2024-06-10T09:02:11.682+02:00  INFO 1927641 --- [           main] energy.eddie.EddieSpringApplication : No active profile set, falling back to 1 default profile: "default"
2024-06-10T09:02:12.265+02:00  INFO 1927641 --- [           main] org.springframework.data.repository.config.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2024-06-10T09:02:12.284+02:00  INFO 1927641 --- [           main] org.springframework.data.repository.config.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 11 ms. Found 0 JPA repository interfaces.
2024-06-10T09:02:12.406+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Starting scan for classes on the classpath annotated with @RegionConnector
2024-06-10T09:02:12.498+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Found 14 region connector processors which will be registered for each region connector individually: [energy.eddie.spring.regionconnector.extensions.ConsentMarketDocumentServiceRegistrar, energy.eddie.spring.regionconnector.extensions.ConsumptionRecordServiceRegistrar, energy.eddie.spring.regionconnector.extensions.DataNeedCalculationServiceRegistrar, energy.eddie.spring.regionconnector.extensions.EddieAccountingPointMarketDocumentServiceRegistrar, energy.eddie.spring.regionconnector.extensions.EddieValidatedHistoricalDataMarketDocumentServiceRegistrar, energy.eddie.spring.regionconnector.extensions.HealthServiceRegistrar, energy.eddie.spring.regionconnector.extensions.MetadataServiceRegistrar, energy.eddie.spring.regionconnector.extensions.PermissionServiceRegistrar, energy.eddie.spring.regionconnector.extensions.RawDataServiceRegistrar, energy.eddie.spring.regionconnector.extensions.RegionConnectorConnectorElementProvider, energy.eddie.spring.regionconnector.extensions.RegionConnectorNameExtension, energy.eddie.spring.regionconnector.extensions.TerminationRouterRegistrar, energy.eddie.spring.regionconnector.extensions.RegionConnectorsCommonControllerAdvice, energy.eddie.dataneeds.web.DataNeedsAdvice]
2024-06-10T09:02:12.538+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Region connector aiida not explicitly enabled by property, will not load it.
2024-06-10T09:02:12.539+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Region connector at-eda not explicitly enabled by property, will not load it.
2024-06-10T09:02:12.544+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Region connector fr-enedis not explicitly enabled by property, will not load it.
2024-06-10T09:02:12.545+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Region connector es-datadis not explicitly enabled by property, will not load it.
2024-06-10T09:02:12.547+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Region connector nl-mijn-aansluiting not explicitly enabled by property, will not load it.
2024-06-10T09:02:12.549+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Registering new region connector with URL mapping /region-connectors/sim/*
2024-06-10T09:02:12.553+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Registering new region connector with URL mapping /region-connectors/dk-energinet/*
2024-06-10T09:02:13.004+02:00  INFO 1927641 --- [           main] org.springframework.boot.web.embedded.tomcat.TomcatWebServer : Tomcat initialized with ports 8080 (http), 9090 (http)
2024-06-10T09:02:13.014+02:00  INFO 1927641 --- [           main] org.apache.catalina.core.StandardService : Starting service [Tomcat]
2024-06-10T09:02:13.015+02:00  INFO 1927641 --- [           main] org.apache.catalina.core.StandardEngine : Starting Servlet engine: [Apache Tomcat/10.1.19]
2024-06-10T09:02:13.067+02:00  INFO 1927641 --- [           main] org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/] : Initializing Spring embedded WebApplicationContext
2024-06-10T09:02:13.068+02:00  INFO 1927641 --- [           main] org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 1361 ms
2024-06-10T09:02:13.077+02:00  INFO 1927641 --- [           main] energy.eddie.core.CoreSpringConfig : Created ServletRegistrationBean for data needs, urlMapping is /data-needs/*
2024-06-10T09:02:13.079+02:00  INFO 1927641 --- [           main] energy.eddie.core.CoreSpringConfig : Created ServletRegistrationBean for european-masterdata, urlMapping is /european-masterdata/*
2024-06-10T09:02:13.080+02:00  INFO 1927641 --- [           main] energy.eddie.core.CoreSpringConfig : Created ServletRegistrationBean for admin-console, urlMapping is /admin-console/*
2024-06-10T09:02:13.276+02:00  INFO 1927641 --- [           main] energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor : Starting Flyway migration for 'core'
2024-06-10T09:02:13.295+02:00  INFO 1927641 --- [           main] com.zaxxer.hikari.HikariDataSource : HikariPool-1 - Starting...
2024-06-10T09:02:14.330+02:00 ERROR 1927641 --- [           main] com.zaxxer.hikari.pool.HikariPool : HikariPool-1 - Exception during pool initialization.
```