### PR TITLE
GH-1711: AIIDA - SGA Issues

### DIFF
--- a/aiida/docs/datasources/sga/SmartGatewaysAdapter.md
+++ b/aiida/docs/datasources/sga/SmartGatewaysAdapter.md
@@ -33,37 +33,28 @@ in your browser. The default username is `admin` and the default password is `sm
 ## How to use with AIIDA
 
 The adapter needs to send the smart meter data via MQTT to the AIIDA broker.
-You should configure the datasource in the AIIDA settings.
+You should configure the datasource in the AIIDA UI.
 
-Example of a working configuration:
+Create a new datasource in AIIDA with the datasource type `Smart Gateways Adapter`.
+This will generate the MQTT settings for the adapter.
 
-```yaml
-aiida:
-  datasources:
-    sga:
-        - enabled: true
-          id: 1
-          mqtt-server-uri: tcp://localhost:1884
-          mqtt-subscribe-topic: sga/metering
-          mqtt-username: sga
-          mqtt-password: sga
-```
-When AIIDA started via docker:
-
+An example configuration is shown below. The values are based on the example working configuration above.
 ```text
-AIIDA_DATASOURCES_SGA_0_ENABLED=true
-AIIDA_DATASOURCES_SGA_0_ID=1
-AIIDA_DATASOURCES_SGA_0_MQTT_SERVER_URI=tcp://localhost:1884
-AIIDA_DATASOURCES_SGA_0_MQTT_SUBSCRIBE_TOPIC=sga/metering
-AIIDA_DATASOURCES_SGA_0_MQTT_USERNAME=sga
-AIIDA_DATASOURCES_SGA_0_MQTT_PASSWORD=sga
+MQTT Server: host or ip of the AIIDA broker
+MQTT Port: 1884
+MQTT Username: unique username (e.g.: r0bw57fSZM)
+MQTT Password: unique password (e.g.: xfeAHruBB4)
+MQTT Topic: AcQY334Z4Q/dsmr/reading/+
 ```
 
 Now configure the MQTT settings in the adapter. The values are based on the example working configuration above.
 ```text
 MQTT Server: host or ip of the AIIDA broker
 MQTT Port: 1884
