### PR TITLE
GH-1151 fingrid region-connector: Implement termination for permission requests

### DIFF
--- a/region-connectors/region-connector-fi-fingrid/src/main/java/energy/eddie/regionconnector/fi/fingrid/FingridRegionConnector.java
+++ b/region-connectors/region-connector-fi-fingrid/src/main/java/energy/eddie/regionconnector/fi/fingrid/FingridRegionConnector.java
@@ -1,11 +1,26 @@
 package energy.eddie.regionconnector.fi.fingrid;
 
+import energy.eddie.api.v0.PermissionProcessStatus;
 import energy.eddie.api.v0.RegionConnector;
 import energy.eddie.api.v0.RegionConnectorMetadata;
+import energy.eddie.regionconnector.fi.fingrid.permission.events.SimpleEvent;
+import energy.eddie.regionconnector.fi.fingrid.persistence.FiPermissionRequestRepository;
+import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FingridRegionConnector implements RegionConnector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FingridRegionConnector.class);
+    private final FiPermissionRequestRepository permissionRequestRepository;
+    private final Outbox outbox;
+
+    public FingridRegionConnector(FiPermissionRequestRepository permissionRequestRepository, Outbox outbox) {
+        this.permissionRequestRepository = permissionRequestRepository;
+        this.outbox = outbox;
+    }
+
     @Override
     public RegionConnectorMetadata getMetadata() {
         return FingridRegionConnectorMetadata.INSTANCE;
@@ -13,6 +28,16 @@ public class FingridRegionConnector implements RegionConnector {
 
     @Override
     public void terminatePermission(String permissionId) {
-        // TODO: GH-1151
+        var pr = permissionRequestRepository.findByPermissionId(permissionId);
+        if (pr.isEmpty()) {
+            LOGGER.info("Permission request {} does not exist, cannot terminate", permissionId);
+        } else if (pr.get().status() != PermissionProcessStatus.ACCEPTED) {
+            LOGGER.info("Permission request {} is not accepted, but has the {} status, cannot terminate",
+                        permissionId,
+                        pr.get().status());
+        } else {
+            outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.TERMINATED));
+            LOGGER.info("Terminated permission request {}", permissionId);
+        }
     }
 }

--- a/region-connectors/region-connector-fi-fingrid/src/main/java/energy/eddie/regionconnector/fi/fingrid/services/PollingService.java
+++ b/region-connectors/region-connector-fi-fingrid/src/main/java/energy/eddie/regionconnector/fi/fingrid/services/PollingService.java
@@ -53,6 +53,7 @@ public class PollingService {
                    error -> LOGGER
                            .atInfo()
                            .addArgument(permissionRequest::permissionId)
+                           .setCause(error)
                            .log("Error while requesting data for permission request {}")
            );
     }

--- a/region-connectors/region-connector-fi-fingrid/src/test/java/energy/eddie/regionconnector/fi/fingrid/FingridRegionConnectorTest.java
+++ b/region-connectors/region-connector-fi-fingrid/src/test/java/energy/eddie/regionconnector/fi/fingrid/FingridRegionConnectorTest.java
@@ -1,0 +1,86 @@
+package energy.eddie.regionconnector.fi.fingrid;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.v0.PermissionProcessStatus;
+import energy.eddie.regionconnector.fi.fingrid.permission.request.FingridPermissionRequest;
+import energy.eddie.regionconnector.fi.fingrid.persistence.FiPermissionRequestRepository;
+import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FingridRegionConnectorTest {
+    @Mock
+    private Outbox outbox;
+    @Mock
+    private FiPermissionRequestRepository repository;
+    @InjectMocks
+    private FingridRegionConnector fingridRegionConnector;
+
+    @Test
+    void testTerminatePermissionRequest_doesNothingForUnknownPermissionRequest() {
+        // Given
+        when(repository.findByPermissionId("pid")).thenReturn(Optional.empty());
+
+        // When
+        fingridRegionConnector.terminatePermission("pid");
+
+        // Then
+        verify(outbox, never()).commit(any());
+    }
+
+    @Test
+    void testTerminatePermissionRequest_doesNothingForNotAcceptedPermissionRequest() {
+        // Given
+        when(repository.findByPermissionId("pid"))
+                .thenReturn(Optional.of(getPermissionRequest(PermissionProcessStatus.VALIDATED)));
+
+        // When
+        fingridRegionConnector.terminatePermission("pid");
+
+        // Then
+        verify(outbox, never()).commit(any());
+    }
+
+    @Test
+    void testTerminatePermissionRequest_emitsTerminated_forAcceptedPermissionRequest() {
+        // Given
+        when(repository.findByPermissionId("pid"))
+                .thenReturn(Optional.of(getPermissionRequest(PermissionProcessStatus.ACCEPTED)));
+
+        // When
+        fingridRegionConnector.terminatePermission("pid");
+
+        // Then
+        verify(outbox).commit(assertArg(event -> assertEquals(PermissionProcessStatus.TERMINATED, event.status())));
+    }
+
+    private static @NotNull FingridPermissionRequest getPermissionRequest(PermissionProcessStatus status) {
+        var now = LocalDate.now(ZoneOffset.UTC);
+        return new FingridPermissionRequest(
+                "pid",
+                "cid",
+                "dnid",
+                status,
+                ZonedDateTime.now(ZoneOffset.UTC),
+                now,
+                now,
+                "cid",
+                "ean",
+                Granularity.PT15M,
+                null
+        );
+    }
+}


### PR DESCRIPTION
Fingrid's JSON API does not support termination of permission requests