### PR TITLE
NOISSUE Fix failing AIIDA E2E test because of EDDIE ID

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/aiida/AiidaTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/aiida/AiidaTest.java
@@ -14,7 +14,7 @@ class AiidaTest extends E2eTestSetup {
 
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 
-        assertThat(page.getByLabel("{\"permissionId\":\"")).isVisible();
+        assertThat(page.getByLabel("\"permissionId\":\"")).isVisible();
         assertThat(page.getByLabel("AIIDA code")).isVisible();
     }
 }


### PR DESCRIPTION
EDDIE ID was included with #1558 and therefore E2E is failing:

![image](https://github.com/user-attachments/assets/d9378f5d-0b93-42a2-978d-0ec778943c41)
