### PR TITLE
GH-1362 CIM: Fix name of snapshot versions of the CIM artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,6 @@ jobs:
     name: Publish maven packages
     needs: build
     runs-on: self-hosted
-    if: github.ref_name == 'main'
     permissions:
       contents: read
       packages: write
@@ -91,32 +90,62 @@ jobs:
         name: Check for CIM changes
         # language=bash
         run: |
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-          
-          # Detect base commit depending on event type
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="origin/${{ github.base_ref }}"
+          git fetch --no-tags --prune --quiet --unshallow
+
+          # Determine base commit
+          if [ "$(git rev-list --parents -n 1 HEAD | wc -w)" -eq 3 ]; then
+            # Merge commit (has two parents)
+            echo "Detected merge commit"
+            BASE_COMMIT=$(git rev-parse HEAD^1)
           else
-            BASE_REF="${{ github.event.before }}"
+            # Regular commit (feature branch or push)
+            echo "Detected non-merge commit"
+            BASE_COMMIT=$(git merge-base HEAD origin/main)
           fi
-          
-          echo "Base ref: $BASE_REF"
-          CHANGED=$(git diff --name-only $BASE_REF HEAD)
-          
+          echo "Base commit: $BASE_COMMIT"
+
+          CHANGED=$(git diff --name-only "$BASE_COMMIT" HEAD)
+
           echo "Changed files:"
           echo "$CHANGED"
-          
+
+          # Flags
+          XSD_CHANGED=false
+          BUILD_CHANGED=false
+          CHANGELOG_CHANGED=false
+
+          echo "$CHANGED" | grep -qE '^api/src/main/schemas/cim/.*\.xsd$' && XSD_CHANGED=true
+          echo "$CHANGED" | grep -qE '^api/build\.gradle\.kts$' && BUILD_CHANGED=true
+          echo "$CHANGED" | grep -qE '^api/CIM_CHANGELOG\.md$' && CHANGELOG_CHANGED=true
+
+          echo "XSD changed: $XSD_CHANGED"
+          echo "Build file changed: $BUILD_CHANGED"
+          echo "Changelog changed: $CHANGELOG_CHANGED"
+
+          # If the XSDs changed the build has to include the updated version and the CHANGELOG needs to be updated
+          if $XSD_CHANGED; then
+            if ! $BUILD_CHANGED; then
+              echo "❌ XSD files changed but api/build.gradle.kts was not updated."
+              exit 1
+            fi
+            if ! $CHANGELOG_CHANGED; then
+              echo "❌ XSD files changed but api/CIM_CHANGELOG.md was not updated."
+              exit 1
+            fi
+          fi
+
+          # Output for downstream jobs
           MATCH=false
-          echo "$CHANGED" | grep -E '^api/src/main/schemas/cim/.*\.xsd$|^api/build\.gradle\.kts$' && MATCH=true
+          if $XSD_CHANGED || $CHANGELOG_CHANGED; then MATCH=true; fi
           echo "changed=$MATCH" >> $GITHUB_OUTPUT
       - name: Set up JDK 21
-        if: steps.check.outputs.changed == 'true'
+        if: steps.check.outputs.changed == 'true' && github.ref_name == 'main'
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
       - name: Build and publish CIM maven package
-        if: steps.check.outputs.changed == 'true'
+        if: steps.check.outputs.changed == 'true' && github.ref_name == 'main'
         env:
           GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPR_USER: ${{ env.GITHUB_ACTOR }}

--- a/api/CIM_CHANGELOG.md
+++ b/api/CIM_CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog for the Common Information Model
+
+This changelog describes the changes made to the CIM maven artifact.
+Inspired by (common-changelog)[https://github.com/vweevers/common-changelog].
+
+## 0.0.0 - 2025-05-07
+
+Introduction of the changelog for the CIM.
+The CIM model now contains classes for CIM v0.82 and v0.91.08.
+For more information, see [Common Information Model Client Libraries ](https://eddie-web.projekte.fh-hagenberg.at/framework/2-integrating/messages/cim-client-libraries.html#common-information-model-client-libraries).

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,9 +1,7 @@
+
 import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
 import org.w3c.dom.Element
-import java.time.LocalDate
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import java.util.*
 import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.io.path.ExperimentalPathApi
@@ -18,6 +16,8 @@ plugins {
 
 group = "energy.eddie"
 version = "0.0.0"
+
+val cimVersion: String = "0.0.0"
 
 repositories {
     mavenCentral()
@@ -154,9 +154,6 @@ tasks.named("compileJava") {
     dependsOn(generateCIMSchemaClasses)
 }
 
-val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
-// Have a different version for generated CIM classes, since they can change disjunct to the API package
-val cimVersion: String = "SNAPSHOT-" + LocalDate.now(ZoneOffset.UTC).format(formatter)
 val cimJar = tasks.register<Jar>("cimJar") {
     description = "Packs the generated CIM classes into a JAR"
     group = "Build"
@@ -164,7 +161,7 @@ val cimJar = tasks.register<Jar>("cimJar") {
     manifest {
         attributes(
             "cim" to project.name,
-            cimVersion to project.version
+            "cimVersion" to project.version
         )
     }
     from(generatedXJCJavaDir)

--- a/docs/2-integrating/messages/cim-client-libraries.md
+++ b/docs/2-integrating/messages/cim-client-libraries.md
@@ -6,7 +6,7 @@ If you already have access to the EDDIE repository, follow this [guide](https://
 If you do not have access to the EDDIE repository, contact the developers to gain access.
 
 > [!INFO]
-> Find the package with the CIM classes in the EDDIE repository [here](https://github.com/eddie-energy/eddie/packages/2494610).
+> Find the package with the CIM classes in the EDDIE repository [here](https://github.com/eddie-energy/eddie/packages/2495238).
 
 ## Getting started
 


### PR DESCRIPTION
The CIM maven artifact used a date-based versioning approach, this led to problems if there were multiple changes to the artifact on the same day, since it is not possible to override the same version on the gh package registry.

Instead a changelog just for the CIM artifact is introduced, with semantic versioning.
If the XSDs of the CIM are changed, the changelog and the version declared in the `api/build.gradle.kts` has to be updated to reflect the change.