### PR TITLE
GH-1219 Use Cron format for transmission schedule instead of seconds

### DIFF
--- a/aiida/src/main/java/energy/eddie/aiida/models/permission/AiidaLocalDataNeed.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/permission/AiidaLocalDataNeed.java
@@ -1,10 +1,16 @@
 package energy.eddie.aiida.models.permission;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import energy.eddie.aiida.dtos.PermissionDetailsDto;
+import energy.eddie.dataneeds.utils.cron.CronExpressionConverter;
 import energy.eddie.dataneeds.needs.aiida.GenericAiidaDataNeed;
+import energy.eddie.dataneeds.utils.cron.CronExpressionDeserializer;
+import energy.eddie.dataneeds.utils.cron.CronExpressionSerializer;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
+import org.springframework.scheduling.support.CronExpression;
 
 import java.util.Set;
 
@@ -30,9 +36,12 @@ public class AiidaLocalDataNeed {
     @Column(nullable = false, name = "policy_link")
     @JsonProperty
     private final String policyLink;
-    @Column(nullable = false, name = "transmission_interval")
+    @Column(nullable = false, name = "transmission_schedule")
+    @Convert(converter = CronExpressionConverter.class)
     @JsonProperty
-    private final int transmissionInterval;
+    @JsonSerialize(using = CronExpressionSerializer.class)
+    @JsonDeserialize(using = CronExpressionDeserializer.class)
+    private final CronExpression transmissionSchedule;
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "aiida_local_data_need_data_tags", joinColumns = @JoinColumn(name = "data_need_id", referencedColumnName = "data_need_id"))
     @Column(name = "data_tags")
@@ -50,7 +59,7 @@ public class AiidaLocalDataNeed {
         this.name = null;
         this.purpose = null;
         this.policyLink = null;
-        this.transmissionInterval = -1;
+        this.transmissionSchedule = null;
         this.dataTags = null;
     }
 
