### PR TITLE
NOISSUE CIM: Increase version of the CIM module, so the new package can be published

### DIFF
--- a/cim/CHANGELOG.md
+++ b/cim/CHANGELOG.md
@@ -23,7 +23,7 @@ For more information, see [Common Information Model Client Libraries](https://ed
 ## 2.0.1 - 2025-05-27
 
 - Change artifact ID to `cim` from `cim-test`
-- Set correct version for the artifact
+- Set the correct version for the artifact
 
 ## 2.1.0 - 2025-06-30
 

--- a/cim/README.md
+++ b/cim/README.md
@@ -1,5 +1,7 @@
 # Information on adding a new CIM schema
 
+**IMPORTANT**: Update the version attribute in the cim `build.gradle.kts`.
+
 ## Look for imports
 
 1. If there are imports inside the xsd file (e.g.

--- a/cim/build.gradle.kts
+++ b/cim/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "energy.eddie"
-version = "2.0.1"
+version = "2.1.0"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
In #1834 the version of the CIM schema was changed in tandem with the changelog, but the version attribute of the `cim/build.gradle.kts` was not updated leading to a failing of the publish workflow.