### PR TITLE
NOISSUE Fix core index.html attribute changes

### DIFF
--- a/core/index.html
+++ b/core/index.html
@@ -22,8 +22,6 @@
     </style>
   </head>
   <body>
-    <eddie-connect-button connection-id="1"></eddie-connect-button>
-
     <form>
       <label>
         <span>Data need</span>
@@ -55,6 +53,12 @@
         (response) => response.json()
       );
 
+      // Create initial button with first data need
+      const button = document.createElement("eddie-connect-button");
+      button.setAttribute("connection-id", "1");
+      button.setAttribute("data-need-id", dataNeeds[0].id);
+      document.body.prepend(button);
+
       // Populate the select element with data needs
       const select = document.querySelector("select[name='data-need-id']");
       for (const { id, name } of dataNeeds) {
@@ -64,24 +68,17 @@
         select.appendChild(option);
       }
 
-      // Set button attributes and form values from query parameters
-      const button = document.querySelector("eddie-connect-button");
+      // Update button on input changes
       const inputs = document.querySelectorAll("input, select");
-
-      inputs.forEach((input) => {
+      for (const input of inputs) {
         input.addEventListener("change", (event) => {
           const { name, value, type, checked } = event.target;
+          // Reselect button as replacing it breaks the reference
+          const button = document.querySelector("eddie-connect-button");
           button.setAttribute(name, type === "checkbox" ? checked : value);
           button.replaceWith(button.cloneNode());
         });
-      });
-
-      // Use a known data need
-      const {
-        0: { id },
-      } = dataNeeds;
-      button.setAttribute("data-need-id", id);
-      button.replaceWith(button.cloneNode());
+      }
 
       // Log all status events for debugging purposes
       document.addEventListener("eddie-request-status", (event) => {


### PR DESCRIPTION
The underlying issue was not introduced with the last change, it just became more obvious. After replacing the button, its reference changed, the `setAttribute` did not work, and the input change would not be applied to the button.

Fixed this by selecting the button in the input change handler. Could use a single variable to track and update, it is easier to read like this.

Also removed the initial button markup and changed it to insert the button after the data needs load, so the first data need is applied as expected and the missing data-need-id does not result in an error.

Hope the slight delay in rendering will still work if we want to do E2E tests here :crossed_fingers: