### PR TITLE
GH-1140 Remove Markdown mentions from Data Need docs

### DIFF
--- a/core/src/main/js/typedefs.js
+++ b/core/src/main/js/typedefs.js
@@ -17,7 +17,7 @@
  * @property {string} id - The unique identifier of the data need.
  * @property {string} name - The name of the data need.
  * @property {string} description - The description of the data need for internal use. It is not displayed to the user.
- * @property {string} purpose - The purpose and description of this data need that will be displayed to the user in the popup. Supports markdown formatting.
+ * @property {string} purpose - The purpose and description of this data need that will be displayed to the user in the popup.
  * @property {string} policyLink - The URL to a document describing the data policy.
  * @property {boolean} enabled - If data need is enabled.
  */

--- a/data-needs/src/main/java/energy/eddie/dataneeds/needs/DataNeed.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/needs/DataNeed.java
@@ -44,7 +44,7 @@ public abstract class DataNeed implements DataNeedInterface {
     @JsonProperty(required = true)
     @NotBlank(message = "must not be blank")
     private String description;
-    @Schema(description = "Purpose and description of this data need that will be displayed to the user in the popup. Supports markdown formatting.")
+    @Schema(description = "Purpose and description of this data need that will be displayed to the user in the popup.")
     @Column(name = "purpose", nullable = false)
     @JsonProperty(required = true)
     @NotBlank(message = "must not be blank")

--- a/docs/OPERATION.md
+++ b/docs/OPERATION.md
@@ -267,8 +267,8 @@ All data needs have these common fields:
 | type        | String  | Type of the data need, e.g. `validated` for historical validated consumption data. Please check the OpenAPI documentation for all supported values. |
 | id          | String  | Unique id that can be used to reference this data need.                                                                                             |
 | name        | String  | Short memorable name of the data need that may be presented to the customer.                                                                        |
-| description | String  | Multiline string that describes this data need in a human readable form to be shown in the UI. May be formatted using Markdown.                     |
-| purpose     | String  | Multiline string that describes the purpose of this data need. May be formatted using Markdown.                                                     |
+| description | String  | Multiline string that describes this data need in a human readable form to be shown in the UI.                                                      |
+| purpose     | String  | Multiline string that describes the purpose of this data need.                                                                                      |
 | policyLink  | URL     | URL to the data policy that applies to this data need.                                                                                              |
 | enabled     | boolean | Enables or disables a data need.                                                                                                                    |
 


### PR DESCRIPTION
As commented on the ticket, EPs should just use basic HTML for formatting instead.

We should probably document this somewhere at some point, but I don't really know where, and I am not sure if we want to keep this as an actual feature at all.

Closes #1140.