### PR TITLE
NOISSUE Add SASL Configurations to Example App

### DIFF
--- a/docs/1-running/example-app.md
+++ b/docs/1-running/example-app.md
@@ -10,11 +10,12 @@ Login is possible with every email/password combination (not checked).
 
 The following environment variables can be configured for the example app:
 
-| Parameter               | Description                                                                                                               |
-|-------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| JDBC_URL                | PostgreSQL database where the example app can store data. DB server can be shared with EDDIE but use a separate database. |
-| JDBC_USER               | Username to authenticate with the PostgreSQL server.                                                                      |
-| JDBC_PASSWORD           | Password to authenticate with the PostgreSQL server.                                                                      |
-| EDDIE_PUBLIC_URL        | Base URL of the EDDIE core.                                                                                               |
-| PUBLIC_CONTEXT_PATH     | Base path for reaching the example application and the web components.                                                    |
-| KAFKA_BOOTSTRAP_SERVERS | Comma separated list of Kafka server IPs/hostnames.                                                                       |
+| Parameter               | Description                                                                                                                                  |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| JDBC_URL                | PostgreSQL database where the example app can store data. DB server can be shared with EDDIE but use a separate database.                    |
+| JDBC_USER               | Username to authenticate with the PostgreSQL server.                                                                                         |
+| JDBC_PASSWORD           | Password to authenticate with the PostgreSQL server.                                                                                         |
+| EDDIE_PUBLIC_URL        | Base URL of the EDDIE core.                                                                                                                  |
+| PUBLIC_CONTEXT_PATH     | Base path for reaching the example application and the web components.                                                                       |
+| KAFKA_BOOTSTRAP_SERVERS | Comma separated list of Kafka server IPs/hostnames.                                                                                          |
+| EXAMPLE_APP_KAFKA_*     | (optional) All Environments starting with EXAMPLE_APP_KAFKA will be used to build the Kafka Configuration e.g. EXAMPLE_APP_SECURITY_PROTOCOL |

--- a/examples/example-app/src/main/java/energy/eddie/examples/exampleapp/kafka/KafkaListener.java
+++ b/examples/example-app/src/main/java/energy/eddie/examples/exampleapp/kafka/KafkaListener.java
@@ -173,6 +173,16 @@ public class KafkaListener implements Runnable {
         Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "example-app-" + streamName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, Env.KAFKA_BOOTSTRAP_SERVERS.get());
+
+        for (Map.Entry<String, String> env : System.getenv().entrySet()) {
+            if (env.getKey().toLowerCase().startsWith("example_app_kafka_")) {
+                var kafkaPropertyKey = env.getKey().toLowerCase() // Kafka properties are written in lowercase
+                        .replace("example_app_kafka_", "")
+                        .replace("_", "."); // Kafka properties are separated with "."
+                streamsConfiguration.put(kafkaPropertyKey, env.getValue());
+            }
+        }
+
         return streamsConfiguration;
     }
 


### PR DESCRIPTION
SASL properties can now be injected to the example App using environments starting with `EXAMPLE_APP_KAFKA`

E.g. to inject security protocol inject:
`EXAMPLE_APP_KAFKA_SECURITY_PROTOCOL = SASL_SSL`