### PR TITLE
GH-1498 Add health indicator for simulation region connector

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -182,6 +182,7 @@ management.endpoint.health.group.region-connector-fi-fingrid.include=fingrid
 management.endpoint.health.group.region-connector-fr-enedis.include=enedisAddressApi,enedisAuthenticationApi,enedisContactApi,enedisContractApi,enedisIdentityApi,enedisMeteringPointApi
 management.endpoint.health.group.region-connector-nl-mijn-aansluiting.include=mijnAansluiting
 management.endpoint.health.group.region-connector-us-green-button.include=greenButtonApi
+management.endpoint.health.group.region-connector-simulation.include=simulation
 
 # WebClient
 spring.codec.max-in-memory-size=20MB

--- a/region-connectors/region-connector-simulation/build.gradle.kts
+++ b/region-connectors/region-connector-simulation/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.actuator)
     implementation(libs.reactor.core)
     implementation(libs.jakarta.persistence.api)
 

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/health/SimulationHealthIndicator.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/health/SimulationHealthIndicator.java
@@ -1,0 +1,19 @@
+package energy.eddie.regionconnector.simulation.health;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SimulationHealthIndicator implements HealthIndicator {
+
+    /**
+     * With no additional dependencies we can always assume the simulation region connector to be healthy when enabled.
+     *
+     * @return up if enabled
+     */
+    @Override
+    public Health health() {
+        return Health.up().build();
+    }
+}

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/health/SimulationHealthIndicatorTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/health/SimulationHealthIndicatorTest.java
@@ -1,0 +1,25 @@
+package energy.eddie.regionconnector.simulation.health;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+class SimulationHealthIndicatorTest {
+    @InjectMocks
+    private SimulationHealthIndicator healthIndicator;
+
+    @Test
+    void testHealth() {
+        // Given
+        // When
+        var health = healthIndicator.health();
+
+        // Then
+        assertEquals(Health.up().build(), health);
+    }
+}


### PR DESCRIPTION
Simulation has no external dependencies, yet we want all our region connectors to feature a health endpoint when enabled. This dummy implementation will always return an "UP" state.

I am open for alternative implementations.

Closes #1498.