### PR TITLE
NOISSUE Ensure EDDIE button dialog does not inherit text alignment

### DIFF
--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -134,6 +134,7 @@ class EddieConnectButton extends LitElement {
           ‘Segoe UI Symbol’;
         font-size: 16px;
         font-weight: normal;
+        text-align: left;
       }
 
       .eddie-connect-button {


### PR DESCRIPTION
Annoyed in the UVIE demonstrator during the EEAB meeting.