### PR TITLE
GH-1180 Replay status events before SSE connection

### DIFF
--- a/core/src/main/java/energy/eddie/core/services/PermissionService.java
+++ b/core/src/main/java/energy/eddie/core/services/PermissionService.java
@@ -8,12 +8,14 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
+import java.time.Duration;
+
 @Service
 public class PermissionService {
     private static final Logger LOGGER = LoggerFactory.getLogger(PermissionService.class);
     private final Sinks.Many<ConnectionStatusMessage> connectionStatusMessageSink = Sinks.many()
-                                                                                         .multicast()
-                                                                                         .onBackpressureBuffer();
+                                                                                         .replay()
+                                                                                         .limit(Duration.ofSeconds(10));
 
     public void registerProvider(ConnectionStatusMessageProvider statusMessageProvider) {
         LOGGER.info("PermissionService: Registering {}", statusMessageProvider.getClass().getName());

--- a/docs/1-running/OPERATION.md
+++ b/docs/1-running/OPERATION.md
@@ -104,7 +104,6 @@ button.addEventListener("eddie-dialog-open", () => {
 | `eddie-dialog-open`      | Dispatched when the dialog is opened.                                                                                                    |
 | `eddie-dialog-close`     | Dispatched when the dialog is closed.                                                                                                    |
 | `eddie-request-status`   | Dispatched when the status of the permission request changes. The event detail contains the new status.                                  |
-| `eddie-request-created`  | Dispatched when the permission request has been created. The event detail contains an endpoint to query the current status from.         |
 | `eddie-request-{status}` | In addition to `eddie-request-status`, an event with the name of the request status is dispatched. For example, `eddie-request-created`. |
 
 #### Callback functions


### PR DESCRIPTION
Ensures that all status events are actually propagated as custom events.

Closes #1180.

Replay is limited to a set time to avoid keeping previous events in memory indefinitely. The event stream is NOT intended to retrieve the current status. It updates the form with new states to enable custom events for status changes and in turn step navigation.

Not sure if 10 seconds are a buffer here, but we will probably find out in testing.

Removed the location from the `eddie-status-created` event, since it was not actually used and the permission id is still present in the `eddie-request-status` event. I will clarify with @georghartner if we still need this anywhere.