### PR TITLE
NOISSUE Only assert last permission status in e2e tests

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/at/AtEdaTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/at/AtEdaTest.java
@@ -12,7 +12,7 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 
 class AtEdaTest extends E2eTestSetup {
     @Test
-    void buttonClick_statusIsPending() {
+    void buttonClick_statusIsSent() {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect with EDDIE")).nth(1).click();
         page.getByRole(AriaRole.COMBOBOX, new Page.GetByRoleOptions().setName("Country")).click();
 
@@ -24,11 +24,9 @@ class AtEdaTest extends E2eTestSetup {
             .click();
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 
-        assertThat(page.locator("at-eda-pa-ce")).containsText(Pattern.compile(
-                "Please wait"));
+        assertThat(page.locator("at-eda-pa-ce")).containsText(Pattern.compile("Please wait"));
 
-        var locator = page.getByText(
-                "response code 99");
+        var locator = page.getByText("Status: Request Sent");
         locator.waitFor(new Locator.WaitForOptions().setTimeout(360_000));
     }
 }

--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/dk/DkEnerginetTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/dk/DkEnerginetTest.java
@@ -18,14 +18,10 @@ class DkEnerginetTest extends E2eTestSetup {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect with EDDIE")).nth(1).click();
         page.getByRole(AriaRole.COMBOBOX, new Page.GetByRoleOptions().setName("Country")).click();
         page.getByRole(AriaRole.OPTION, new Page.GetByRoleOptions().setName("Denmark")).locator("slot").nth(1).click();
-        page.getByLabel("Refresh Token").click();
-        page.getByLabel("Refresh Token").fill("foo");
-        page.getByLabel("Refresh Token").press("Tab");
-        page.getByLabel("Metering Point").fill("bar");
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
+        page.getByLabel("Metering Point").fill("foo");
+        page.getByLabel("Refresh Token").fill("bar");
 
-        assertThat(page.locator("body")).containsText(
-                "Status: Request Validated The permission request has been validated.");
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 
         var locator = page.locator("body", new Page.LocatorOptions().setHasText("Status: Invalid Request"));
         locator.waitFor(new Locator.WaitForOptions().setTimeout(120_000));  // 2 min
@@ -41,9 +37,6 @@ class DkEnerginetTest extends E2eTestSetup {
         page.getByLabel("Refresh Token").fill(DK_ENERGINET_REFRESH_TOKEN);
         page.getByLabel("Metering Point").fill(DK_ENERGINET_METERING_POINT);
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
-
-        assertThat(page.locator("body")).containsText(
-                "Status: Request Validated The permission request has been validated.");
 
         var locator = page.locator("body", new Page.LocatorOptions().setHasText("Status: Request Accepted"));
         locator.waitFor(new Locator.WaitForOptions().setTimeout(120_000));  // 2 min

--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/es/EsDatadisTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/es/EsDatadisTest.java
@@ -20,9 +20,6 @@ class EsDatadisTest extends E2eTestSetup {
         page.getByLabel("CUPS").fill("bar");
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 
-        assertThat(page.locator("body")).containsText(
-                "Status: Request Validated The permission request has been validated.");
-
         // Datadis API may take a long time to respond
         var locator = page.locator("body", new Page.LocatorOptions().setHasText("Status: Invalid Request"));
         locator.waitFor(new Locator.WaitForOptions().setTimeout(120_000));  // 2 min

--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/fr/FrEnedisTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/fr/FrEnedisTest.java
@@ -42,9 +42,6 @@ class FrEnedisTest extends E2eTestSetup {
                                            )
                                            .click());
 
-        assertThat(buttonPage.locator("body")).containsText(
-                "Status: Request Validated The permission request has been validated.");
-
         var redirectUrl = requestDetails.url() +
                           "/authorization-callback" +
                           "?state=" + requestDetails.permissionId() +


### PR DESCRIPTION
Page might sometimes skip a status depending on when the connection is established and when the status is updated on the backend.