### PR TITLE
NOISSUE Support context path in EDDIE button

### DIFF
--- a/core/src/main/js/api.js
+++ b/core/src/main/js/api.js
@@ -1,6 +1,4 @@
-const CORE_URL =
-  import.meta.env.VITE_CORE_URL ??
-  import.meta.url.replace("/lib/eddie-components.js", "");
+const CORE_URL = import.meta.env.VITE_CORE_URL ?? new URL(import.meta.url).href.split("/lib/eddie-components.js")[0];
 
 function fetchJson(path) {
   return fetch(CORE_URL + path).then((response) => {

--- a/core/src/main/js/data-need-summary.js
+++ b/core/src/main/js/data-need-summary.js
@@ -5,7 +5,7 @@ import { ENERGY_TYPES } from "./constants/energy-types.js";
 import cronstrue from "cronstrue";
 
 const CORE_URL =
-  import.meta.env.VITE_CORE_URL ?? new URL(import.meta.url).origin;
+  import.meta.env.VITE_CORE_URL ?? new URL(import.meta.url).href.split("/lib/data-need-summary.js")[0];
 
 class DataNeedSummary extends HTMLElement {
   static get observedAttributes() {

--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -40,7 +40,7 @@ const COUNTRY_NAMES = new Intl.DisplayNames(["en"], { type: "region" });
 
 const CORE_URL =
   import.meta.env.VITE_CORE_URL ??
-  import.meta.url.replace("/lib/eddie-components.js", "");
+  new URL(import.meta.url).href.split("/lib/eddie-components.js")[0];
 
 /**
  * Maps events dispatched by the button to the view they should navigate to.

--- a/region-connectors/shared/src/main/web/permission-request-form-base.js
+++ b/region-connectors/shared/src/main/web/permission-request-form-base.js
@@ -16,7 +16,7 @@ class PermissionRequestFormBase extends LitElement {
      * URL of the core service inferred from the import URL.
      * @type {string}
      */
-    this.CORE_URL = new URL(import.meta.url).origin;
+    this.CORE_URL = new URL(import.meta.url).href.split("/region-connectors")[0];
 
     /**
      * Base URL of the current script inferred from the import URL.


### PR DESCRIPTION
Currently, the CORE_URL in js is built, using `import.meta.url` or `import.meta.url.origin`, this works properly, if eddie is deployed on e.g. `localhost:8080`, but if eddie is deployed with a context path e.g. `localhost/hardening/eddie` the second part of the url (hardening/eddie) is not used and requests aren't working.

This PR fixes such errors, by using `split[0]` instead of `replace`