### PR TITLE
NOISSUE Set timeouts for long-running workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-22.04
+    timeout-minutes: 25 # Builds running longer than 25 minutes should be investigated
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-playwright-e2e-tests.yml
+++ b/.github/workflows/run-playwright-e2e-tests.yml
@@ -32,6 +32,7 @@ jobs:
   e2e-tests:
     name: Build and run E2E tests
     runs-on: [ self-hosted, fh-server-e2e ]
+    timeout-minutes: 15 # Shorten job timeout to account for missing timeouts in playwright tests
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
25 minutes for the main build is very generous. 15 minutes for E2E might have to be adjusted in the future when we add more tests.