### PR TITLE
NOISSUE Remove issuer URI and add Keycloak logout endpoint in AIIDA

### DIFF
--- a/aiida/README.md
+++ b/aiida/README.md
@@ -67,6 +67,7 @@ The following properties must be set in the `application.yml` file:
 | jwk-set-uri         | URI to obtain the public key for verifying JWTs.              |
 | user-name-attribute | JWT claim that contains the username.                         |
 | redirect-uri        | URI for redirecting users back to the application post-login. |
+| end-session-uri     | URI for logging out of Keycloak sessions.                     |
 
 Additionally, Keycloak requires a configured frontend URL to validate the issuer URI. This is specified using the `KC_HOSTNAME` variable in the `compose.yml` file.
 The provided `compose.yml` file provides a preconfiguration of these values for keycloak, you can configure it using the environments:

--- a/aiida/src/main/java/energy/eddie/aiida/config/KeycloakConfiguration.java
+++ b/aiida/src/main/java/energy/eddie/aiida/config/KeycloakConfiguration.java
@@ -5,12 +5,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "aiida.keycloak")
 public class KeycloakConfiguration {
     private final String accountUri;
+    private final String endSessionUri;
 
-    public KeycloakConfiguration(String accountUri) {
+    public KeycloakConfiguration(String accountUri, String endSessionUri) {
         this.accountUri = accountUri;
+        this.endSessionUri = endSessionUri;
     }
 
     public String accountUri() {
         return accountUri;
+    }
+
+    public String endSessionUri() {
+        return endSessionUri;
     }
 }

--- a/aiida/src/main/resources/application.yml
+++ b/aiida/src/main/resources/application.yml
@@ -24,7 +24,6 @@ spring:
             user-info-uri: ${KEYCLOAK_INTERNAL_HOST:http://localhost:8888}/realms/${KEYCLOAK_REALM:EDDIE}/protocol/openid-connect/userinfo
             jwk-set-uri: ${KEYCLOAK_INTERNAL_HOST:http://localhost:8888}/realms/${KEYCLOAK_REALM:EDDIE}/protocol/openid-connect/certs
             user-name-attribute: preferred_username
-            issuer-uri: ${KEYCLOAK_INTERNAL_HOST:http://localhost:8888}/realms/${KEYCLOAK_REALM:EDDIE}
         registration:
           keycloak:
             client-id: ${KEYCLOAK_CLIENT:AIIDA}
@@ -37,6 +36,7 @@ spring:
 aiida:
   keycloak:
     account-uri: ${KEYCLOAK_EXTERNAL_HOST:http://localhost:8888}/realms/${KEYCLOAK_REALM:EDDIE}/account
+    end-session-uri: ${KEYCLOAK_EXTERNAL_HOST:http://localhost:8888}/realms/${KEYCLOAK_REALM:EDDIE}/protocol/openid-connect/logout
 #  datasources:
 #    at:
 #      oeas:

--- a/aiida/src/test/java/energy/eddie/aiida/config/OAuth2SecurityConfigurationTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/config/OAuth2SecurityConfigurationTest.java
@@ -13,6 +13,8 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -33,20 +35,14 @@ class OAuth2SecurityConfigurationTest {
         @Test
         @WithMockUser
         void givenNoCorsMappingProperty_addsNoCorsMapping() throws Exception {
-            mockMvc.perform(get("/")
-                            .header("Origin", "https://example.com"))
-                    .andExpect(status().isOk())
-                    .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+            mockMvc.perform(get("/").header("Origin", "https://example.com"))
+                   .andExpect(status().isOk())
+                   .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
         }
     }
 
     @Nested
-    @WebMvcTest(
-            properties = {
-                    "aiida.cors.allowed-origins=https://example.com",
-            },
-            controllers = HomeController.class
-    )
+    @WebMvcTest(properties = {"aiida.cors.allowed-origins=https://example.com",}, controllers = HomeController.class)
     @Import(OAuth2SecurityConfiguration.class)
     class GivenCorsPropertyTest {
         @Autowired
@@ -58,27 +54,58 @@ class OAuth2SecurityConfigurationTest {
         @Test
         @WithMockUser
         void givenCorsMappingProperty_addsCorsHeader() throws Exception {
-            mockMvc.perform(get("/")
-                            .header("Origin", "https://example.com"))
-                    .andExpect(status().isOk())
-                    .andExpect(header().string("Access-Control-Allow-Origin", "https://example.com"));
+            mockMvc.perform(get("/").header("Origin", "https://example.com"))
+                   .andExpect(status().isOk())
+                   .andExpect(header().string("Access-Control-Allow-Origin", "https://example.com"));
         }
 
         @Test
         @WithMockUser
         void givenCorsMappingProperty_withWrongOriginHeader_returnsForbidden() throws Exception {
-            mockMvc.perform(get("/")
-                            .header("Origin", "https://some-other-not-permitted-domain.com"))
-                    .andExpect(status().isForbidden());
+            mockMvc.perform(get("/").header("Origin", "https://some-other-not-permitted-domain.com"))
+                   .andExpect(status().isForbidden());
         }
 
         @Test
         @WithMockUser
         void givenCorsMappingProperty_locationHeaderIsExposed() throws Exception {
-            mockMvc.perform(get("/")
-                            .header("Origin", "https://example.com"))
-                    .andExpect(status().isOk())
-                    .andExpect(header().string("Access-Control-Expose-Headers", "Location"));
+            mockMvc.perform(get("/").header("Origin", "https://example.com"))
+                   .andExpect(status().isOk())
+                   .andExpect(header().string("Access-Control-Expose-Headers", "Location"));
+        }
+    }
+
+    @Nested
+    @WebMvcTest(controllers = HomeController.class)
+    @AutoConfigureMockMvc
+    @Import(OAuth2SecurityConfiguration.class)
+    class LogoutTest {
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Autowired
+        private ClientRegistrationRepository clientRegistrationRepository;
+
+        @Test
+        @WithMockUser
+        void givenClientRegistrationRepository_containsEndSessionUri() {
+            var clientRegistration = clientRegistrationRepository.findByRegistrationId("keycloak");
+            assertNotEquals(null, clientRegistration);
+
+            var configurationMetadata = clientRegistration.getProviderDetails().getConfigurationMetadata();
+
+            assertTrue(configurationMetadata.containsKey("end_session_endpoint"));
+            assertEquals("https://auth.aiida.energy/logout", configurationMetadata.get("end_session_endpoint"));
+        }
+
+        @Test
+        void testLogoutSuccessHandlerIsConfigured() throws Exception {
+            mockMvc.perform(get("/logout").with(csrf()))
+                   .andExpect(status().is3xxRedirection())
+                   .andExpect(result -> {
+                       String location = result.getResponse().getHeader("Location");
+                       assert location != null && location.contains("http://localhost/login");
+                   });
         }
     }
 }

--- a/aiida/src/test/java/energy/eddie/aiida/web/HomeControllerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/web/HomeControllerTest.java
@@ -75,7 +75,8 @@ class HomeControllerTest {
     @Test
     void getHomeWithoutAuthentication_isUnauthorized() throws Exception {
         mockMvc.perform(get("/"))
-               .andExpect(status().isUnauthorized());
+               .andExpect(status().is3xxRedirection())
+               .andExpect(redirectedUrlPattern("**/oauth2/authorization/keycloak"));
     }
 
     @Test
@@ -87,7 +88,8 @@ class HomeControllerTest {
     @Test
     void getAccountWithoutAuthentication_isUnauthorized() throws Exception {
         mockMvc.perform(get("/account"))
-               .andExpect(status().isUnauthorized());
+               .andExpect(status().is3xxRedirection())
+               .andExpect(redirectedUrlPattern("**/oauth2/authorization/keycloak"));
     }
 
     @Test
@@ -95,6 +97,6 @@ class HomeControllerTest {
     void getAccountAuthentication_isFoundAndHasRedirectUri() throws Exception {
         mockMvc.perform(get("/account").with(csrf()))
                .andExpect(status().isFound())
-               .andExpect(redirectedUrl("http://localhost:8888/realms/EDDIE/account"));
+               .andExpect(redirectedUrl("https://auth.aiida.energy/account"));
     }
 }

--- a/aiida/src/test/resources/application.yml
+++ b/aiida/src/test/resources/application.yml
@@ -10,7 +10,26 @@ spring:
       ddl-auto: validate
   flyway:
     enabled: true
+  security:
+    oauth2:
+      client:
+        provider:
+          keycloak:
+            authorization-uri: https://auth.aiida.energy//auth
+            token-uri: https://auth.aiida.energy/token
+            user-info-uri: https://auth.aiida.energy/userinfo
+            jwk-set-uri: https://auth.aiida.energy/certs
+            user-name-attribute: preferred_username
+        registration:
+          keycloak:
+            client-id: AIIDA
+            client-secret: Test123!
+            authorization-grant-type: authorization_code
+            redirect-uri: https://aiida.energy/login/oauth2/code/keycloak
+            scope: openid
+            provider: keycloak
 
 aiida:
   keycloak:
-    account-uri: http://localhost:8888/realms/EDDIE/account
+    account-uri: https://auth.aiida.energy/account
+    end-session-uri: https://auth.aiida.energy/logout


### PR DESCRIPTION
Issuer URI again prevented AIIDA to run in the Docker container. Therefore removed it and added the `end-session-uri` explicitly in the `OAuth2Config`.

Code duplication is because of CORS (#1507).