### PR TITLE
GH-1309 Use Gradle path parsing over concat for Mijn OpenAPI config paths

### DIFF
--- a/region-connectors/region-connector-nl-mijn-aansluiting/build.gradle.kts
+++ b/region-connectors/region-connector-nl-mijn-aansluiting/build.gradle.kts
@@ -105,9 +105,9 @@ openApiSpecs.forEach { (name, spec) ->
         description = "Generates Java classes for single API of Mijn Aansluiting"
 
         generatorName.set("java")
-        inputSpec.set("${projectDir}${spec}")
+        inputSpec.set("${projectDir.invariantSeparatorsPath}${spec}")
         outputDir.set(generatedSwaggerJavaDir)
-        ignoreFileOverride.set("${projectDir}/src/main/resources/.openapi-generator-ignore")
+        ignoreFileOverride.set("${projectDir.invariantSeparatorsPath}/src/main/resources/.openapi-generator-ignore")
 
         apiPackage.set("${packagePrefix}.api")
         invokerPackage.set("${packagePrefix}.invoker")


### PR DESCRIPTION
Fixes #1309.

Maybe keep an eye open for such issues in the future.