### PR TITLE
GH-1233 Temporarily revert AIIDA E2E test to fixed button over DN select

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/aiida/AiidaTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/aiida/AiidaTest.java
@@ -10,7 +10,8 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 class AiidaTest extends E2eTestSetup {
     @Test
     void buttonClickShowsQrCode_andBase64() {
-        this.navigateToRegionConnector("FUTURE_NEAR_REALTIME_DATA", null, null);
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect with EDDIE")).nth(3).click();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Continue")).click();
 
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 


### PR DESCRIPTION
Prevents AIIDA test from choosing the wrong DN when not waiting for the DN select option to be available.