### PR TITLE
GH-1119 Disable countries which do not support the given data need

### DIFF
--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -21,7 +21,7 @@ import headerImage from "../resources/header.svg?raw";
 import PERMISSION_ADMINISTRATORS from "../../../../european-masterdata/src/main/resources/permission-administrators.json";
 import { dataNeedSummary } from "./components/data-need-summary.js";
 
-setBasePath("https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.11.2/cdn");
+setBasePath("https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.15.0/cdn");
 
 const COUNTRY_NAMES = new Intl.DisplayNames(["en"], { type: "region" });
 


### PR DESCRIPTION
Countries will now be disabled instead of not being shown at all if they do not support the given data need.

The select field will also show a help text if a country is disabled for that reason.

![image](https://github.com/user-attachments/assets/e1c8029d-ccd7-45fa-b354-4bbcf828d6a6)

Closes #1119.

### Additional Notes

I initially planned on showing an error message as the PA in question is selected (see ticket option 1). However, I think the help text communicates the situation well enough. 

We could also show all countries for which we have a PA in our list, but I do not think it makes sense to show countries which RCs have been disabled by the EP.

Please let me know if you think otherwise.

There is a known issue where the first option in the select field is in focus even if it is disabled (though it cannot be selected). Seems to be a Shoelace issue. Not sure how to fix it.

In theory, we could have multiple RCs supporting different DNs per country, because RCs are mapped by PA. I would ignore this for now because it makes things messy and we currently have no country with multiple RCs anyway.