### PR TITLE
NOISSUE Fix the appearance of countries name in admin-console

### DIFF
--- a/admin-console/src/main/java/energy/eddie/admin/console/data/StatusMessageService.java
+++ b/admin-console/src/main/java/energy/eddie/admin/console/data/StatusMessageService.java
@@ -46,7 +46,7 @@ public class StatusMessageService {
         if (message.getReceiverMarketParticipantMRID().getCodingScheme() == null) {
             country = "Unknown";
         } else {
-            country = message.getReceiverMarketParticipantMRID().getCodingScheme().toString();
+            country = message.getReceiverMarketParticipantMRID().getCodingScheme().value();
         }
         return new StatusMessage(
                 message.getMRID(),

--- a/admin-console/src/test/java/energy/eddie/admin/console/data/StatusMessageServiceTest.java
+++ b/admin-console/src/test/java/energy/eddie/admin/console/data/StatusMessageServiceTest.java
@@ -59,7 +59,7 @@ class StatusMessageServiceTest {
         verify(statusMessageRepository)
                 .save(assertArg(message -> assertAll(
                         () -> assertEquals("mrid", message.getPermissionId()),
-                        () -> assertEquals("FRANCE_NATIONAL_CODING_SCHEME", message.getCountry()),
+                        () -> assertEquals("NFR", message.getCountry()),
                         () -> assertEquals("Enedis", message.getDso()),
                         () -> assertEquals("2021-01-01T00:00:00Z", message.getStartDate()),
                         () -> assertEquals("A05", message.getStatus())
@@ -90,6 +90,7 @@ class StatusMessageServiceTest {
                 );
         // When
         testPublisher.emit(cmd);
+        testPublisher.complete();
 
         // Then
         verify(statusMessageRepository)


### PR DESCRIPTION
The countries from permissions generated with the examples app appeared as DENMARK_NATIONAL_COUNTRY_CODE instead of Denmark