### PR TITLE
NOISSUE Fix path ignore for E2E test workflow

### DIFF
--- a/.github/workflows/run-playwright-e2e-tests.yml
+++ b/.github/workflows/run-playwright-e2e-tests.yml
@@ -5,6 +5,12 @@ on:
       - opened
       - reopened
       - synchronize
+    paths-ignore:
+      - "admin-console/**"
+      - "aiida/**"
+      - "docs/**"
+      - "env/**"
+      - "outbound-connectors/**"
   push:
     branches:
       - main


### PR DESCRIPTION
The setting was located at the wrong level. The correct syntax is `on.<event>.paths-ignore`.

See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore.