### PR TITLE
NOISSUE e2e-tests: Update e2e tests to export port of example app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build and analyze
-    runs-on: self-hosted
+    runs-on: [self-hosted, no-dind]
     timeout-minutes: 25 # Builds running longer than 25 minutes should be investigated
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-playwright-e2e-tests.yml
+++ b/.github/workflows/run-playwright-e2e-tests.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   e2e-tests:
     name: Build and run E2E tests
-    runs-on: [ self-hosted, fh-server-e2e ]
+    runs-on: [ self-hosted, fh-server-e2e, dind ]
     timeout-minutes: 15 # Shorten job timeout to account for missing timeouts in playwright tests
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This fixes the failing e2e tests and testcontainer tests, by only executing e2e tests on runners that allow docker in docker (dind) with a custom network and normal build only on runners that do not use a custom dind setup.