### PR TITLE
GH-1592 Wait for region connectors to be available before running E2E tests

### DIFF
--- a/.github/workflows/run-playwright-e2e-tests.yml
+++ b/.github/workflows/run-playwright-e2e-tests.yml
@@ -69,6 +69,20 @@ jobs:
       - name: Install playwright dependencies
         run: ./gradlew e2e-tests:install-playwright-deps
 
+      - name: Wait for region connectors
+        run: |
+          RCS=$(echo "aiida at-eda dk-energinet es-datadis fr-enedis nl-mijn-aansluiting" | jq -R 'split(" ")')
+          for i in {1..20}; do
+            if curl -S --retry 5 --retry-connrefused http://eddie:8080/api/region-connectors-metadata | jq "[.[].id] | contains($RCS)"; then
+              echo "All connectors ready!"
+              exit 0
+            fi
+          
+            echo "Attempt $i/20 - Some connectors are missing - waiting 5s..."
+            sleep 5
+          done
+          exit 1
+
       - name: Run playwright tests
         env:
           E2E_BASE_URL: "http://eddie:8080"

--- a/e2e-tests/docker/docker-compose.yml
+++ b/e2e-tests/docker/docker-compose.yml
@@ -16,6 +16,9 @@ services:
     env_file:
       - .env
       - .env_secrets
+    ports:
+      - "8080:8080"
+      - "9090:9090"
     volumes:
       - ./keys:/opt/core/keys # mount a folder to store key files
       - ./ponton:/ponton # mount a folder to store ponton files


### PR DESCRIPTION
The retry on the curl is needed, since the core APIs do not become available immediately and the docker compose does not wait for the health check. It created a separate ticket to address this: #1656.

Exposing the ports in the E2E compose was not required, but was added as a preemptive measure.

Closes #1592.