### PR TITLE
GH-1395 Delay E2E tests for 30 seconds to let RCs get ready

### DIFF
--- a/.github/workflows/run-playwright-e2e-tests.yml
+++ b/.github/workflows/run-playwright-e2e-tests.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install playwright dependencies
         run: ./gradlew e2e-tests:install-playwright-deps
 
+      - name: Sleep for 30 seconds to let the region connectors warm up
+        run: sleep 30s
+
       - name: Run playwright tests
         env:
           E2E_BASE_URL: "http://eddie:8080"


### PR DESCRIPTION
Temporary improvement for #1592