@@ -61,7 +70,7 @@ public class AiidaLocalDataNeed {
         this.name = details.dataNeed().name();
         this.purpose = details.dataNeed().purpose();
         this.policyLink = details.dataNeed().policyLink();
-        this.transmissionInterval = details.dataNeed().transmissionInterval();
+        this.transmissionSchedule = details.dataNeed().transmissionSchedule();
 
         if (details.dataNeed() instanceof GenericAiidaDataNeed genericAiida) {
             this.dataTags = Set.copyOf(genericAiida.dataTags());
@@ -94,8 +103,8 @@ public class AiidaLocalDataNeed {
         return policyLink;
     }
 
-    public int transmissionInterval() {
-        return transmissionInterval;
+    public CronExpression transmissionSchedule() {
+        return transmissionSchedule;
     }
 
     public @Nullable Set<String> dataTags() {

--- a/aiida/src/main/java/energy/eddie/aiida/streamers/StreamerManager.java
+++ b/aiida/src/main/java/energy/eddie/aiida/streamers/StreamerManager.java
@@ -13,6 +13,7 @@ import org.eclipse.paho.mqttv5.common.MqttException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
@@ -74,8 +75,9 @@ public class StreamerManager implements AutoCloseable {
                                                                         "Data need not supported"));
         }
         Set<String> codes = requireNonNull(dataNeed.dataTags());
+        CronExpression transmissionSchedule = requireNonNull(dataNeed.transmissionSchedule());
 
-        Flux<AiidaRecord> recordFlux = aggregator.getFilteredFlux(codes, expirationTime);
+        Flux<AiidaRecord> recordFlux = aggregator.getFilteredFlux(codes, expirationTime, transmissionSchedule);
         Sinks.One<String> streamerTerminationRequestSink = Sinks.one();
 
         streamerTerminationRequestSink.asMono().subscribe(permissionId -> {

--- a/aiida/src/main/resources/db/aiida/migration/V2_3__add_transmission_schedule.sql
+++ b/aiida/src/main/resources/db/aiida/migration/V2_3__add_transmission_schedule.sql
@@ -1,0 +1,5 @@
+ALTER TABLE aiida_local_data_need
+    DROP COLUMN transmission_interval;
+
+ALTER TABLE aiida_local_data_need
+    ADD transmission_schedule VARCHAR(36) NOT NULL DEFAULT '* * * * * *';

--- a/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.web.client.HttpClientErrorException;
 import reactor.core.publisher.Mono;
 import reactor.test.publisher.TestPublisher;
@@ -157,7 +158,7 @@ class PermissionServiceTest {
         when(mockRepository.existsById(permissionId)).thenReturn(false);
         when(mockRepository.save(any(Permission.class))).then(i -> i.getArgument(0));
         when(mockHandshakeService.fetchDetailsForPermission(any())).thenReturn(Mono.just(permissionDetails));
-        when(mockDataNeed.transmissionInterval()).thenReturn(23);
+        when(mockDataNeed.transmissionSchedule()).thenReturn(CronExpression.parse("*/23 * * * * *"));
         when(mockDataNeed.id()).thenReturn("myId");
         when(mockDataNeed.type()).thenReturn(GenericAiidaDataNeed.DISCRIMINATOR_VALUE);
         when(mockDataNeed.name()).thenReturn("My Name");
@@ -186,7 +187,7 @@ class PermissionServiceTest {
         assertNotNull(dataNeed);
         assertEquals(permissionId, dataNeed.permissionId());
         assertEquals("myId", dataNeed.dataNeedId());
-        assertEquals(23, dataNeed.transmissionInterval());
+        assertEquals("*/23 * * * * *", dataNeed.transmissionSchedule().toString());
         assertEquals(GenericAiidaDataNeed.DISCRIMINATOR_VALUE, dataNeed.type());
         assertEquals("My Name", dataNeed.name());
         assertEquals("Some purpose", dataNeed.purpose());

--- a/aiida/src/test/java/energy/eddie/aiida/streamers/StreamerManagerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/streamers/StreamerManagerTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.test.util.ReflectionTestUtils;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -62,12 +63,13 @@ class StreamerManagerTest {
     @Test
     void givenSamePermissionTwice_createNewStreamer_throws() {
         // Given
-        when(aggregatorMock.getFilteredFlux(any(), any())).thenReturn(Flux.empty());
+        when(aggregatorMock.getFilteredFlux(any(), any(), any())).thenReturn(Flux.empty());
         when(mockPermission.permissionId()).thenReturn(permissionId);
         when(mockPermission.expirationTime()).thenReturn(expirationTime);
         when(mockPermission.dataNeed()).thenReturn(mockDataNeed);
         when(mockDataNeed.type()).thenReturn(GenericAiidaDataNeed.DISCRIMINATOR_VALUE);
         when(mockDataNeed.dataTags()).thenReturn(Set.of("1.8.0"));
+        when(mockDataNeed.transmissionSchedule()).thenReturn(CronExpression.parse("* * * * * *"));
         try (MockedStatic<StreamerFactory> utilities = Mockito.mockStatic(StreamerFactory.class)) {
             utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any()))
                      .thenReturn(mockAiidaStreamer);
@@ -85,12 +87,13 @@ class StreamerManagerTest {
     @Test
     void givenPermission_createStreamer_callsConnect() throws MqttException {
         // Given
-        when(aggregatorMock.getFilteredFlux(any(), any())).thenReturn(Flux.empty());
+        when(aggregatorMock.getFilteredFlux(any(), any(), any())).thenReturn(Flux.empty());
         when(mockPermission.permissionId()).thenReturn(permissionId);
         when(mockPermission.expirationTime()).thenReturn(expirationTime);
         when(mockPermission.dataNeed()).thenReturn(mockDataNeed);
         when(mockDataNeed.type()).thenReturn(GenericAiidaDataNeed.DISCRIMINATOR_VALUE);
         when(mockDataNeed.dataTags()).thenReturn(Set.of("1.8.0"));
+        when(mockDataNeed.transmissionSchedule()).thenReturn(CronExpression.parse("* * * * * *"));
         try (MockedStatic<StreamerFactory> utilities = Mockito.mockStatic(StreamerFactory.class)) {
             utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any()))
                      .thenReturn(mockAiidaStreamer);
@@ -128,13 +131,14 @@ class StreamerManagerTest {
 
     @Test
     void verify_close_closesAllStreamers() throws MqttException {
-        when(aggregatorMock.getFilteredFlux(any(), any())).thenReturn(Flux.empty());
+        when(aggregatorMock.getFilteredFlux(any(), any(), any())).thenReturn(Flux.empty());
         when(mockPermission.permissionId()).thenReturn(permissionId);
         when(mockPermission.expirationTime()).thenReturn(expirationTime);
         when(mockPermission.dataNeed()).thenReturn(mockDataNeed);
         when(mockDataNeed.type()).thenReturn(GenericAiidaDataNeed.DISCRIMINATOR_VALUE);
         when(mockDataNeed.dataTags()).thenReturn(Set.of("1.8.0"));
-        when(aggregatorMock.getFilteredFlux(any(), any())).thenReturn(Flux.empty());
+        when(mockDataNeed.transmissionSchedule()).thenReturn(CronExpression.parse("* * * * * *"));
+        when(aggregatorMock.getFilteredFlux(any(), any(), any())).thenReturn(Flux.empty());
         try (MockedStatic<StreamerFactory> utilities = Mockito.mockStatic(StreamerFactory.class)) {
             utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any()))
                      .thenReturn(mockAiidaStreamer);

--- a/core/src/main/js/data-need-summary.js
+++ b/core/src/main/js/data-need-summary.js
@@ -42,7 +42,7 @@ class DataNeedSummary extends HTMLElement {
       minGranularity,
       maxGranularity,
       energyType,
-      transmissionInterval,
+      transmissionSchedule,
       dataTags,
     } = dataNeed;
 
@@ -95,8 +95,8 @@ class DataNeedSummary extends HTMLElement {
             : ""}
 
           <!-- For AIIDA data needs -->
-          ${transmissionInterval
-            ? `<dt>Transmission Interval</dt><dd>${transmissionInterval} seconds</dd>`
+          ${transmissionSchedule
+            ? `<dt>Transmission Schedule</dt><dd>${transmissionSchedule}</dd>`
             : ""}
 
           <!-- For AIIDA smart meter data needs -->

--- a/core/src/main/js/typedefs.js
+++ b/core/src/main/js/typedefs.js
@@ -70,7 +70,7 @@
 
 /**
  * @typedef {DataNeed} AiidaDataNeed
- * @property {number} transmissionInterval - The interval at which data is transmitted.
+ * @property {string} transmissionSchedule - The schedule at which data is transmitted.
  */
 
 /**
@@ -79,7 +79,7 @@
 
 /**
  * @typedef {AiidaDataNeed} GenericAiidaDataNeed
- * @property {number} transmissionInterval - The interval at which data is transmitted.
+ * @property {string} transmissionSchedule - The schedule at which data is transmitted.
  * @property {Array<string>} dataTags - The tags associated with the data.
  */
 

--- a/data-needs/DataNeeds.plantuml
+++ b/data-needs/DataNeeds.plantuml
@@ -42,7 +42,7 @@ abstract AbsoluteDuration {
 }
 
 abstract AiidaDataNeed {
-    transmissionInterval int<seconds>
+    transmissionSchedule String<CronExpression>
 }
 
 class GenericAiidaDataNeed {
@@ -64,5 +64,4 @@ DataNeedDuration <|-- RelativeDuration
 TimeframedDataNeed <|-- AiidaDataNeed
 AiidaDataNeed <|-- GenericAiidaDataNeed
 AiidaDataNeed <|-- SmartMeterAiidaDataNeed
-
 @enduml

--- a/data-needs/data-needs-management-api.http
+++ b/data-needs/data-needs-management-api.http
@@ -50,7 +50,7 @@ Content-Type: application/json
   "description": "foo",
   "purpose": "purpose",
   "policyLink": "https://example.com/toc",
-  "transmissionInterval": 2,
+  "transmissionSchedule": "*/2 * * * * *",
   "duration": {
     "type": "absoluteDuration",
     "start": "2024-01-01",

--- a/data-needs/data-needs.json
+++ b/data-needs/data-needs.json
@@ -43,7 +43,7 @@
       "start": "P0D",
       "end": "P10D"
     }, 
-    "transmissionInterval": 5,
+    "transmissionSchedule": "*/5 * * * * *",
     "dataTags": [
       "1-0:1.8.0",
       "1-0:1.7.0"

--- a/data-needs/src/main/java/energy/eddie/dataneeds/needs/aiida/AiidaDataNeed.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/needs/aiida/AiidaDataNeed.java
@@ -1,29 +1,36 @@
 package energy.eddie.dataneeds.needs.aiida;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import energy.eddie.dataneeds.needs.TimeframedDataNeed;
+import energy.eddie.dataneeds.utils.cron.CronExpressionConverter;
+import energy.eddie.dataneeds.utils.cron.CronExpressionDeserializer;
+import energy.eddie.dataneeds.utils.cron.CronExpressionSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
+import org.springframework.scheduling.support.CronExpression;
 
 @Entity
 @Table(schema = "data_needs")
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public abstract class AiidaDataNeed extends TimeframedDataNeed {
-    @Column(name = "transmission_interval", nullable = false)
+    @Column(name = "transmission_schedule", nullable = false)
+    @Convert(converter = CronExpressionConverter.class)
     @JsonProperty(required = true)
-    @Min(value = 1, message = "Must not be less than 1")
-    @Schema(description = "The interval in seconds, at which the AIIDA instance should send data.")
-    private int transmissionInterval;
+    @JsonSerialize(using = CronExpressionSerializer.class)
+    @JsonDeserialize(using = CronExpressionDeserializer.class)
+    @Schema(description = "The schedule in cron format, at which the AIIDA instance should send data.")
+    private CronExpression transmissionSchedule;
 
     @SuppressWarnings("NullAway.Init")
     protected AiidaDataNeed() {
     }
 
     /**
-     * Returns the interval in seconds, at which the AIIDA instance should send data.
+     * Returns the schedule in cron format, at which the AIIDA instance should send data.
      */
-    public int transmissionInterval() {
-        return transmissionInterval;
+    public CronExpression transmissionSchedule() {
+        return transmissionSchedule;
     }
 }

--- a/data-needs/src/main/java/energy/eddie/dataneeds/utils/cron/CronExpressionConverter.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/utils/cron/CronExpressionConverter.java
@@ -1,0 +1,26 @@
+package energy.eddie.dataneeds.utils.cron;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.scheduling.support.CronExpression;
+
+@Converter(autoApply = true)
+public class CronExpressionConverter implements AttributeConverter<CronExpression, String> {
+    @Override
+    public String convertToDatabaseColumn(CronExpression cronExpression) {
+        return cronExpression != null ? cronExpression.toString() : CronExpressionDefaults.SECONDLY.expression();
+    }
+
+    @Override
+    public CronExpression convertToEntityAttribute(String dbCronExpression) {
+        if (dbCronExpression == null || dbCronExpression.isEmpty()) {
+            dbCronExpression = CronExpressionDefaults.SECONDLY.expression();
+        }
+
+        try {
+            return CronExpression.parse(dbCronExpression);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Could not convert database value to CronExpression", e);
+        }
+    }
+}

--- a/data-needs/src/main/java/energy/eddie/dataneeds/utils/cron/CronExpressionDefaults.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/utils/cron/CronExpressionDefaults.java
@@ -1,0 +1,18 @@
+package energy.eddie.dataneeds.utils.cron;
+
+public enum CronExpressionDefaults {
+    SECONDLY("* * * * * *"),
+    MINUTELY("0 * * * * *"),
+    HOURLY("0 0 * * * *"),
+    DAILY("0 0 0 * * *");
+
+    private final String expression;
+
+    CronExpressionDefaults(String expression) {
+        this.expression = expression;
+    }
+
+    public String expression() {
+        return expression;
+    }
+}

--- a/data-needs/src/main/java/energy/eddie/dataneeds/utils/cron/CronExpressionDeserializer.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/utils/cron/CronExpressionDeserializer.java
@@ -1,0 +1,22 @@
+package energy.eddie.dataneeds.utils.cron;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.scheduling.support.CronExpression;
+
+import java.io.IOException;
+
+public class CronExpressionDeserializer extends JsonDeserializer<CronExpression> {
+    @Override
+    public CronExpression deserialize(
+            JsonParser jsonParser,
+            DeserializationContext deserializationContext
+    ) throws IOException {
+        ObjectCodec oc = jsonParser.getCodec();
+        JsonNode node = oc.readTree(jsonParser);
+        return CronExpression.parse(node.asText(CronExpressionDefaults.SECONDLY.expression()));
+    }
+}

--- a/data-needs/src/main/java/energy/eddie/dataneeds/utils/cron/CronExpressionSerializer.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/utils/cron/CronExpressionSerializer.java
@@ -1,0 +1,18 @@
+package energy.eddie.dataneeds.utils.cron;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.*;
+import org.springframework.scheduling.support.CronExpression;
+
+import java.io.IOException;
+
+public class CronExpressionSerializer extends JsonSerializer<CronExpression> {
+    @Override
+    public void serialize(
+            CronExpression cronExpression,
+            JsonGenerator jsonGenerator,
+            SerializerProvider serializers
+    ) throws IOException {
+        jsonGenerator.writeString(cronExpression.toString());
+    }
+}

--- a/data-needs/src/main/java/energy/eddie/dataneeds/web/management/DataNeedsManagementController.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/web/management/DataNeedsManagementController.java
@@ -54,7 +54,7 @@ public class DataNeedsManagementController {
                             ),
                             @ExampleObject(name = "Generic AIIDA data need for the next 10 days",
                                     description = "Create a new data need to get the generic AIIDA data tags '1.7.0' and '1.8.0' in a two second interval for the next ten days including today",
-                                    value = "{\"type\":\"genericAiida\",\"name\":\"Generic AIIDA data need\",\"description\":\"Please describe the data need.\",\"purpose\":\"And also its purpose.\",\"policyLink\":\"https://example.com/toc\",\"transmissionInterval\":2,\"duration\":{\"type\":\"relativeDuration\",\"start\":\"P0D\",\"end\":\"P10D\"},\"dataTags\":[\"1.8.0\",\"1.7.0\"],\"regionConnectorFilter\":{\"type\":\"allowlist\",\"regionConnectorIds\":[\"aiida\"]}}"
+                                    value = "{\"type\":\"genericAiida\",\"name\":\"Generic AIIDA data need\",\"description\":\"Please describe the data need.\",\"purpose\":\"And also its purpose.\",\"policyLink\":\"https://example.com/toc\",\"transmissionSchedule\":\"*/2 * * * * *\",\"duration\":{\"type\":\"relativeDuration\",\"start\":\"P0D\",\"end\":\"P10D\"},\"dataTags\":[\"1.8.0\",\"1.7.0\"],\"regionConnectorFilter\":{\"type\":\"allowlist\",\"regionConnectorIds\":[\"aiida\"]}}"
                             )
                     }
             )

--- a/data-needs/src/main/resources/db/migration/data-needs/V1_3__add_transmission_schedule.sql
+++ b/data-needs/src/main/resources/db/migration/data-needs/V1_3__add_transmission_schedule.sql
@@ -1,0 +1,11 @@
+ALTER TABLE generic_aiida_data_need
+    DROP COLUMN transmission_interval;
+
+ALTER TABLE smart_meter_aiida_data_need
+    DROP COLUMN transmission_interval;
+
+ALTER TABLE generic_aiida_data_need
+    ADD transmission_schedule VARCHAR(36) NOT NULL DEFAULT '* * * * * *';
+
+ALTER TABLE smart_meter_aiida_data_need
+    ADD transmission_schedule VARCHAR(36) NOT NULL DEFAULT '* * * * * *';

--- a/data-needs/src/test/java/energy/eddie/dataneeds/web/DataNeedsManagementControllerTest.java
+++ b/data-needs/src/test/java/energy/eddie/dataneeds/web/DataNeedsManagementControllerTest.java
@@ -263,7 +263,7 @@ class DataNeedsManagementFullTest {
                 Arguments.of(
                         "{\"type\":\"validated\",\"name\":\"My awesome data need\",\"description\":\"descr\",\"purpose\":\"purpose\",\"policyLink\":\"https://example.com/toc\",\"duration\":{\"type\":\"relativeDuration\"},\"energyType\":\"ELECTRICITY\",\"minGranularity\":\"PT1H\",\"maxGranularity\":\"P1D\"}"),
                 Arguments.of(
-                        "{\"type\":\"genericAiida\",\"name\":\"name\",\"description\":\"foo\",\"purpose\":\"purpose\",\"policyLink\":\"https://example.com/toc\",\"transmissionInterval\":2,\"duration\":{\"type\":\"relativeDuration\",\"durationStart\":\"-P10D\",\"durationEnd\":\"P10D\"},\"dataTags\":[\"1.8.0\",\"1.7.0\"]}"),
+                        "{\"type\":\"genericAiida\",\"name\":\"name\",\"description\":\"foo\",\"purpose\":\"purpose\",\"policyLink\":\"https://example.com/toc\",\"transmissionSchedule\":\"*/2 * * * * *\",\"duration\":{\"type\":\"relativeDuration\",\"durationStart\":\"-P10D\",\"durationEnd\":\"P10D\"},\"dataTags\":[\"1.8.0\",\"1.7.0\"]}"),
                 Arguments.of(
                         "{\"type\":\"validated\",\"id\":\"dcbc1c74-37bd-4c5b-ab2e-fd0be9c1edf3\",\"name\":\"NEXT_10_DAYS_ONE_MEASUREMENT_PER_DAY\",\"description\":\"Historical validated consumption data for the next 10 days, one measurement per day\",\"purpose\":\"Some purpose\",\"policyLink\":\"https://example.com/toc\",\"duration\":{\"type\":\"absoluteDuration\",\"start\":\"2024-04-01\",\"end\":\"2024-04-05\"},\"energyType\":\"ELECTRICITY\",\"minGranularity\":\"P1D\",\"maxGranularity\":\"P1D\"}"),
                 Arguments.of(

--- a/data-needs/src/test/resources/test-data-needs-management-api.sql
+++ b/data-needs/src/test/resources/test-data-needs-management-api.sql
@@ -50,9 +50,7 @@ CREATE TABLE IF NOT EXISTS data_needs.generic_aiida_data_need
     name                  varchar(255) NOT NULL,
     policy_link           varchar(255) NOT NULL,
     purpose               varchar(255) NOT NULL,
-    transmission_interval integer      NOT NULL
-        CONSTRAINT generic_aiida_data_need_transmission_interval_check
-            CHECK (transmission_interval >= 1),
+    transmission_schedule varchar(36) NOT NULL,
     enabled               boolean DEFAULT TRUE
 );
 
@@ -85,9 +83,7 @@ CREATE TABLE IF NOT EXISTS data_needs.smart_meter_aiida_data_need
     name                  varchar(255) NOT NULL,
     policy_link           varchar(255) NOT NULL,
     purpose               varchar(255) NOT NULL,
-    transmission_interval integer      NOT NULL
-        CONSTRAINT smart_meter_aiida_data_need_transmission_interval_check
-            CHECK (transmission_interval >= 1),
+    transmission_schedule varchar(36) NOT NULL,
     enabled               boolean DEFAULT TRUE
 );
 

--- a/data-needs/src/test/resources/test-valid-data-needs.json
+++ b/data-needs/src/test/resources/test-valid-data-needs.json
@@ -43,7 +43,7 @@
       "start": "P0D",
       "end": "P10D"
     },
-    "transmissionInterval": 5,
+    "transmissionSchedule": "*/5 * * * * *",
     "dataTags": [
       "1-0:1.8.0",
       "1-0:1.7.0"

--- a/e2e-tests/docker/data-needs.json
+++ b/e2e-tests/docker/data-needs.json
@@ -43,7 +43,7 @@
       "start": "P1D",
       "end": "P10D"
     },
-    "transmissionInterval": 5,
+    "transmissionSchedule": "*/5 * * * * *",
     "dataTags": [
       "1.8.0",
       "1.7.0"

--- a/env/data-needs.json
+++ b/env/data-needs.json
@@ -43,7 +43,7 @@
       "start": "2024-04-01",
       "end": "2024-04-05"
     },
-    "transmissionInterval": 5,
+    "transmissionSchedule":"*/5 * * * * *",
     "dataTags": [
       "1.8.0",
       "1.7.0"

--- a/region-connectors/region-connector-aiida/src/main/java/energy/eddie/regionconnector/aiida/services/AiidaTransmissionScheduleProvider.java
+++ b/region-connectors/region-connector-aiida/src/main/java/energy/eddie/regionconnector/aiida/services/AiidaTransmissionScheduleProvider.java
@@ -8,8 +8,6 @@ import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-
 public record AiidaTransmissionScheduleProvider(DataNeedsService dataNeedsService)
         implements TransmissionScheduleProvider<AiidaPermissionRequest> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AiidaTransmissionScheduleProvider.class);
@@ -21,7 +19,7 @@ public record AiidaTransmissionScheduleProvider(DataNeedsService dataNeedsServic
                 .findById(pr.dataNeedId())
                 .map(dataNeed -> {
                     if (dataNeed instanceof AiidaDataNeed aiidaDataNeed)
-                        return Duration.ofSeconds(aiidaDataNeed.transmissionInterval()).toString();
+                        return aiidaDataNeed.transmissionSchedule().toString();
 
                     LOGGER.warn(
                             "Finding transmission schedule for non-AIIDA data need with ID {} is not possible. Permission ID was {}",

--- a/region-connectors/region-connector-aiida/src/test/java/energy/eddie/regionconnector/aiida/services/AiidaTransmissionScheduleProviderTest.java
+++ b/region-connectors/region-connector-aiida/src/test/java/energy/eddie/regionconnector/aiida/services/AiidaTransmissionScheduleProviderTest.java
@@ -4,6 +4,7 @@ import energy.eddie.dataneeds.needs.aiida.AiidaDataNeed;
 import energy.eddie.dataneeds.services.DataNeedsService;
 import energy.eddie.regionconnector.aiida.permission.request.AiidaPermissionRequest;
 import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.support.CronExpression;
 
 import java.util.Optional;
 
@@ -17,7 +18,7 @@ class AiidaTransmissionScheduleProviderTest {
     void testFindTransmissionSchedule_returnsISODuration() {
         // Given
         var dataNeed = mock(AiidaDataNeed.class);
-        when(dataNeed.transmissionInterval()).thenReturn(10);
+        when(dataNeed.transmissionSchedule()).thenReturn(CronExpression.parse("*/10 * * * * *"));
         var dataNeedsService = mock(DataNeedsService.class);
         when(dataNeedsService.findById("dataNeedId"))
                 .thenReturn(Optional.of(dataNeed));
@@ -29,6 +30,6 @@ class AiidaTransmissionScheduleProviderTest {
         var res = scheduleProvider.findTransmissionSchedule(permissionRequest);
 
         // Then
-        assertEquals("PT10S", res);
+        assertEquals("*/10 * * * * *", res);
     }
 }


### PR DESCRIPTION
AIIDA records are buffered until a record's timestamp matches or surpasses the scheduled Cron timestamp (e.g. */5 * * * * *). Since there are multiple records for each code version (e.g., 1.7.0 and 1.8.0), the buffering process ends as soon as the first code reaches the Cron timestamp. As a result, while one code aligns with the correct timestamp, others may be transmitted with an earlier timestamp, prior to the Cron event. This issue will be resolved in #1206, where AIIDA records will be consolidated into a single record per data source entry, preventing the possibility of incorrect timestamps.