### PR TITLE
 NOISSUE framework docs: Prepend slash in sidebar links to enable automatic prev/next

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -33,114 +33,114 @@ export default withMermaid(
         {
           text: "Running",
           items: [
-            { text: "Operation", link: "1-running/OPERATION" },
+            { text: "Operation", link: "/1-running/OPERATION" },
             {
               text: "EDDIE Button",
-              link: "1-running/eddie-button/eddie-button.md",
+              link: "/1-running/eddie-button/eddie-button.md",
               items: [
-                { text: "Angular", link: "1-running/eddie-button/angular.md" },
+                { text: "Angular", link: "/1-running/eddie-button/angular.md" },
               ],
             },
             {
               text: "Region Connectors",
-              link: "1-running/region-connectors/region-connectors.md",
+              link: "/1-running/region-connectors/region-connectors.md",
               items: [
                 {
                   text: "AIIDA",
-                  link: "1-running/region-connectors/region-connector-aiida.md",
+                  link: "/1-running/region-connectors/region-connector-aiida.md",
                 },
                 {
                   text: "EDA (Austria)",
-                  link: "1-running/region-connectors/region-connector-at-eda.md",
+                  link: "/1-running/region-connectors/region-connector-at-eda.md",
                 },
                 {
                   text: "Fluvius (Belgium)",
-                  link: "1-running/region-connectors/region-connector-be-fluvius.md",
+                  link: "/1-running/region-connectors/region-connector-be-fluvius.md",
                 },
                 {
                   text: "Energinet (Denmark)",
-                  link: "1-running/region-connectors/region-connector-dk-energinet.md",
+                  link: "/1-running/region-connectors/region-connector-dk-energinet.md",
                 },
                 {
                   text: "Datadis (Spain)",
-                  link: "1-running/region-connectors/region-connector-es-datadis.md",
+                  link: "/1-running/region-connectors/region-connector-es-datadis.md",
                 },
                 {
                   text: "Fingrid (Finland)",
-                  link: "1-running/region-connectors/region-connector-fi-fingrid.md",
+                  link: "/1-running/region-connectors/region-connector-fi-fingrid.md",
                 },
                 {
                   text: "Enedis (France)",
-                  link: "1-running/region-connectors/region-connector-fr-enedis.md",
+                  link: "/1-running/region-connectors/region-connector-fr-enedis.md",
                 },
                 {
                   text: "Mijn Aansluiting (Netherlands)",
-                  link: "1-running/region-connectors/region-connector-nl-mijn-aansluiting.md",
+                  link: "/1-running/region-connectors/region-connector-nl-mijn-aansluiting.md",
                 },
                 {
                   text: "Green Button (USA)",
-                  link: "1-running/region-connectors/region-connector-us-green-button.md",
+                  link: "/1-running/region-connectors/region-connector-us-green-button.md",
                 },
                 {
                   text: "CDS",
-                  link: "1-running/region-connectors/region-connector-cds.md",
+                  link: "/1-running/region-connectors/region-connector-cds.md",
                 },
               ],
             },
             {
               text: "Outbound-connectors",
-              link: "1-running/outbound-connectors/outbound-connectors.md",
+              link: "/1-running/outbound-connectors/outbound-connectors.md",
               items: [
                 {
                   text: "Apache Kafka",
-                  link: "1-running/outbound-connectors/outbound-connector-kafka.md",
+                  link: "/1-running/outbound-connectors/outbound-connector-kafka.md",
                 },
                 {
                   text: "AMQP",
-                  link: "1-running/outbound-connectors/outbound-connector-amqp.md",
+                  link: "/1-running/outbound-connectors/outbound-connector-amqp.md",
                 },
               ],
             },
-            { text: "Admin Console", link: "1-running/admin-console" },
-            { text: "Demo Button", link: "1-running/demo-button" },
-            { text: "Example App", link: "1-running/example-app" },
+            { text: "Admin Console", link: "/1-running/admin-console" },
+            { text: "Demo Button", link: "/1-running/demo-button" },
+            { text: "Example App", link: "/1-running/example-app" },
           ],
         },
         {
           text: "Integrating",
-          link: "2-integrating/integrating.md",
+          link: "/2-integrating/integrating.md",
           items: [
             {
               text: "Data Needs",
-              link: "2-integrating/data-needs.md",
+              link: "/2-integrating/data-needs.md",
             },
             {
               text: "Messages and Documents",
-              link: "2-integrating/messages/messages.md",
+              link: "/2-integrating/messages/messages.md",
               items: [
                 {
                   text: "Connection Status Messages",
-                  link: "2-integrating/messages/connection-status-messages.md",
+                  link: "/2-integrating/messages/connection-status-messages.md",
                 },
                 {
                   text: "Raw Data Messages",
-                  link: "2-integrating/messages/raw-data-messages.md",
+                  link: "/2-integrating/messages/raw-data-messages.md",
                 },
                 {
                   text: "Permission Market Documents",
-                  link: "2-integrating/messages/permission-market-documents.md",
+                  link: "/2-integrating/messages/permission-market-documents.md",
                 },
                 {
                   text: "Validated Historical Data Market Documents",
-                  link: "2-integrating/messages/validated-historical-data-market-documents.md",
+                  link: "/2-integrating/messages/validated-historical-data-market-documents.md",
                 },
                 {
                   text: "Accounting Point Data Market Documents",
-                  link: "2-integrating/messages/accounting-point-data-market-documents.md",
+                  link: "/2-integrating/messages/accounting-point-data-market-documents.md",
                 },
                 {
                   text: "Redistribution Transaction Request Documents",
-                  link: "2-integrating/messages/redistribution-transaction-request-documents.md",
+                  link: "/2-integrating/messages/redistribution-transaction-request-documents.md",
                 },
               ],
             },
@@ -149,54 +149,54 @@ export default withMermaid(
         {
           text: "Extending",
           items: [
-            { text: "Tech Stack", link: "3-extending/tech-stack" },
+            { text: "Tech Stack", link: "/3-extending/tech-stack" },
             {
               text: "Add a region connector",
-              link: "3-extending/region-connector/add-region-connector",
+              link: "/3-extending/region-connector/add-region-connector",
               items: [
                 {
                   text: "Quickstart",
-                  link: "3-extending/region-connector/quickstart",
+                  link: "/3-extending/region-connector/quickstart",
                 },
                 {
                   text: "Build and Setup",
-                  link: "3-extending/region-connector/build-and-setup",
+                  link: "/3-extending/region-connector/build-and-setup",
                 },
                 {
                   text: "API",
-                  link: "3-extending/region-connector/api",
+                  link: "/3-extending/region-connector/api",
                 },
                 {
                   text: "Internal Architecture",
-                  link: "3-extending/region-connector/internal-architecture",
+                  link: "/3-extending/region-connector/internal-architecture",
                 },
                 {
                   text: "Configuration",
-                  link: "3-extending/region-connector/configuration",
+                  link: "/3-extending/region-connector/configuration",
                 },
                 {
                   text: "Frontend",
-                  link: "3-extending/region-connector/frontend",
+                  link: "/3-extending/region-connector/frontend",
                 },
                 {
                   text: "Beans of Interest",
-                  link: "3-extending/region-connector/beans-of-interest",
+                  link: "/3-extending/region-connector/beans-of-interest",
                 },
                 {
                   text: "Shared Functionality",
-                  link: "3-extending/region-connector/shared-functionality",
+                  link: "/3-extending/region-connector/shared-functionality",
                 },
                 {
                   text: "Dispatcher Servlet",
-                  link: "3-extending/region-connector/dispatcher-servlet",
+                  link: "/3-extending/region-connector/dispatcher-servlet",
                 },
               ],
             },
             {
               text: "Add an outbound-connector",
-              link: "3-extending/add-outbound-connector",
+              link: "/3-extending/add-outbound-connector",
             },
-            { text: "Edit Documentation", link: "3-extending/documentation" },
+            { text: "Edit Documentation", link: "/3-extending/documentation" },
           ],
         },
       ],

--- a/docs/1-running/admin-console.md
+++ b/docs/1-running/admin-console.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Outbound Connectors"
-  link: "./outbound-connectors/outbound-connectors.md"
-next:
-  text: "Demo Button"
-  link: "./demo-button.md"
----
-
 # Admin Console
 
 The administrative console allows the eligible party to manage permission via a web interface.

--- a/docs/1-running/demo-button.md
+++ b/docs/1-running/demo-button.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Admin Console"
-  link: "./admin-console.md"
-next:
-  text: "Example App"
-  link: "./example-app.md"
----
-
 # Demo Button
 
 The demo button can be used to test the [EDDIE button](./eddie-button/eddie-button.md) and region connector elements during development.

--- a/docs/1-running/example-app.md
+++ b/docs/1-running/example-app.md
@@ -1,9 +1,3 @@
----
-prev:
-  text: "Demo Button"
-  link: "./demo-button.md"
----
-
 # Example App
 
 A simple demo app to check and try EDDIE's functionality.

--- a/docs/2-integrating/data-needs.md
+++ b/docs/2-integrating/data-needs.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Integrating"
-  link: "./integrating.md"
-next:
-  text: "Messages and Documents"
-  link: "./messages/messages.md"
----
-
 # Data Needs
 
 Data needs define the format of permission requests and the data they provide.

--- a/docs/2-integrating/integrating.md
+++ b/docs/2-integrating/integrating.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Example App"
-  link: "../1-running/example-app.md"
-next:
-  text: "Data Needs"
-  link: "./data-needs.md"
----
-
 # Integrating
 
 EDDIE can integrate with other systems using [several protocols](../1-running/outbound-connectors/outbound-connectors.md).

--- a/docs/2-integrating/messages/accounting-point-data-market-documents.md
+++ b/docs/2-integrating/messages/accounting-point-data-market-documents.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Validated Historical Data Market Documents"
-  link: "./validated-historical-data-market-documents.md"
-next:
-  text: "Redistribution Transaction Request Documents"
-  link: "./redistribution-transaction-request-documents.md"
----
-
 # Accounting Point Data Market Documents
 
 Accounting point data market documents provide information to one or multiple metering points related to one permission request.

--- a/docs/2-integrating/messages/connection-status-messages.md
+++ b/docs/2-integrating/messages/connection-status-messages.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Messages"
-  link: "./messages.md"
-next:
-  text: "Raw Data Messages"
-  link: "./raw-data-messages.md"
----
-
 # Connection status messages
 
 Connection status messages are an EDDIE internal message format and are an alternative version to the permission market documents.

--- a/docs/2-integrating/messages/messages.md
+++ b/docs/2-integrating/messages/messages.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Data Needs"
-  link: "../data-needs.md"
-next:
-  text: "Connection Status Messages"
-  link: "./connection-status-messages.md"
----
-
 # Messages and Documents
 
 EDDIE emits several messages and documents that can be used by the EP to react to permission request status changes, as well as collect the data that was requested from final customers.

--- a/docs/2-integrating/messages/permission-market-documents.md
+++ b/docs/2-integrating/messages/permission-market-documents.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Raw Data Messages"
-  link: "./raw-data-messages.md"
-next:
-  text: "Validated Historical Data Market Documents"
-  link: "./validated-historical-data-market-documents.md"
----
-
 # Permission Market Documents
 
 Permission market documents are used to signal the status change of one or multiple permission requests.

--- a/docs/2-integrating/messages/raw-data-messages.md
+++ b/docs/2-integrating/messages/raw-data-messages.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Connection Status Messages"
-  link: "./connection-status-messages.md"
-next:
-  text: "Permission Market Documents"
-  link: "./permission-market-documents.md"
----
-
 # Raw Data Messages
 
 Raw data messages are used to forward data from MDAs as is.

--- a/docs/2-integrating/messages/redistribution-transaction-request-documents.md
+++ b/docs/2-integrating/messages/redistribution-transaction-request-documents.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Accounting Point Data Market Documents"
-  link: "./accounting-point-data-market-documents.md"
-next:
-  text: "Data Needs"
-  link: "../data-needs.md"
----
-
 # Redistribution Transaction Request Documents (RTR Documents)
 
 Redistribution Transaction Request Documents (RTR Documents) are a CIM document that allows the eligible party to request validated historical data for a specific timeframe for a specific permission request.

--- a/docs/2-integrating/messages/validated-historical-data-market-documents.md
+++ b/docs/2-integrating/messages/validated-historical-data-market-documents.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Permission Market Documents"
-  link: "./permission-market-documents.md"
-next:
-  text: "Accounting Point Data Market Documents"
-  link: "./accounting-point-data-market-documents.md"
----
-
 # Validated Historical Data Market Documents
 
 Validated historical data market documents contain metered data that is received from the MDA.

--- a/docs/3-extending/add-outbound-connector.md
+++ b/docs/3-extending/add-outbound-connector.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Add a Region Connector"
-  link: "./region-connector/add-region-connector.md"
-next:
-  text: "Edit Documentation"
-  link: "./documentation.md"
----
-
 # Add an outbound-connector
 
 An outbound-connector is a Spring Boot application.

--- a/docs/3-extending/region-connector/add-region-connector.md
+++ b/docs/3-extending/region-connector/add-region-connector.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Tech Stack"
-  link: "../tech-stack.md"
-next:
-  text: "Quickstart"
-  link: "./quickstart.md"
----
-
 # Add a region connector
 
 Region connectors are an essential part of EDDIE for creating and managing [permission requests](../../2-integrating/integrating.md#permission-requests) for the eligible party.

--- a/docs/3-extending/region-connector/api.md
+++ b/docs/3-extending/region-connector/api.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Build and Setup"
-  link: "./build-and-setup.md"
-next:
-  text: "Internal Architecture"
-  link: "./internal-architecture.md"
----
-
 # API
 
 The API documentation is split into two parts.

--- a/docs/3-extending/region-connector/beans-of-interest.md
+++ b/docs/3-extending/region-connector/beans-of-interest.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Frontend"
-  link: "./frontend.md"
-next:
-  text: "Shared Functiona"
-  link: "./shared-functionality.md"
----
-
 # Beans of interest
 
 The following beans are of special interest, because they are either:

--- a/docs/3-extending/region-connector/build-and-setup.md
+++ b/docs/3-extending/region-connector/build-and-setup.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Quickstart"
-  link: "./quickstart.md"
-next:
-  text: "API"
-  link: "./api.md"
----
-
 # Build and Setup
 
 The region connectors are subprojects of the [region-connectors project](https://github.com/eddie-energy/eddie/tree/main/region-connectors).

--- a/docs/3-extending/region-connector/configuration.md
+++ b/docs/3-extending/region-connector/configuration.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Internal Architecture"
-  link: "./internal-architecture.md"
-next:
-  text: "Frontend"
-  link: "./frontend.md"
----
-
 # Configuration
 
 This section gives insights on which files have to be adapted in order to show the new region connector, as well as describing the naming conventions of configuration properties.

--- a/docs/3-extending/region-connector/dispatcher-servlet.md
+++ b/docs/3-extending/region-connector/dispatcher-servlet.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Shared Functionality"
-  link: "./shared-functionality.md"
-next:
-  text: "Add an Outbound Connector"
-  link: "../add-outbound-connector.md"
----
-
 # Dispatcher Servlet (web interface)
 
 Each region connector is started in its own spring context and runs in a separate dispatcher servlet.

--- a/docs/3-extending/region-connector/frontend.md
+++ b/docs/3-extending/region-connector/frontend.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Configuration"
-  link: "./configuration.md"
-next:
-  text: "Beans of Interest"
-  link: "./beans-of-interest.md"
----
-
 # Implementing a Region Connector Frontend
 
 The frontend of each region connector is to be implemented as a custom element.

--- a/docs/3-extending/region-connector/internal-architecture.md
+++ b/docs/3-extending/region-connector/internal-architecture.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "API"
-  link: "./api.md"
-next:
-  text: "Configuration"
-  link: "./configuration.md"
----
-
 # Internal Architecture
 
 While each region connector could implement a completely different architecture, since they are isolated from another, it is better to use the same architecture.

--- a/docs/3-extending/region-connector/quickstart.md
+++ b/docs/3-extending/region-connector/quickstart.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Add a Region Connector"
-  link: "./add-region-connector.md"
-next:
-  text: "Build and Setup"
-  link: "./build-and-setup.md"
----
-
 # Quickstart
 
 This is a simple quickstart guide to implement a new region connector.

--- a/docs/3-extending/region-connector/shared-functionality.md
+++ b/docs/3-extending/region-connector/shared-functionality.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Beans of Interest"
-  link: "./beans-of-interest.md"
-next:
-  text: "Dispatcher Servlet"
-  link: "./dispatcher-servlet.md"
----
-
 # Shared Functionality
 
 Often region connectors have to implement the same functionality slightly different.

--- a/docs/3-extending/tech-stack.md
+++ b/docs/3-extending/tech-stack.md
@@ -1,12 +1,3 @@
----
-prev:
-  text: "Data Needs"
-  link: "../2-integrating/data-needs.md"
-next:
-  text: "Add a region connector"
-  link: "./region-connector/add-region-connector.md"
----
-
 # Tech Stack
 
 **Backend**


### PR DESCRIPTION
Found this from a random bug report in the VitePress repo that provides no further information :laughing:
https://github.com/vuejs/vitepress/issues/1795

Some existing links have changed to reflect the hierarchy visible on the sidebar. If you want this modified, please comment or add them again when needed.