### PR TITLE
GH-1610 Aiida Bug fix, multiple permission caused aiida record values to being empty

### DIFF
--- a/aiida/src/main/java/energy/eddie/aiida/aggregator/Aggregator.java
+++ b/aiida/src/main/java/energy/eddie/aiida/aggregator/Aggregator.java
@@ -151,8 +151,11 @@ public class Aggregator implements AutoCloseable {
                                         .stream()
                                         .filter(value -> allowedDataTags.contains(value.dataTag().toString()))
                                         .toList();
-        aiidaRecord.setAiidaRecordValues(filteredValues);
-        return aiidaRecord;
+        return new AiidaRecord(
+                aiidaRecord.timestamp(),
+                aiidaRecord.asset(),
+                new ArrayList<>(filteredValues)
+        );
     }
 
     private boolean isRecordValid(AiidaRecord aiidaRecord, Instant expirationTime) {

--- a/aiida/src/main/java/energy/eddie/aiida/models/record/AiidaRecord.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/record/AiidaRecord.java
@@ -53,10 +53,6 @@ public class AiidaRecord {
         return aiidaRecordValues;
     }
 
-    public void setAiidaRecordValues(List<AiidaRecordValue> aiidaRecordValues) {
-        this.aiidaRecordValues = aiidaRecordValues;
-    }
-
     public String asset() {
         return asset;
     }


### PR DESCRIPTION
Multiple permission caused that the aiida record values were empty.

When filtering the aiida record the original object was modified but this caused a side effect... after buffering the aiida record values were empty. Now create a new aiida record after filtering.