### PR TITLE
GH-1823 Admin Console: correct favicon path

### DIFF
--- a/admin-console/ui/index.html
+++ b/admin-console/ui/index.html
@@ -6,7 +6,7 @@
     /*/-->
 
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.svg" />
+    <link rel="icon" href="public/favicon.svg" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 
     <script th:inline="javascript">


### PR DESCRIPTION
Correct the path of the favicon of the admin console.

![image](https://github.com/user-attachments/assets/fc037e0b-8c19-48b5-8e8b-19150598fdba)
