### PR TITLE
GH-1170 Make success pages more colorful

### DIFF
--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -743,100 +743,145 @@ class EddieConnectButton extends LitElement {
             "unable-to-send",
             () => html`
               <h3>Unable to send permission request</h3>
-              <p>
-                We were unable to send the permission request to your permission
-                administrator. Please contact the customer support of the
-                service provider.
-              </p>
 
-              <sl-button @click="${this.closeDialog}">Close</sl-button>
+              <sl-alert variant="danger" open>
+                <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+
+                <p>
+                  We were unable to send the permission request to your
+                  permission administrator. Please contact the customer support
+                  of the service provider.
+                </p>
+              </sl-alert>
+
+              <br />
+              <sl-button variant="danger" @click="${this.closeDialog}">
+                Close
+              </sl-button>
             `,
           ],
           [
             "accepted",
             () => html`
               <h3>Permission granted</h3>
-              <p>
-                You successfully granted permission for the service provider to
-                access to your data. The permission can be terminated by either
-                party at any time.
-              </p>
 
-              <p>
-                You may now close this dialog and continue on the website of the
-                service provider.
-              </p>
+              <sl-alert variant="success" open>
+                <sl-icon slot="icon" name="check-circle"></sl-icon>
 
-              <sl-button @click="${this.closeDialog}">Close</sl-button>
+                <p>
+                  You successfully granted permission for the service provider
+                  to access to your data. The permission can be terminated by
+                  either party at any time.
+                </p>
+
+                <p>
+                  You may now close this dialog and continue on the website of
+                  the service provider.
+                </p>
+              </sl-alert>
+
+              <br />
+              <sl-button variant="success" @click="${this.closeDialog}">
+                Close
+              </sl-button>
             `,
           ],
           [
             "rejected",
             () => html`
               <h3>Permission request rejected</h3>
-              <p>
-                You rejected the permission request for the service provider to
-                access to your data. No data will be processed.
-              </p>
 
-              <p>
-                You may now close this dialog. Please start again if the request
-                was rejected unintentionally.
-              </p>
+              <sl-alert variant="primary" open>
+                <sl-icon slot="icon" name="info-circle"></sl-icon>
+                
+                <p>
+                  You rejected the permission request for the service provider
+                  to access to your data. No data will be processed.
+                </p>
 
-              <sl-button @click="${this.closeDialog}">Close</sl-button>
+                <p>
+                  You may now close this dialog. Please start again if the
+                  request was rejected unintentionally.
+                </p>
+              </sl-alert>
+
+              <br />
+              <sl-button variant="primary" @click="${this.closeDialog}">
+                Close
+              </sl-button>
             `,
           ],
           [
             "timed-out",
             () => html`
               <h3>Permission request timed out</h3>
-              <p>
-                The permission request was not accepted in the expected
-                timeframe. No data will be processed.
-              </p>
+              
+              <sl-alert variant="danger" open>
+                <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+                <p>
+                  The permission request was not accepted in the expected
+                  timeframe. No data will be processed.
+                </p>
 
-              <p>
-                You may close this dialog and start again. Please contact the
-                service provider if the permission request does not show up in
-                the portal of your permission administrator.
-              </p>
+                <p>
+                  You may close this dialog and start again. Please contact the
+                  service provider if the permission request does not show up in
+                  the portal of your permission administrator.
+                </p>
+              </sl-alert>
 
-              <sl-button @click="${this.closeDialog}">Close</sl-button>
+              <br />
+              <sl-button variant="danger" @click="${this.closeDialog}">
+                Close
+              </sl-button>
             `,
           ],
           [
             "invalid",
             () => html`
               <h3>Request was declined as invalid</h3>
-              <p>
-                Your permission administrator declined our permission request as
-                invalid.
-              </p>
 
-              <p>
-                You may close this dialog and start again. Please contact the
-                service provider if the issue persists.
-              </p>
+              <sl-alert variant="danger" open>
+                <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+                <p>
+                  Your permission administrator declined our permission request
+                  as invalid.
+                </p>
 
-              <sl-button @click="${this.closeDialog}">Close</sl-button>
+                <p>
+                  You may close this dialog and start again. Please contact the
+                  service provider if the issue persists.
+                </p>
+              </sl-alert>
+
+              <br />
+              <sl-button variant="danger" @click="${this.closeDialog}">
+                Close
+              </sl-button>
             `,
           ],
           [
             "unfulfillable",
             () => html`
               <h3>Unable to fulfill the request</h3>
-              <p>
-                Your energy data provider is unable to provide the requested
-                data. No data will be processed.
-              </p>
 
-              <p>
-                You may now close this dialog and continue on the website of the
-                service provider.
-              </p>
+              <sl-alert variant="danger" open>
+                <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+                <p>
+                  Your energy data provider is unable to provide the requested
+                  data. No data will be processed.
+                </p>
 
-              <sl-button @click="${this.closeDialog}">Close</sl-button>
+                <p>
+                  You may now close this dialog and continue on the website of
+                  the service provider.
+                </p>
+              </sl-alert>
+
+              <br />
+              <sl-button variant="danger" @click="${this.closeDialog}">
+                Close
+              </sl-button>
             `,
           ],
         ])}


### PR DESCRIPTION
Not happy yet, but probably a quick win for visuals until I figure out what I actually want this to look like.

Before

![Screenshot From 2024-11-22 10-50-17](https://github.com/user-attachments/assets/db66335f-27e1-4274-9092-7c2e526f1048)

After

![Screenshot From 2024-11-22 10-50-34](https://github.com/user-attachments/assets/46ddb9f1-2ff6-416a-aeb8-a866b16e69d8)

![image](https://github.com/user-attachments/assets/997027b6-66cd-44f7-b91f-c467b27aa1b2)

![image](https://github.com/user-attachments/assets/cdb04247-0585-43fc-9393-c61e970e78a4)

![image](https://github.com/user-attachments/assets/c02fdebf-d64c-4f49-a748-d3d1d56198e8)

![image](https://github.com/user-attachments/assets/1337a6a9-89b4-44d9-83d0-bcf8553ad0fb)
