### PR TITLE
GH-1386 Adjust EDA element for multistep form

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/at/AtEdaTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/at/AtEdaTest.java
@@ -12,13 +12,18 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 
 class AtEdaTest extends E2eTestSetup {
     @Test
-    void buttonClick_statusIsSent() {
+    void withoutAccountingPointId() {
         this.navigateToRegionConnector(null, "Austria", "Netz Niederösterreich GmbH");
+
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 
-        assertThat(page.locator("at-eda-pa-ce")).containsText(Pattern.compile("Please wait"));
+        page.getByText("Your permission request was created successfully.");
 
-        var locator = page.getByText("Status: Request Sent");
-        locator.waitFor(new Locator.WaitForOptions().setTimeout(120_000));  // 2 min
+        var locator = page.getByText("Your request was successfully sent");
+        locator.waitFor(new Locator.WaitForOptions().setTimeout(120_000));
+        assertThat(locator).isVisible();
+
+        // Continue button should show the name of the PA
+        page.getByText("Continue to Netz Niederösterreich").click();
     }
 }


### PR DESCRIPTION
The EDA element is the first to be fully adapted to the new multistep flow. Instead of explicitly showing the status of the permission, the element should inform the end user of the next steps to take. The element is also better customized towards the PA.

Please note that the creation and status alerts are still visible. I will remove them once all elements can inform the user about the permission state on their own.

Tests may still fail because it currently takes a long time to send the request.

I will do separate PRs for all RC elements, but group cleanups and bug fixes.

The Flag emoji is from another PR that is coming soon.

![image](https://github.com/user-attachments/assets/da0a4950-66cd-4b1c-ab9e-ab2da63c7d4f)

![image](https://github.com/user-attachments/assets/7fbe76b7-5517-451d-9619-dc572147cf28)