### PR TITLE
NOISSUE Temporarily run all workflows on self-hosted runners

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -15,8 +15,7 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build and analyze
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     timeout-minutes: 25 # Builds running longer than 25 minutes should be investigated
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-commit-message:
     name: Check Commit Message
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     steps:
       - name: Check for referenced issue
         uses: gsactions/commit-message-checker@v2

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docs-deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK

--- a/.github/workflows/deploy-javadocs.yml
+++ b/.github/workflows/deploy-javadocs.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs-deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
We blew our budget :money_with_wings::skull: 

Will revert with January