### PR TITLE
GH-384 Allow passing of additional information with SSE status messages

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/AtEdaBeanConfig.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/AtEdaBeanConfig.java
@@ -233,7 +233,13 @@ public class AtEdaBeanConfig {
             Sinks.Many<ConnectionStatusMessage> messages,
             AtPermissionRequestRepository repository
     ) {
-        return new ConnectionStatusMessageHandler<>(eventBus, messages, repository, AtPermissionRequest::message);
+        return new ConnectionStatusMessageHandler<>(
+                eventBus,
+                messages,
+                repository,
+                AtPermissionRequest::message,
+                pr -> objectMapper().createObjectNode().put("cmRequestId", pr.cmRequestId())
+        );
     }
 
     @Bean


### PR DESCRIPTION
Fixes an issue where EDA status messages do not contain the cmRequestId.