-MQTT Username: sga
-MQTT Password: sga
-MQTT Prefix: sga/metering
+MQTT Username: unique username (e.g.: r0bw57fSZM)
+MQTT Password: unique password (e.g.: xfeAHruBB4)
+MQTT Prefix: random string of 10 characters (e.g. AcQY334Z4Q)
 ```
+
+For the prefix only the first 10 characters of the MQTT Topic are used. In this
+example the prefix is `AcQY334Z4Q`.

--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterMessage.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterMessage.java
@@ -1,5 +1,7 @@
 package energy.eddie.aiida.adapters.datasource.sga;
 
+import java.util.Objects;
+
 public record SmartGatewaysAdapterMessage(
         SmartGatewaysAdapterMessageField electricityEquipmentId,
         SmartGatewaysAdapterMessageField gasEquipmentId,
@@ -25,10 +27,21 @@ public record SmartGatewaysAdapterMessage(
         SmartGatewaysAdapterMessageField phaseVoltageL3,
         SmartGatewaysAdapterMessageField phasePowerCurrentL1,
         SmartGatewaysAdapterMessageField phasePowerCurrentL2,
-        SmartGatewaysAdapterMessageField phasePowerCurrentL3,
-        SmartGatewaysAdapterMessageField gasDelivered,
-        SmartGatewaysAdapterMessageField powerDeliveredHour,
-        SmartGatewaysAdapterMessageField gasDeliveredHour
-) {}
+        SmartGatewaysAdapterMessageField phasePowerCurrentL3
+) {
+    private static final String DSMR_TARIFF_LOW = "0001";
+
+    SmartGatewaysAdapterMessageField electricityDelivered() {
+        return Objects.equals(this.electricityTariff().value(), DSMR_TARIFF_LOW) ?
+                this.electricityDeliveredTariff1() :
+                this.electricityDeliveredTariff2();
+    }
+
+    SmartGatewaysAdapterMessageField electricityReturned() {
+        return Objects.equals(this.electricityTariff().value(), DSMR_TARIFF_LOW) ?
+                this.electricityReturnedTariff1() :
+                this.electricityReturnedTariff2();
+    }
+}
 
 

--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterMessageBuilder.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterMessageBuilder.java
@@ -1,0 +1,160 @@
+package energy.eddie.aiida.adapters.datasource.sga;
+
+@SuppressWarnings("NullAway")
+public class SmartGatewaysAdapterMessageBuilder {
+    private SmartGatewaysAdapterMessageField electricityEquipmentId;
+    private SmartGatewaysAdapterMessageField gasEquipmentId;
+    private SmartGatewaysAdapterMessageField electricityTariff;
+    private SmartGatewaysAdapterMessageField electricityDeliveredTariff1;
+    private SmartGatewaysAdapterMessageField electricityReturnedTariff1;
+    private SmartGatewaysAdapterMessageField electricityDeliveredTariff2;
+    private SmartGatewaysAdapterMessageField electricityReturnedTariff2;
+    private SmartGatewaysAdapterMessageField reactiveEnergyDeliveredTariff1;
+    private SmartGatewaysAdapterMessageField reactiveEnergyReturnedTariff1;
+    private SmartGatewaysAdapterMessageField reactiveEnergyDeliveredTariff2;
+    private SmartGatewaysAdapterMessageField reactiveEnergyReturnedTariff2;
+    private SmartGatewaysAdapterMessageField powerCurrentlyDelivered;
+    private SmartGatewaysAdapterMessageField powerCurrentlyReturned;
+    private SmartGatewaysAdapterMessageField phaseCurrentlyDeliveredL1;
+    private SmartGatewaysAdapterMessageField phaseCurrentlyDeliveredL2;
+    private SmartGatewaysAdapterMessageField phaseCurrentlyDeliveredL3;
+    private SmartGatewaysAdapterMessageField phaseCurrentlyReturnedL1;
+    private SmartGatewaysAdapterMessageField phaseCurrentlyReturnedL2;
+    private SmartGatewaysAdapterMessageField phaseCurrentlyReturnedL3;
+    private SmartGatewaysAdapterMessageField phaseVoltageL1;
+    private SmartGatewaysAdapterMessageField phaseVoltageL2;
+    private SmartGatewaysAdapterMessageField phaseVoltageL3;
+    private SmartGatewaysAdapterMessageField phasePowerCurrentL1;
+    private SmartGatewaysAdapterMessageField phasePowerCurrentL2;
+    private SmartGatewaysAdapterMessageField phasePowerCurrentL3;
+
+    public SmartGatewaysAdapterMessage build() {
+        return new SmartGatewaysAdapterMessage(
+                electricityEquipmentId,
+                gasEquipmentId,
+                electricityTariff,
+                electricityDeliveredTariff1,
+                electricityReturnedTariff1,
+                electricityDeliveredTariff2,
+                electricityReturnedTariff2,
+                reactiveEnergyDeliveredTariff1,
+                reactiveEnergyReturnedTariff1,
+                reactiveEnergyDeliveredTariff2,
+                reactiveEnergyReturnedTariff2,
+                powerCurrentlyDelivered,
+                powerCurrentlyReturned,
+                phaseCurrentlyDeliveredL1,
+                phaseCurrentlyDeliveredL2,
+                phaseCurrentlyDeliveredL3,
+                phaseCurrentlyReturnedL1,
+                phaseCurrentlyReturnedL2,
+                phaseCurrentlyReturnedL3,
+                phaseVoltageL1,
+                phaseVoltageL2,
+                phaseVoltageL3,
+                phasePowerCurrentL1,
+                phasePowerCurrentL2,
+                phasePowerCurrentL3
+        );
+    }
+
+    public void setElectricityEquipmentId(SmartGatewaysAdapterMessageField field) {
+        this.electricityEquipmentId = field;
+    }
+
+    public void setGasEquipmentId(SmartGatewaysAdapterMessageField field) {
+        this.gasEquipmentId = field;
+    }
+
+    public void setElectricityTariff(SmartGatewaysAdapterMessageField electricityTariff) {
+        this.electricityTariff = electricityTariff;
+    }
+
+    public void setElectricityDeliveredTariff1(SmartGatewaysAdapterMessageField electricityDeliveredTariff1) {
+        this.electricityDeliveredTariff1 = electricityDeliveredTariff1;
+    }
+
+    public void setElectricityReturnedTariff1(SmartGatewaysAdapterMessageField electricityReturnedTariff1) {
+        this.electricityReturnedTariff1 = electricityReturnedTariff1;
+    }
+
+    public void setElectricityDeliveredTariff2(SmartGatewaysAdapterMessageField electricityDeliveredTariff2) {
+        this.electricityDeliveredTariff2 = electricityDeliveredTariff2;
+    }
+
+    public void setElectricityReturnedTariff2(SmartGatewaysAdapterMessageField electricityReturnedTariff2) {
+        this.electricityReturnedTariff2 = electricityReturnedTariff2;
+    }
+
+    public void setReactiveEnergyDeliveredTariff1(SmartGatewaysAdapterMessageField reactiveEnergyDeliveredTariff1) {
+        this.reactiveEnergyDeliveredTariff1 = reactiveEnergyDeliveredTariff1;
+    }
+
+    public void setReactiveEnergyReturnedTariff1(SmartGatewaysAdapterMessageField reactiveEnergyReturnedTariff1) {
+        this.reactiveEnergyReturnedTariff1 = reactiveEnergyReturnedTariff1;
+    }
+
+    public void setReactiveEnergyDeliveredTariff2(SmartGatewaysAdapterMessageField reactiveEnergyDeliveredTariff2) {
+        this.reactiveEnergyDeliveredTariff2 = reactiveEnergyDeliveredTariff2;
+    }
+
+    public void setReactiveEnergyReturnedTariff2(SmartGatewaysAdapterMessageField reactiveEnergyReturnedTariff2) {
+        this.reactiveEnergyReturnedTariff2 = reactiveEnergyReturnedTariff2;
+    }
+
+    public void setPowerCurrentlyDelivered(SmartGatewaysAdapterMessageField powerCurrentlyDelivered) {
+        this.powerCurrentlyDelivered = powerCurrentlyDelivered;
+    }
+
+    public void setPowerCurrentlyReturned(SmartGatewaysAdapterMessageField powerCurrentlyReturned) {
+        this.powerCurrentlyReturned = powerCurrentlyReturned;
+    }
+
+    public void setPhaseCurrentlyDeliveredL1(SmartGatewaysAdapterMessageField phaseCurrentlyDeliveredL1) {
+        this.phaseCurrentlyDeliveredL1 = phaseCurrentlyDeliveredL1;
+    }
+
+    public void setPhaseCurrentlyDeliveredL2(SmartGatewaysAdapterMessageField phaseCurrentlyDeliveredL2) {
+        this.phaseCurrentlyDeliveredL2 = phaseCurrentlyDeliveredL2;
+    }
+
+    public void setPhaseCurrentlyDeliveredL3(SmartGatewaysAdapterMessageField phaseCurrentlyDeliveredL3) {
+        this.phaseCurrentlyDeliveredL3 = phaseCurrentlyDeliveredL3;
+    }
+
+    public void setPhaseCurrentlyReturnedL1(SmartGatewaysAdapterMessageField phaseCurrentlyReturnedL1) {
+        this.phaseCurrentlyReturnedL1 = phaseCurrentlyReturnedL1;
+    }
+
+    public void setPhaseCurrentlyReturnedL2(SmartGatewaysAdapterMessageField phaseCurrentlyReturnedL2) {
+        this.phaseCurrentlyReturnedL2 = phaseCurrentlyReturnedL2;
+    }
+
+    public void setPhaseCurrentlyReturnedL3(SmartGatewaysAdapterMessageField phaseCurrentlyReturnedL3) {
+        this.phaseCurrentlyReturnedL3 = phaseCurrentlyReturnedL3;
+    }
+
+    public void setPhaseVoltageL1(SmartGatewaysAdapterMessageField phaseVoltageL1) {
+        this.phaseVoltageL1 = phaseVoltageL1;
+    }
+
+    public void setPhaseVoltageL2(SmartGatewaysAdapterMessageField phaseVoltageL2) {
+        this.phaseVoltageL2 = phaseVoltageL2;
+    }
+
+    public void setPhaseVoltageL3(SmartGatewaysAdapterMessageField phaseVoltageL3) {
+        this.phaseVoltageL3 = phaseVoltageL3;
+    }
+
+    public void setPhasePowerCurrentL1(SmartGatewaysAdapterMessageField phasePowerCurrentL1) {
+        this.phasePowerCurrentL1 = phasePowerCurrentL1;
+    }
+
+    public void setPhasePowerCurrentL2(SmartGatewaysAdapterMessageField phasePowerCurrentL2) {
+        this.phasePowerCurrentL2 = phasePowerCurrentL2;
+    }
+
+    public void setPhasePowerCurrentL3(SmartGatewaysAdapterMessageField phasePowerCurrentL3) {
+        this.phasePowerCurrentL3 = phasePowerCurrentL3;
+    }
+}

--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterValueDeserializer.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterValueDeserializer.java
@@ -1,116 +1,75 @@
 package energy.eddie.aiida.adapters.datasource.sga;
 
+import energy.eddie.aiida.models.datasource.mqtt.sga.SmartGatewaysTopic;
 import energy.eddie.aiida.models.record.UnitOfMeasurement;
 import energy.eddie.aiida.utils.ObisCode;
 
-import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 public class SmartGatewaysAdapterValueDeserializer {
     protected SmartGatewaysAdapterValueDeserializer() {}
 
-    public static SmartGatewaysAdapterMessage deserialize(
-            byte[] message
-    ) {
-        String[] lines = new String(message, StandardCharsets.UTF_8).split("\\r?\\n", -1);
+    public static SmartGatewaysAdapterMessage deserialize(Map<SmartGatewaysTopic, String> batch) {
+        SmartGatewaysAdapterMessageBuilder builder = new SmartGatewaysAdapterMessageBuilder();
 
-        return new SmartGatewaysAdapterMessage(
-                new SmartGatewaysAdapterMessageField("electricityEquipmentId",
-                                                     lines[0],
-                                                     UnitOfMeasurement.NONE,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("gasEquipmentId", lines[1], UnitOfMeasurement.NONE, ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("electricityTariff", lines[2], UnitOfMeasurement.NONE, ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("electricityDeliveredTariff1",
-                                                     lines[3],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.POSITIVE_ACTIVE_ENERGY),
-                new SmartGatewaysAdapterMessageField("electricityReturnedTariff1",
-                                                     lines[4],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.NEGATIVE_ACTIVE_ENERGY),
-                new SmartGatewaysAdapterMessageField("electricityDeliveredTariff2",
-                                                     lines[5],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.POSITIVE_ACTIVE_ENERGY),
-                new SmartGatewaysAdapterMessageField("electricityReturnedTariff2",
-                                                     lines[6],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.NEGATIVE_ACTIVE_ENERGY),
-                new SmartGatewaysAdapterMessageField("reactiveEnergyDeliveredTariff1",
-                                                     lines[7],
-                                                     UnitOfMeasurement.KILO_WATT,
-                                                     ObisCode.POSITIVE_REACTIVE_INSTANTANEOUS_POWER),
-                new SmartGatewaysAdapterMessageField("reactiveEnergyReturnedTariff1",
-                                                     lines[8],
-                                                     UnitOfMeasurement.KILO_WATT,
-                                                     ObisCode.NEGATIVE_REACTIVE_INSTANTANEOUS_POWER),
-                new SmartGatewaysAdapterMessageField("reactiveEnergyDeliveredTariff2",
-                                                     lines[9],
-                                                     UnitOfMeasurement.KILO_WATT,
-                                                     ObisCode.POSITIVE_REACTIVE_INSTANTANEOUS_POWER),
-                new SmartGatewaysAdapterMessageField("reactiveEnergyReturnedTariff2",
-                                                     lines[10],
-                                                     UnitOfMeasurement.KILO_WATT,
-                                                     ObisCode.NEGATIVE_REACTIVE_INSTANTANEOUS_POWER),
-                new SmartGatewaysAdapterMessageField("powerCurrentlyDelivered",
-                                                     lines[11],
-                                                     UnitOfMeasurement.KILO_WATT,
-                                                     ObisCode.POSITIVE_ACTIVE_INSTANTANEOUS_POWER),
-                new SmartGatewaysAdapterMessageField("powerCurrentlyReturned",
-                                                     lines[12],
-                                                     UnitOfMeasurement.KILO_WATT,
-                                                     ObisCode.NEGATIVE_ACTIVE_INSTANTANEOUS_POWER),
-                new SmartGatewaysAdapterMessageField("phaseCurrentlyDeliveredL1",
-                                                     lines[13],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phaseCurrentlyDeliveredL2",
-                                                     lines[14],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phaseCurrentlyDeliveredL3",
-                                                     lines[15],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phaseCurrentlyReturnedL1",
-                                                     lines[16],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phaseCurrentlyReturnedL2",
-                                                     lines[17],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phaseCurrentlyReturnedL3",
-                                                     lines[18],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phaseVoltageL1", lines[19], UnitOfMeasurement.VOLT, ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phaseVoltageL2", lines[20], UnitOfMeasurement.VOLT, ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phaseVoltageL3", lines[21], UnitOfMeasurement.VOLT, ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phasePowerCurrentL1",
-                                                     lines[22],
-                                                     UnitOfMeasurement.AMPERE,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phasePowerCurrentL2",
-                                                     lines[23],
-                                                     UnitOfMeasurement.AMPERE,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("phasePowerCurrentL3",
-                                                     lines[24],
-                                                     UnitOfMeasurement.AMPERE,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("gasDelivered",
-                                                     lines[25],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("PowerDeliveredHour",
-                                                     lines[26],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN),
-                new SmartGatewaysAdapterMessageField("GasDeliveredHour",
-                                                     lines[27],
-                                                     UnitOfMeasurement.KILO_WATT_HOUR,
-                                                     ObisCode.UNKNOWN)
-        );
+        for (var entry : batch.entrySet()) {
+            SmartGatewaysTopic topic = entry.getKey();
+            String value = entry.getValue();
+
+            switch (topic) {
+                case ELECTRICITY_EQUIPMENT_ID -> builder.setElectricityEquipmentId(
+                        new SmartGatewaysAdapterMessageField("electricityEquipmentId", value, UnitOfMeasurement.NONE, ObisCode.UNKNOWN));
+                case GAS_EQUIPMENT_ID -> builder.setGasEquipmentId(
+                        new SmartGatewaysAdapterMessageField("gasEquipmentId", value, UnitOfMeasurement.NONE, ObisCode.UNKNOWN));
+                case ELECTRICITY_TARIFF -> builder.setElectricityTariff(
+                        new SmartGatewaysAdapterMessageField("electricityTariff", value, UnitOfMeasurement.NONE, ObisCode.UNKNOWN));
+                case ELECTRICITY_DELIVERED_1 -> builder.setElectricityDeliveredTariff1(
+                        new SmartGatewaysAdapterMessageField("electricityDeliveredTariff1", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.POSITIVE_ACTIVE_ENERGY));
+                case ELECTRICITY_RETURNED_1 -> builder.setElectricityReturnedTariff1(
+                        new SmartGatewaysAdapterMessageField("electricityReturnedTariff1", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.NEGATIVE_ACTIVE_ENERGY));
+                case ELECTRICITY_DELIVERED_2 -> builder.setElectricityDeliveredTariff2(
+                        new SmartGatewaysAdapterMessageField("electricityDeliveredTariff2", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.POSITIVE_ACTIVE_ENERGY));
+                case ELECTRICITY_RETURNED_2 -> builder.setElectricityReturnedTariff2(
+                        new SmartGatewaysAdapterMessageField("electricityReturnedTariff2", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.NEGATIVE_ACTIVE_ENERGY));
+                case REACTIVE_ELECTRICITY_DELIVERED_1 -> builder.setReactiveEnergyDeliveredTariff1(
+                        new SmartGatewaysAdapterMessageField("reactiveEnergyDeliveredTariff1", value, UnitOfMeasurement.KILO_WATT, ObisCode.POSITIVE_REACTIVE_INSTANTANEOUS_POWER));
+                case REACTIVE_ELECTRICITY_RETURNED_1 -> builder.setReactiveEnergyReturnedTariff1(
+                        new SmartGatewaysAdapterMessageField("reactiveEnergyReturnedTariff1", value, UnitOfMeasurement.KILO_WATT, ObisCode.NEGATIVE_REACTIVE_INSTANTANEOUS_POWER));
+                case REACTIVE_ELECTRICITY_DELIVERED_2 -> builder.setReactiveEnergyDeliveredTariff2(
+                        new SmartGatewaysAdapterMessageField("reactiveEnergyDeliveredTariff2", value, UnitOfMeasurement.KILO_WATT, ObisCode.POSITIVE_REACTIVE_INSTANTANEOUS_POWER));
+                case REACTIVE_ELECTRICITY_RETURNED_2 -> builder.setReactiveEnergyReturnedTariff2(
+                        new SmartGatewaysAdapterMessageField("reactiveEnergyReturnedTariff2", value, UnitOfMeasurement.KILO_WATT, ObisCode.NEGATIVE_REACTIVE_INSTANTANEOUS_POWER));
+                case ELECTRICITY_CURRENTLY_DELIVERED -> builder.setPowerCurrentlyDelivered(
+                        new SmartGatewaysAdapterMessageField("powerCurrentlyDelivered", value, UnitOfMeasurement.KILO_WATT, ObisCode.POSITIVE_ACTIVE_INSTANTANEOUS_POWER));
+                case ELECTRICITY_CURRENTLY_RETURNED -> builder.setPowerCurrentlyReturned(
+                        new SmartGatewaysAdapterMessageField("powerCurrentlyReturned", value, UnitOfMeasurement.KILO_WATT, ObisCode.NEGATIVE_ACTIVE_INSTANTANEOUS_POWER));
+                case PHASE_CURRENTLY_DELIVERED_L1 -> builder.setPhaseCurrentlyDeliveredL1(
+                        new SmartGatewaysAdapterMessageField("phaseCurrentlyDeliveredL1", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.UNKNOWN));
+                case PHASE_CURRENTLY_DELIVERED_L2 -> builder.setPhaseCurrentlyDeliveredL2(
+                        new SmartGatewaysAdapterMessageField("phaseCurrentlyDeliveredL2", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.UNKNOWN));
+                case PHASE_CURRENTLY_DELIVERED_L3 -> builder.setPhaseCurrentlyDeliveredL3(
+                        new SmartGatewaysAdapterMessageField("phaseCurrentlyDeliveredL3", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.UNKNOWN));
+                case PHASE_CURRENTLY_RETURNED_L1 -> builder.setPhaseCurrentlyReturnedL1(
+                        new SmartGatewaysAdapterMessageField("phaseCurrentlyReturnedL1", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.UNKNOWN));
+                case PHASE_CURRENTLY_RETURNED_L2 -> builder.setPhaseCurrentlyReturnedL2(
+                        new SmartGatewaysAdapterMessageField("phaseCurrentlyReturnedL2", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.UNKNOWN));
+                case PHASE_CURRENTLY_RETURNED_L3 -> builder.setPhaseCurrentlyReturnedL3(
+                        new SmartGatewaysAdapterMessageField("phaseCurrentlyReturnedL3", value, UnitOfMeasurement.KILO_WATT_HOUR, ObisCode.UNKNOWN));
+                case PHASE_VOLTAGE_L1 -> builder.setPhaseVoltageL1(
+                        new SmartGatewaysAdapterMessageField("phaseVoltageL1", value, UnitOfMeasurement.VOLT, ObisCode.UNKNOWN));
+                case PHASE_VOLTAGE_L2 -> builder.setPhaseVoltageL2(
+                        new SmartGatewaysAdapterMessageField("phaseVoltageL2", value, UnitOfMeasurement.VOLT, ObisCode.UNKNOWN));
+                case PHASE_VOLTAGE_L3 -> builder.setPhaseVoltageL3(
+                        new SmartGatewaysAdapterMessageField("phaseVoltageL3", value, UnitOfMeasurement.VOLT, ObisCode.UNKNOWN));
+                case PHASE_POWER_CURRENT_L1 -> builder.setPhasePowerCurrentL1(
+                        new SmartGatewaysAdapterMessageField("phasePowerCurrentL1", value, UnitOfMeasurement.AMPERE, ObisCode.UNKNOWN));
+                case PHASE_POWER_CURRENT_L2 -> builder.setPhasePowerCurrentL2(
+                        new SmartGatewaysAdapterMessageField("phasePowerCurrentL2", value, UnitOfMeasurement.AMPERE, ObisCode.UNKNOWN));
+                case PHASE_POWER_CURRENT_L3 -> builder.setPhasePowerCurrentL3(
+                        new SmartGatewaysAdapterMessageField("phasePowerCurrentL3", value, UnitOfMeasurement.AMPERE, ObisCode.UNKNOWN));
+            }
+        }
+
+        return builder.build();
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/models/datasource/mqtt/sga/SmartGatewaysDataSource.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/datasource/mqtt/sga/SmartGatewaysDataSource.java
@@ -4,6 +4,7 @@ import energy.eddie.aiida.dtos.DataSourceDto;
 import energy.eddie.aiida.dtos.DataSourceMqttDto;
 import energy.eddie.aiida.models.datasource.DataSourceType;
 import energy.eddie.aiida.models.datasource.mqtt.MqttDataSource;
+import energy.eddie.aiida.models.datasource.mqtt.MqttSecretGenerator;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 
@@ -12,7 +13,7 @@ import java.util.UUID;
 @Entity
 @DiscriminatorValue(DataSourceType.Identifiers.SMART_GATEWAYS_ADAPTER)
 public class SmartGatewaysDataSource extends MqttDataSource {
-    private static final String TOPIC_SUFFIX = "/#";
+    private static final String TOPIC_SUFFIX = "/dsmr/reading/+";
 
     @SuppressWarnings("NullAway")
     protected SmartGatewaysDataSource() {}
@@ -23,6 +24,6 @@ public class SmartGatewaysDataSource extends MqttDataSource {
 
     @Override
     protected void updateMqttSubscribeTopic() {
-        this.mqttSubscribeTopic = TOPIC_PREFIX + id + TOPIC_SUFFIX;
+        this.mqttSubscribeTopic = MqttSecretGenerator.generate() + TOPIC_SUFFIX;
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/models/datasource/mqtt/sga/SmartGatewaysTopic.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/datasource/mqtt/sga/SmartGatewaysTopic.java
@@ -1,0 +1,53 @@
+package energy.eddie.aiida.models.datasource.mqtt.sga;
+
+public enum SmartGatewaysTopic {
+    ELECTRICITY_EQUIPMENT_ID("dsmr/reading/electricity_equipment_id"),
+    GAS_EQUIPMENT_ID("dsmr/reading/gas_equipment_id"),
+    ELECTRICITY_TARIFF("dsmr/reading/electricity_tariff"),
+    ELECTRICITY_DELIVERED_1("dsmr/reading/electricity_delivered_1"),
+    ELECTRICITY_DELIVERED_2("dsmr/reading/electricity_delivered_2"),
+    ELECTRICITY_RETURNED_1("dsmr/reading/electricity_returned_1"),
+    ELECTRICITY_RETURNED_2("dsmr/reading/electricity_returned_2"),
+    REACTIVE_ELECTRICITY_DELIVERED_1("dsmr/reading/reactive_electricity_delivered_1"),
+    REACTIVE_ELECTRICITY_RETURNED_1("dsmr/reading/reactive_electricity_returned_1"),
+    REACTIVE_ELECTRICITY_DELIVERED_2("dsmr/reading/reactive_electricity_delivered_2"),
+    REACTIVE_ELECTRICITY_RETURNED_2("dsmr/reading/reactive_electricity_returned_2"),
+    ELECTRICITY_CURRENTLY_DELIVERED("dsmr/reading/electricity_currently_delivered"),
+    ELECTRICITY_CURRENTLY_RETURNED("dsmr/reading/electricity_currently_returned"),
+    PHASE_CURRENTLY_DELIVERED_L1("dsmr/reading/phase_currently_delivered_l1"),
+    PHASE_CURRENTLY_DELIVERED_L2("dsmr/reading/phase_currently_delivered_l2"),
+    PHASE_CURRENTLY_DELIVERED_L3("dsmr/reading/phase_currently_delivered_l3"),
+    PHASE_CURRENTLY_RETURNED_L1("dsmr/reading/phase_currently_returned_l1"),
+    PHASE_CURRENTLY_RETURNED_L2("dsmr/reading/phase_currently_returned_l2"),
+    PHASE_CURRENTLY_RETURNED_L3("dsmr/reading/phase_currently_returned_l3"),
+    PHASE_VOLTAGE_L1("dsmr/reading/phase_voltage_l1"),
+    PHASE_VOLTAGE_L2("dsmr/reading/phase_voltage_l2"),
+    PHASE_VOLTAGE_L3("dsmr/reading/phase_voltage_l3"),
+    PHASE_POWER_CURRENT_L1("dsmr/reading/phase_power_current_l1"),
+    PHASE_POWER_CURRENT_L2("dsmr/reading/phase_power_current_l2"),
+    PHASE_POWER_CURRENT_L3("dsmr/reading/phase_power_current_l3"),
+    NOT_EXPECTED("not_expected"),;
+
+    private final String topic;
+
+    SmartGatewaysTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String topic() {
+        return topic;
+    }
+
+    public boolean isExpected() {
+        return this != NOT_EXPECTED;
+    }
+
+    public static SmartGatewaysTopic from(String subscribeTopic, String topicPrefix) {
+        for (SmartGatewaysTopic t : SmartGatewaysTopic.values()) {
+            if (subscribeTopic.equals(topicPrefix + "/" + t.topic())) {
+                return t;
+            }
+        }
+        return NOT_EXPECTED;
+    }
+}

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterMessageTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterMessageTest.java
@@ -1,51 +1,42 @@
 package energy.eddie.aiida.adapters.datasource.sga;
 
+import energy.eddie.aiida.models.datasource.mqtt.sga.SmartGatewaysTopic;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
+import java.util.EnumMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-class SmartGatewaysAdapterMessageTest {
+class SmartGatewaysAdapterValueDeserializerTest {
+
     @Test
-    void verify_isProperlyDeserialized() {
-        var message = """
-                4530303632303030303037393239333232
-                4730303732303034303036353733323230
-                0002
-                3845.467
-                2621.303
-                1894.882
-                1435.228
-                0.000
-                0.000
-                0.000
-                0.000
-                0.531
-                0.030
-                0
-                71
-                460
-                30
-                0
-                0
-                233.00
-                234.00
-                234.00
-                0.00
-                0.00
-                2.00
-                736.650
-                -0.061
-                0.002""";
+    void testDeserializeSelectedFields() {
+        Map<SmartGatewaysTopic, String> batch = new EnumMap<>(SmartGatewaysTopic.class);
 
-        var actual = SmartGatewaysAdapterValueDeserializer.deserialize(message.getBytes(StandardCharsets.UTF_8));
+        batch.put(SmartGatewaysTopic.ELECTRICITY_TARIFF, "0002");
+        batch.put(SmartGatewaysTopic.ELECTRICITY_DELIVERED_1, "3845.467");
+        batch.put(SmartGatewaysTopic.ELECTRICITY_RETURNED_2, "1435.228");
+        batch.put(SmartGatewaysTopic.ELECTRICITY_CURRENTLY_DELIVERED, "0.531");
+        batch.put(SmartGatewaysTopic.PHASE_CURRENTLY_DELIVERED_L3, "460");
 
-        assertEquals("0002", actual.electricityTariff().value());
-        assertEquals("3845.467", actual.electricityDeliveredTariff1().value());
-        assertEquals("1435.228", actual.electricityReturnedTariff2().value());
-        assertEquals("0.531", actual.powerCurrentlyDelivered().value());
-        assertEquals("736.650", actual.gasDelivered().value());
-        assertEquals("460", actual.phaseCurrentlyDeliveredL3().value());
+        var result = SmartGatewaysAdapterValueDeserializer.deserialize(batch);
+
+        assertEquals("0002", result.electricityTariff().value());
+        assertEquals("3845.467", result.electricityDeliveredTariff1().value());
+        assertEquals("1435.228", result.electricityReturnedTariff2().value());
+        assertEquals("0.531", result.powerCurrentlyDelivered().value());
+        assertEquals("460", result.phaseCurrentlyDeliveredL3().value());
+    }
+
+    @Test
+    void testEmptyBatchProducesNullFields() {
+        Map<SmartGatewaysTopic, String> batch = new EnumMap<>(SmartGatewaysTopic.class);
+        var result = SmartGatewaysAdapterValueDeserializer.deserialize(batch);
+
+        assertNull(result.electricityTariff());
+        assertNull(result.electricityDeliveredTariff1());
+        assertNull(result.electricityReturnedTariff2());
     }
 }

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/sga/SmartGatewaysAdapterTest.java
@@ -4,6 +4,7 @@ import energy.eddie.aiida.dtos.DataSourceDto;
 import energy.eddie.aiida.dtos.DataSourceMqttDto;
 import energy.eddie.aiida.models.datasource.DataSourceType;
 import energy.eddie.aiida.models.datasource.mqtt.sga.SmartGatewaysDataSource;
+import energy.eddie.aiida.models.datasource.mqtt.sga.SmartGatewaysTopic;
 import energy.eddie.aiida.utils.MqttFactory;
 import energy.eddie.dataneeds.needs.aiida.AiidaAsset;
 import nl.altindag.log.LogCaptor;
@@ -23,107 +24,37 @@ import java.util.UUID;
 import static energy.eddie.aiida.utils.ObisCode.POSITIVE_ACTIVE_ENERGY;
 import static energy.eddie.aiida.utils.ObisCode.POSITIVE_ACTIVE_INSTANTANEOUS_POWER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 class SmartGatewaysAdapterTest {
-    private static final LogCaptor LOG_CAPTOR = LogCaptor.forClass(SmartGatewaysAdapter.class);
-    private static final String TEST_MESSAGE_TARIFF_1 = """
-            4530303632303030303037393239333232
-            4730303732303034303036353733323230
-            0001
-            3845.467
-            2621.303
-            1894.882
-            1435.228
-            0.000
-            0.000
-            0.000
-            0.000
-            0.531
-            0.445
-            0
-            71
-            460
-            30
-            0
-            0
-            233.00
-            234.00
-            234.00
-            0.00
-            0.00
-            2.00
-            736.650
-            -0.061
-            0.002""";
-    private static final String TEST_MESSAGE_TARIFF_2 = """
-            4530303632303030303037393239333232
-            4730303732303034303036353733323230
-            0002
-            3845.467
-            2621.303
-            1894.882
-            1435.228
-            0.000
-            0.000
-            0.000
-            0.000
-            0.531
-            0.030
-            0
-            71
-            460
-            30
-            0
-            0
-            233.00
-            234.00
-            234.00
-            0.00
-            0.00
-            2.00
-            736.650
-            -0.061
-            0.002""";
+
     private static final UUID DATA_SOURCE_ID = UUID.fromString("4211ea05-d4ab-48ff-8613-8f4791a56606");
     private static final UUID USER_ID = UUID.fromString("5211ea05-d4ab-48ff-8613-8f4791a56606");
+
     private static final SmartGatewaysDataSource DATA_SOURCE = new SmartGatewaysDataSource(
-            new DataSourceDto(DATA_SOURCE_ID,
-                              DataSourceType.SMART_GATEWAYS_ADAPTER,
-                              AiidaAsset.SUBMETER,
-                              "sma",
-                              true,
-                              null,
-                              null,
-                              null),
+            new DataSourceDto(DATA_SOURCE_ID, DataSourceType.SMART_GATEWAYS_ADAPTER, AiidaAsset.SUBMETER, "sma", true, null, null, null),
             USER_ID,
-            new DataSourceMqttDto("tcp://localhost:1883",
-                                  "tcp://localhost:1883",
-                                  "aiida/test",
-                                  "user",
-                                  "password")
+            new DataSourceMqttDto("tcp://localhost:1883", "tcp://localhost:1883", "aiida/test", "user", "password")
     );
+
     private SmartGatewaysAdapter adapter;
 
     @BeforeEach
     void setUp() {
         StepVerifier.setDefaultTimeout(Duration.ofSeconds(1));
-
         adapter = new SmartGatewaysAdapter(DATA_SOURCE);
     }
 
     @AfterEach
     void tearDown() {
-        LOG_CAPTOR.clearLogs();
+        LogCaptor.forClass(SmartGatewaysAdapter.class).clearLogs();
     }
 
     @Test
     void verify_close_disconnectsAndClosesClient_andEmitsCompleteOnFlux() throws MqttException {
         try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
             var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
+            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(any(), any(), any())).thenReturn(mockClient);
             when(mockClient.isConnected()).thenReturn(true);
 
             StepVerifier.create(adapter.start()).then(adapter::close).expectComplete().verify();
@@ -135,12 +66,9 @@ class SmartGatewaysAdapterTest {
 
     @Test
     void verify_whenClientDisconnected_close_doesNotCallDisconnect() throws MqttException {
-        // calling .disconnect() on the MQTT client when it's not connected leads to an exception, therefore ensure to only call when it's connected
-
         try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
             var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
+            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(any(), any(), any())).thenReturn(mockClient);
             when(mockClient.isConnected()).thenReturn(false);
 
             StepVerifier.create(adapter.start()).then(adapter::close).expectComplete().verify();
@@ -155,15 +83,14 @@ class SmartGatewaysAdapterTest {
         try (LogCaptor logCaptor = LogCaptor.forClass(SmartGatewaysAdapter.class)) {
             try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
                 var mockClient = mock(MqttAsyncClient.class);
-                mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                               .thenReturn(mockClient);
-                when(mockClient.disconnect(anyLong())).thenThrow(new MqttException(998877));
+                mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(any(), any(), any())).thenReturn(mockClient);
+                when(mockClient.disconnect(anyLong())).thenThrow(new MqttException(999));
                 when(mockClient.isConnected()).thenReturn(true);
 
                 adapter.start().subscribe();
                 adapter.close();
 
-                assertThat(logCaptor.getWarnLogs()).contains("Error while disconnecting or closing MQTT client");
+                assertThat(logCaptor.getWarnLogs()).anyMatch(log -> log.contains("Error while disconnecting or closing MQTT client"));
             }
         }
     }
@@ -172,8 +99,7 @@ class SmartGatewaysAdapterTest {
     void verify_start_callsConnect() throws MqttException {
         try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
             var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
+            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(any(), any(), any())).thenReturn(mockClient);
 
             adapter.start().subscribe();
 
@@ -188,8 +114,7 @@ class SmartGatewaysAdapterTest {
 
         try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
             var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
+            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(any(), any(), any())).thenReturn(mockClient);
 
             adapter.start().subscribe();
 
@@ -202,71 +127,47 @@ class SmartGatewaysAdapterTest {
     void givenErrorDuringStart_errorPublishedOnFlux() throws MqttException {
         try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
             var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
+            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(any(), any(), any())).thenReturn(mockClient);
             when(mockClient.connect(any())).thenThrow(new MqttException(998877));
 
             StepVerifier.create(adapter.start())
-                        .expectErrorMatches(throwable -> ((MqttException) throwable).getReasonCode() == 998877)
+                        .expectErrorMatches(t -> ((MqttException) t).getReasonCode() == 998877)
                         .verify();
         }
     }
 
     @Test
-    void givenRecordFromMqttBroker_isPublishedOnFluxTariff1() {
+    void givenBatchCompleted_emitsAiidaRecord() {
         try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
             var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
+            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(any(), any(), any())).thenReturn(mockClient);
 
-            MqttMessage message = new MqttMessage(TEST_MESSAGE_TARIFF_1.getBytes(StandardCharsets.UTF_8));
-
-            StepVerifier.create(adapter.start())
-                        // call method to simulate arrived message
-                        .then(() -> adapter.messageArrived("sga/data", message))
-                        .expectNextMatches(received -> received.aiidaRecordValues()
-                                                               .stream()
-                                                               .anyMatch(aiidaRecordValue -> (
-                                                                                                     aiidaRecordValue.dataTag()
-                                                                                                                     .equals(POSITIVE_ACTIVE_INSTANTANEOUS_POWER) &&
-                                                                                                     aiidaRecordValue.value()
-                                                                                                                     .equals("0.445")) ||
-                                                                                             (aiidaRecordValue.dataTag()
-                                                                                                              .equals(POSITIVE_ACTIVE_ENERGY) && aiidaRecordValue.value()
-                                                                                                                                                                 .equals("3845.467"))))
+            StepVerifier.create(adapter.start()).then(() -> {
+                            for (SmartGatewaysTopic t : SmartGatewaysTopic.values()) {
+                                if (t.isExpected()) {
+                                    send(t.topic(), "45");
+                                }
+                            }
+                        })
+                        .expectNextMatches(record ->
+                                           record.aiidaRecordValues()
+                                                 .stream()
+                                                 .anyMatch(v -> v.dataTag()
+                                                                 .equals(POSITIVE_ACTIVE_ENERGY) && v.value().equals("45"))
+                                           && record.aiidaRecordValues()
+                                                    .stream()
+                                                    .anyMatch(v -> v.dataTag()
+                                                                    .equals(POSITIVE_ACTIVE_INSTANTANEOUS_POWER) && v.value().equals("45"))
+                        )
                         .then(adapter::close)
                         .expectComplete()
-                        .log()
                         .verify();
         }
     }
 
-    @Test
-    void givenRecordFromMqttBroker_isPublishedOnFluxTariff2() {
-        try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
-            var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
-
-            MqttMessage message = new MqttMessage(TEST_MESSAGE_TARIFF_2.getBytes(StandardCharsets.UTF_8));
-
-            StepVerifier.create(adapter.start())
-                        // call method to simulate arrived message
-                        .then(() -> adapter.messageArrived("sga/data", message))
-                        .expectNextMatches(received -> received.aiidaRecordValues()
-                                                               .stream()
-                                                               .anyMatch(aiidaRecordValue -> (aiidaRecordValue.dataTag()
-                                                                                                              .equals(POSITIVE_ACTIVE_INSTANTANEOUS_POWER) &&
-                                                                                              aiidaRecordValue.value()
-                                                                                                              .equals("0.030")) ||
-                                                                                             (aiidaRecordValue.dataTag()
-                                                                                                              .equals(POSITIVE_ACTIVE_ENERGY) &&
-                                                                                              aiidaRecordValue.value()
-                                                                                                              .equals("1894.882"))))
-                        .then(adapter::close)
-                        .expectComplete()
-                        .log()
-                        .verify();
-        }
+    private void send(String topicSuffix, String value) {
+        String topic = "aiida/" + topicSuffix;
+        MqttMessage message = new MqttMessage(value.getBytes(StandardCharsets.UTF_8));
+        adapter.messageArrived(topic, message);
     }
 }


### PR DESCRIPTION
SGA sends each message field in its own topic
-  E.g.: aiida/dsmr/reading/electricity_equipment_id
- Added a buffer to wait till all topics for a message are stored before processing
- Added a timeout of 15s in case a some topics are missing (process it with the arrived fields)

Subscribe to wildcard topic
- subscribe to AcQY334Z4Q/dsmr/reading/+
- The prefix is coming from the `MqttSecretGenerator`
- This prefix need to be inserted in the SGA MQTT Prefix settings (maximum length of 10 characters)