### PR TITLE
NOISSUE Only run build workflow on PRs and pushes to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,14 @@
 name: Gradle Build, Test, and Analyze
-on: [ push ]
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
 jobs:
   build:
     name: Build and analyze


### PR DESCRIPTION
Prevents unnecessary builds when sharing a branch during development of a new feature without it having an associated pull request.