### PR TITLE
NOISSUE Unproxy data need results when requested from the database

### DIFF
--- a/data-needs/build.gradle.kts
+++ b/data-needs/build.gradle.kts
@@ -28,10 +28,16 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.spring.boot.security)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.spring.boot.testcontainers)
     // needed to have access to RegionConnectorsCommonControllerAdvice that formats error responses correctly
     testImplementation(project(":region-connectors:shared"))
 
     testRuntimeOnly(libs.h2database)
+    testRuntimeOnly(libs.postgresql)
+    testRuntimeOnly(libs.flyway.core)
+    testRuntimeOnly(libs.flyway.postgresql)
 }
 
 tasks.test {

--- a/data-needs/src/main/java/energy/eddie/dataneeds/DataNeedsSpringConfig.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/DataNeedsSpringConfig.java
@@ -21,7 +21,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -29,7 +28,6 @@ import java.time.Clock;
 import java.util.Map;
 
 @Configuration
-@EnableWebMvc
 @SpringBootApplication
 public class DataNeedsSpringConfig {
     @Bean

--- a/data-needs/src/main/java/energy/eddie/dataneeds/needs/AccountingPointDataNeed.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/needs/AccountingPointDataNeed.java
@@ -1,6 +1,7 @@
 package energy.eddie.dataneeds.needs;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
@@ -12,4 +13,18 @@ import jakarta.persistence.Table;
 @Schema(description = "Data need for accounting point information request, i.e. information about the customer and their metering point.")
 public class AccountingPointDataNeed extends DataNeed {
     public static final String DISCRIMINATOR_VALUE = "account";
+
+    public AccountingPointDataNeed() {}
+
+    @SuppressWarnings("java:S107")
+    public AccountingPointDataNeed(
+            String name,
+            String description,
+            String purpose,
+            String policyLink,
+            boolean enabled,
+            @Nullable RegionConnectorFilter regionConnectorFilter
+    ) {
+        super(name, description, purpose, policyLink, enabled, regionConnectorFilter);
+    }
 }

--- a/data-needs/src/main/java/energy/eddie/dataneeds/needs/DataNeed.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/needs/DataNeed.java
@@ -16,6 +16,7 @@ import org.hibernate.validator.constraints.URL;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
 @Entity
 @Table(schema = "data_needs")
@@ -77,6 +78,24 @@ public abstract class DataNeed implements DataNeedInterface {
 
     @SuppressWarnings("NullAway.Init")
     protected DataNeed() {
+    }
+
+    @SuppressWarnings({"java:S107", "NullAway"})
+    protected DataNeed(
+            String name,
+            String description,
+            String purpose,
+            String policyLink,
+            boolean enabled,
+            @Nullable RegionConnectorFilter regionConnectorFilter
+    ) {
+        this.id = UUID.randomUUID().toString();
+        this.name = name;
+        this.description = description;
+        this.purpose = purpose;
+        this.policyLink = policyLink;
+        this.enabled = enabled;
+        this.regionConnectorFilter = regionConnectorFilter;
     }
 
     public String id() {

--- a/data-needs/src/main/java/energy/eddie/dataneeds/web/DataNeedWebConfig.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/web/DataNeedWebConfig.java
@@ -1,0 +1,9 @@
+package energy.eddie.dataneeds.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+@EnableWebMvc
+public class DataNeedWebConfig {
+}

--- a/data-needs/src/test/java/energy/eddie/dataneeds/services/DataNeedsDbServiceIntegrationTest.java
+++ b/data-needs/src/test/java/energy/eddie/dataneeds/services/DataNeedsDbServiceIntegrationTest.java
@@ -1,0 +1,100 @@
+package energy.eddie.dataneeds.services;
+
+import energy.eddie.dataneeds.needs.AccountingPointDataNeed;
+import energy.eddie.dataneeds.needs.DataNeed;
+import energy.eddie.dataneeds.persistence.DataNeedsRepository;
+import org.hibernate.proxy.HibernateProxy;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/migration/data-needs",
+        "spring.flyway.schemas=data_needs"
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class DataNeedsDbServiceIntegrationTest {
+    @SuppressWarnings("unused")
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> postgresqlContainer = new PostgreSQLContainer<>("postgres:15-alpine");
+    @Autowired
+    private DataNeedsRepository repository;
+
+    public static DataNeed createDataNeed() {
+        return new AccountingPointDataNeed("ac", "desc", "purpose", "https://localhost", true, null);
+    }
+
+    @Test
+    void testGetDataNeedIdsAndNames_returnsUnproxiedImplementation() {
+        // Given
+        var service = new DataNeedsDbService(repository);
+        repository.save(createDataNeed());
+
+        // When
+        var res = service.getDataNeedIdsAndNames();
+
+        // Then
+        assertThat(res).singleElement().isNotInstanceOf(HibernateProxy.class);
+    }
+
+    @Test
+    void testFindById_returnsUnproxiedImplementation() {
+        // Given
+        var service = new DataNeedsDbService(repository);
+        var dn = repository.save(createDataNeed());
+
+        // When
+        var res = service.findById(dn.id());
+
+        // Then
+        assertThat(res).isNotEmpty().isNotInstanceOf(HibernateProxy.class);
+    }
+
+    @Test
+    void testGetById_returnsUnproxiedImplementation() {
+        // Given
+        var service = new DataNeedsDbService(repository);
+        var dn = repository.save(createDataNeed());
+
+        // When
+        var res = service.getById(dn.id());
+
+        // Then
+        assertThat(res).isNotInstanceOf(HibernateProxy.class);
+    }
+
+    @Test
+    void testSaveNewDataNeed_returnsUnproxiedImplementation() {
+        // Given
+        var service = new DataNeedsDbService(repository);
+
+        // When
+        var res = service.saveNewDataNeed(createDataNeed());
+
+        // Then
+        assertThat(res).isNotInstanceOf(HibernateProxy.class);
+    }
+
+    @Test
+    void testFindAll_returnsUnproxiedImplementation() {
+        // Given
+        var service = new DataNeedsDbService(repository);
+        repository.save(createDataNeed());
+
+        // When
+        var res = service.findAll();
+
+        // Then
+        assertThat(res).singleElement().isNotInstanceOf(HibernateProxy.class);
+    }
+}


### PR DESCRIPTION
Unproxy data need results when requested from the database, because hibernate wraps everything in a proxy to support lazy loading, which results in the `instanceof` operator always failing when checking data needs for a specific type