### PR TITLE
GH-1175 Add helper functions to open, close, and reset the EDDIE popup

### DIFF
--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -184,15 +184,16 @@ class EddieConnectButton extends LitElement {
     this.addRequestStatusHandlers();
   }
 
-  async connect() {
+  openDialog() {
     this.dialogRef.value.show();
+  }
 
-    if (
-      !this.permissionAdministratorId &&
-      this.rememberPermissionAdministrator
-    ) {
-      this.loadPermissionAdministratorFromLocalStorage();
-    }
+  closeDialog() {
+    this.dialogRef.value.hide();
+  }
+
+  reset() {
+    this.selectPermissionAdministrator(this._presetPermissionAdministrator)
   }
 
   async getRegionConnectorElement() {
@@ -385,6 +386,13 @@ class EddieConnectButton extends LitElement {
     if (this._presetPermissionAdministrator) {
       this.selectPermissionAdministrator(this._presetPermissionAdministrator);
     }
+
+    if (
+      !this.permissionAdministratorId &&
+      this.rememberPermissionAdministrator
+    ) {
+      this.loadPermissionAdministratorFromLocalStorage();
+    }
   }
 
   isAiida() {
@@ -466,7 +474,7 @@ class EddieConnectButton extends LitElement {
         rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.11.2/cdn/themes/light.css"
       />
-      <button class="eddie-connect-button" @click="${this.connect}">
+      <button class="eddie-connect-button" @click="${this.openDialog}">
         ${unsafeSVG(buttonIcon)}
         <span>Connect with EDDIE</span>
       </button>

--- a/docs/OPERATION.md
+++ b/docs/OPERATION.md
@@ -133,6 +133,23 @@ The callback function has to be defined in the global scope and is passed as a s
 ></eddie-connect-button>
 ```
 
+## Controlling the EDDIE button programmatically
+
+The EDDIE button exposes methods to control its behavior programmatically.
+
+- `openDialog()`: Opens the dialog. Similar to clicking the button.
+- `closeDialog()`: Closes the dialog, keeping the button in its current state.
+- `reset()`: Resets the button to its initial state. Does not close the dialog if it is already open.
+
+```js
+const button = document.querySelector("eddie-connect-button");
+button.openDialog();
+button.reset();
+button.closeDialog();
+```
+
+Please use with care! Closing or resetting the button programmatically can lead to unexpected behavior or break the user experience if the user is still interacting with the button. Similarly, opening the dialog programmatically can be seen as intrusive and should be used with caution.
+
 # Configuration
 
 It is recommended to configure EDDIE core and the region connectors via the `.env` file in combination with


### PR DESCRIPTION
Closes #1175.

I would like to also present the documentation added in the commit here:

## Controlling the EDDIE button programmatically

The EDDIE button exposes methods to control its behavior programmatically.

- `openDialog()`: Opens the dialog. Similar to clicking the button.
- `closeDialog()`: Closes the dialog, keeping the button in its current state.
- `reset()`: Resets the button to its initial state.

```js
const button = document.querySelector("eddie-connect-button");
button.openDialog();
button.reset();
button.closeDialog();
```

Please use with care! Closing or resetting the button programmatically can lead to unexpected behavior or break the user experience if the user is still interacting with the button. Similarly, opening the dialog programmatically can be seen as intrusive and should be used with caution.