### PR TITLE
NOISSUE Do not run E2E tests if changes do not affect them

### DIFF
--- a/.github/workflows/run-playwright-e2e-tests.yml
+++ b/.github/workflows/run-playwright-e2e-tests.yml
@@ -8,6 +8,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "admin-console/**"
+      - "aiida/**"
+      - "docs/**"
+      - "env/**"
+      - "outbound-connectors/**"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Many PRs will only change files of the ignored folders, which have no way of affecting the E2E tests.

Admin Console and AIIDA UIs might get their own, but separate, E2E tests in the future.