### PR TITLE
GH-1469 Group health indicators by region connector

### DIFF
--- a/core/internal.http
+++ b/core/internal.http
@@ -4,6 +4,9 @@ GET http://localhost:8080/actuator
 ### GET health information of region-connectors
 GET http://localhost:8080/actuator/health
 
+### GET health information for region connector group
+GET http://localhost:8080/actuator/health/region-connector-at-eda
+
 ### GET supported features of region-connectors
 GET http://localhost:9090/management/region-connectors/supported-features
 

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -169,8 +169,17 @@ spring.jpa.properties.jakarta.persistence.validation.mode=none
 spring.flyway.baseline-on-migrate=true
 spring.flyway.enabled=true
 
-# Actuator
+# Actuator health indicator groups
 management.endpoint.health.show-details=always
+management.endpoint.health.validate-group-membership=false
+management.endpoint.health.group.region-connector-aiida.include=mqtt
+management.endpoint.health.group.region-connector-at-eda.include=ponton
+management.endpoint.health.group.region-connector-es-datadis.include=datadisApi
+management.endpoint.health.group.region-connector-dk-energinet.include=energinetApi
+management.endpoint.health.group.region-connector-fi-fingrid.include=fingrid
+management.endpoint.health.group.region-connector-fr-enedis.include=enedisAddressApi,enedisAuthenticationApi,enedisContactApi,enedisContractApi,enedisIdentityApi,enedisMeteringPointApi
+management.endpoint.health.group.region-connector-nl-mijn-aansluiting.include=mijnAansluiting
+management.endpoint.health.group.region-connector-us-green-button.include=greenButtonApi
 
 # WebClient
 spring.codec.max-in-memory-size=20MB


### PR DESCRIPTION
Closes #1469.

Need this to display health of RCs and their components in the admin console.

Will not merge immediately.

## Considerations

**Bean name shenanigans**

The prefix of `region-connector-` is needed since the group is created as a bean with the group name, which means they clash with our region connector beans. We could address this by adding a string to the RC bean name, but it seems counterintuitive to have the health indicator have the name of the RC but not the RC itself. Another option is to override health group autoconfiguration, but I was unable to find any documentation on this.

**Component names**

We might also want to add human-readable names for components in the details when displaying them in the admin console.

## Result

```http
### GET health information for region connector group
GET http://localhost:8080/actuator/health/region-connector-at-eda
```

```json
{
  "status": "UP",
  "components": {
    "ponton": {
      "status": "UP",
      "details": {
        "simpleHealthCheck": {
          "name": "simpleHealthCheck",
          "ok": true,
          "content": "UP"
        },
        "startup": {
          "name": "startup",
          "ok": true,
          "content": "startup completed"
        },
        "activation": {
          "name": "activation",
          "ok": true,
          "content": "Activation Valid"
        }
      }
    }
  }
}
```