### PR TITLE
GH-1514 Add header to SSE endpoint to prevent proxies like Nginx from buffering

### DIFF
--- a/core/src/main/java/energy/eddie/core/web/ConnectionStatusMessageController.java
+++ b/core/src/main/java/energy/eddie/core/web/ConnectionStatusMessageController.java
@@ -3,6 +3,7 @@ package energy.eddie.core.web;
 import energy.eddie.api.agnostic.ConnectionStatusMessage;
 import energy.eddie.core.services.PermissionService;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,11 +20,16 @@ public class ConnectionStatusMessageController {
     }
 
     @GetMapping(value = "{permission-id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<ConnectionStatusMessage> connectionStatusMessageByPermissionId(
+    public ResponseEntity<Flux<ConnectionStatusMessage>> connectionStatusMessageByPermissionId(
             @PathVariable("permission-id") String permissionId
     ) {
-        return permissionService
+        var messages = permissionService
                 .getConnectionStatusMessageStream()
                 .filter(message -> message.permissionId().equals(permissionId));
+
+        return ResponseEntity.ok()
+                             // Tell reverse proxies like Nginx not to buffer the response
+                             .header("X-Accel-Buffering", "no")
+                             .body(messages);
     }
 }


### PR DESCRIPTION
Fixes #1514.

Prevents an issue where SSE requests time out.

Might also need a ping from the browser to the server, since Nginx times out SSE requests after 3 minutes.

The EP can also configure `proxy_buffering off;` on the framework location. With Nginx being a very popular proxy, we want to implement this fix on our side.

Tested on Georg's server with his Nginx configuration and `proxy_buffering on;`.

Will not merge immediately. Might set up a local testing environment first.