### PR TITLE
GH-746 Replace commit message check action with simple script

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -5,9 +5,6 @@ on:
       - opened
       - reopened
       - synchronize
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -17,14 +14,25 @@ jobs:
   check-commit-message:
     name: Check Commit Message
     runs-on: self-hosted
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Check for referenced issue
-        uses: gsactions/commit-message-checker@v2
-        with:
-          pattern: '^((\#|GH\-|gh\-)[0-9]+|NOISSUE|Merge|Revert).+'
-          flags: 'gm'
-          error: 'Commit message must reference an issue at the start, start with NOISSUE, or start with Merge'
-          excludeDescription: 'true' # exclude description and title of pull request
-          excludeTitle: 'true'
-          checkAllCommitMessages: 'true'
-          accessToken: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          url="https://api.github.com/repos/$REPOSITORY/pulls/$PR_NUMBER/commits"
+          commits=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$url" | jq -r '.[].commit.message')
+          regex="^((#|GH-|gh-)[0-9]+|NOISSUE|Merge|Revert).+"
+          
+          echo "Checking commit messages against \"$regex\"..."
+          
+          commits=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$url" | jq -r '.[].commit.message')
+          invalid=$(echo "$commits" | grep -vE $regex || true)
+          
+          if [[ -n "$invalid" ]]; then
+            echo "$invalid" | sed 's/^/❌  /'
+            exit 1
+          fi
+          
+          echo "✅ All commit messages are valid."


### PR DESCRIPTION
Closes GH-746.

Replaced the GitHub Action from the marketplace with a simple script. 

Removed the check on pushes to main, since all commits reaching main will have done so through a pull request.

Tested the error case with these commits:

![Screenshot From 2025-01-16 19-21-43](https://github.com/user-attachments/assets/c953bda8-52c2-4f07-831d-6b5368d757b6)

Got the following result:

```
Checking commit messages against "^((#|GH-|gh-)[0-9]+|NOISSUE|Merge|Revert).+"...
❌  This is not valid
❌  This is not valid
```

Local test command, in case you are interested:

```sh
act pull_request -j check-commit-message -P self-hosted=-self-hosted -s GITHUB_TOKEN=notmyactualtoken --env PR_NUMBER=155