### PR TITLE
NOISSUE EDA: Filter out data from terminated and revoked permissions

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/persistence/JpaPermissionRequestRepository.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/persistence/JpaPermissionRequestRepository.java
@@ -114,11 +114,6 @@ public interface JpaPermissionRequestRepository extends PagingAndSortingReposito
           AND status IN (
               'ACCEPTED',
               'FULFILLED',
-              'REVOKED',
-              'TERMINATED',
-              'REQUIRES_EXTERNAL_TERMINATION',
-              'EXTERNALLY_TERMINATED',
-              'FAILED_TO_TERMINATE',
               'SENT_TO_PERMISSION_ADMINISTRATOR'
           );
     """, nativeQuery = true)


### PR DESCRIPTION
At INNOnet we had the problem, that terminated permissions still forwarded data. The terminiation request was sent to the DSO, but they didn't terminate it in their system.

With that fix, EDDIE won't forward those messages to the EP anymore.