### PR TITLE
GH-935 Move API calls to their own JS file

### DIFF
--- a/core/api.http
+++ b/core/api.http
@@ -1,0 +1,6 @@
+### GET region connector metadata
+GET http://localhost:8080/api/region-connectors-metadata
+
+### GET data need calculations of region connectors for a specific data need
+@dataNeedId = 9bd0668f-cc19-40a8-99db-dc2cb2802b17
+GET http://localhost:8080/api/region-connectors/data-needs/{{dataNeedId}}

--- a/core/src/main/js/api.js
+++ b/core/src/main/js/api.js
@@ -1,0 +1,53 @@
+const CORE_URL =
+  import.meta.env.VITE_CORE_URL ??
+  import.meta.url.replace("/lib/eddie-components.js", "");
+
+function fetchJson(path) {
+  return fetch(CORE_URL + path).then((response) => {
+    if (!response.ok) {
+      throw new Error(
+        `Fetch to ${path} returned invalid status code ${response.status}`
+      );
+    }
+    return response.json();
+  });
+}
+
+/**
+ * Fetches the data need attributes for the given data need ID.
+ * @param {string} dataNeedId - The ID of the data need to fetch attributes for.
+ * @returns {Promise<DataNeedAttributes>} - The attributes of the data need.
+ */
+export function getDataNeedAttributes(dataNeedId) {
+  return fetchJson(`/data-needs/api/${dataNeedId}`);
+}
+
+/**
+ * Fetches the data need calculations for the given data need ID.
+ * @param dataNeedId - The ID of the data need to fetch calculations for.
+ * @returns {Promise<Map<string, DataNeedCalculation>>} - A map of region connector IDs to their respective data need calculation.
+ */
+export function getDataNeedCalculations(dataNeedId) {
+  return fetchJson(`/api/region-connectors/data-needs/${dataNeedId}`);
+}
+
+/**
+ * Fetches the supported region connectors for the given data need ID.
+ * @param dataNeedId - The ID of the data need to fetch supported region connectors for.
+ * @returns {Promise<string[]>} - A list of region connector IDs that support the given data need.
+ */
+export function getSupportedRegionConnectors(dataNeedId) {
+  return getDataNeedCalculations(dataNeedId).then((calculations) =>
+    Object.keys(calculations).filter(
+      (regionConnectorId) => calculations[regionConnectorId].supportsDataNeed
+    )
+  );
+}
+
+/**
+ * Fetches the metadata for all region connectors.
+ * @returns {Promise<RegionConnectorMetadata[]>} - Metadata for all region connectors.
+ */
+export function getRegionConnectorMetadata() {
+  return fetchJson("/api/region-connectors-metadata");
+}

--- a/core/src/main/js/typedefs.js
+++ b/core/src/main/js/typedefs.js
@@ -86,3 +86,29 @@
 /**
  * @typedef {ValidatedHistoricalDataDataNeed | SmartMeterAiidaDataNeed | GenericAiidaDataNeed | AccountingPointDataNeed} DataNeedAttributes
  */
+
+/**
+ * @typedef {Object} RegionConnectorMetadata
+ * @property {string} id - The unique identifier of the region connector.
+ * @property {string} timeZone - Time zone of the region covered by the region connector.
+ * @property {string[]} countryCodes - Country codes of the regions covered by the region connector in uppercase.
+ * @property {number} coveredMeteringPoints - Number of metering points that are accessible through the region connector.
+ * @property {string} earliestStart - The earliest possible start for permissions as a string such as P6Y3M1D.
+ * @property {string} latestEnd - The latest possible end for permissions as a string such as P6Y3M1D.
+ * @property {string[]} supportedGranularities - List of supported granularities.
+ */
+
+/**
+ * @typedef {Object} DataNeedCalculation
+ * @property {boolean} supportsDataNeed - Indicates if the data need is supported.
+ * @property {string} [unsupportedDataNeedMessage] - Message explaining why the data need is not supported.
+ * @property {string[]} [granularities] - List of granularities supported by the data need.
+ * @property {DataNeedCalculationTimeframe} [permissionTimeframe] - The timeframe for which permission is granted.
+ * @property {DataNeedCalculationTimeframe} [energyDataTimeframe] - The timeframe for which energy data is available.
+ */
+
+/**
+ * @typedef {Object} DataNeedCalculationTimeframe
+ * @property {string} start - The start of the timeframe.
+ * @property {string} end - The end of the timeframe.
+ */


### PR DESCRIPTION
Makes it easier to manage and document API calls.

No visual or functional changes. Tested with production build and example app.

Resolving `CORE_URL` still works because api.js is bundled into `eddie-components.js`. I am trying to get rid of the URL replacement to avoid import issues when switching between development and production builds.