### PR TITLE
GH-1800 Optimize fulfillment query for EDA

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/projections/MeterReadingTimeframe.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/permission/request/projections/MeterReadingTimeframe.java
@@ -1,24 +1,12 @@
 package energy.eddie.regionconnector.at.eda.permission.request.projections;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-
 import java.time.LocalDate;
 import java.util.Objects;
 
-@Entity
-@Table(schema = "at_eda", name = "meter_reading_timeframe")
 public class MeterReadingTimeframe {
-    @Id
-    @Column(name = "id")
     private final Long id;
-    @Column(name = "permission_id")
     private final String permissionId;
-    @Column(name = "meter_reading_start")
     private final LocalDate start;
-    @Column(name = "meter_reading_end")
     private final LocalDate end;
 
     public MeterReadingTimeframe(Long id, String permissionId, LocalDate start, LocalDate end) {
@@ -34,6 +22,10 @@ public class MeterReadingTimeframe {
         permissionId = null;
         start = null;
         end = null;
+    }
+
+    public Long id() {
+        return id;
     }
 
     public String permissionId() {

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/persistence/MeterReadingTimeframeRepository.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/persistence/MeterReadingTimeframeRepository.java
@@ -1,12 +1,80 @@
 package energy.eddie.regionconnector.at.eda.persistence;
 
-
 import energy.eddie.regionconnector.at.eda.permission.request.projections.MeterReadingTimeframe;
-import org.springframework.data.repository.Repository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Tuple;
+import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 
-@org.springframework.stereotype.Repository
-public interface MeterReadingTimeframeRepository extends Repository<MeterReadingTimeframe, Long> {
-    List<MeterReadingTimeframe> findAllByPermissionId(String permissionId);
+@Repository
+public class MeterReadingTimeframeRepository {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    public MeterReadingTimeframeRepository(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public List<MeterReadingTimeframe> findAllByPermissionId(String permissionId) {
+        String permissionsQuery = """
+        WITH ordered_data AS (SELECT permission_id,
+                                     meter_reading_start,
+                                     meter_reading_end,
+                                     LAG(permission_event.meter_reading_start)
+                                     OVER (PARTITION BY permission_id ORDER BY meter_reading_end, meter_reading_start) AS prev_start_date,
+                                     LAG(meter_reading_end)
+                                     OVER (PARTITION BY permission_id ORDER BY meter_reading_end, meter_reading_start) AS prev_end_date
+                              FROM at_eda.permission_event
+                              WHERE dtype = 'DataReceivedEvent' -- Only get the corresponding events to not iterate over all events
+                                AND permission_id = :permissionId
+                                AND permission_event.meter_reading_end IS NOT NULL
+                                AND permission_event.meter_reading_start IS NOT NULL),
+             grouped_data AS (
+                 -- Create a group when the current row is NOT consecutive or overlapping with the previous row
+                 SELECT permission_id,
+                        meter_reading_start,
+                        meter_reading_end,
+                        prev_end_date,
+                        SUM(
+                        CASE
+                            WHEN meter_reading_start > prev_end_date + INTERVAL '1 day'
+                                THEN 1
+                            ELSE 0
+                            END
+                           ) OVER (PARTITION BY permission_id ORDER BY meter_reading_end, meter_reading_start) AS group_id
+                 FROM ordered_data)
+        -- Aggregate by group_id to get final merged intervals
+        SELECT permission_id,
+               MIN(meter_reading_start) AS meter_reading_start,
+               MAX(meter_reading_end)   AS meter_reading_end,
+               ROW_NUMBER() OVER ()     AS id
+        FROM grouped_data
+        GROUP BY permission_id, group_id
+        ORDER BY permission_id, meter_reading_start, meter_reading_end;
+        """;
+
+        List<?> permissions = entityManager
+                .createNativeQuery(permissionsQuery, Tuple.class)
+                .setParameter("permissionId", permissionId)
+                .getResultList();
+
+        List<MeterReadingTimeframe> timeframes = new ArrayList<>();
+        for (Object obj : permissions) {
+            var tuple = (Tuple) obj;
+            timeframes.add(new MeterReadingTimeframe(
+                    ((Number) tuple.get("id")).longValue(),
+                    tuple.get("permission_id", String.class),
+                    tuple.get("meter_reading_start", Instant.class).atZone(ZoneId.systemDefault()).toLocalDate(),
+                    tuple.get("meter_reading_end", Instant.class).atZone(ZoneId.systemDefault()).toLocalDate()
+            ));
+        }
+
+        return timeframes;
+    }
 }

--- a/region-connectors/region-connector-at-eda/src/main/resources/db/migration/at-eda/V1_4__remove_unused_meter_reading_view.sql
+++ b/region-connectors/region-connector-at-eda/src/main/resources/db/migration/at-eda/V1_4__remove_unused_meter_reading_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS at_eda.meter_reading_timeframe;

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/persistence/MeterReadingTimeframeRepositoryTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/persistence/MeterReadingTimeframeRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MeterReadingTimeframeRepository.class)
 @Testcontainers
 class MeterReadingTimeframeRepositoryTest {
     @SuppressWarnings("unused")


### PR DESCRIPTION
Filter permissionId directly in the `permission_event` table instead of getting all permissions and filtering afterwards.

Therefore the query cost goes down from `300k` to `1k`.