### PR TITLE
NOISSUE eda rc: update master data schema to support 01.33

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/MultiMasterDataInboundMessageFactory.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/MultiMasterDataInboundMessageFactory.java
@@ -1,0 +1,61 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata;
+
+import energy.eddie.regionconnector.at.eda.dto.EdaMasterData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.oxm.XmlMappingException;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.Set;
+
+public class MultiMasterDataInboundMessageFactory implements EdaMasterDataInboundMessageFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultiMasterDataInboundMessageFactory.class);
+    private final Set<EdaMasterDataInboundMessageFactory> factories;
+
+    public MultiMasterDataInboundMessageFactory(Set<EdaMasterDataInboundMessageFactory> factories) {this.factories = factories;}
+
+    @Override
+    public EdaMasterData parseInputStream(InputStream inputStream) {
+        var is = new UnclosableBufferedInputStream(inputStream);
+        for (var factory : factories) {
+            try {
+                var res = factory.parseInputStream(is);
+                is.forceClose();
+                return res;
+            } catch (Exception e) {
+                LOGGER.info("Failed to parse master data from input stream, retrying...", e);
+            }
+        }
+        is.forceClose();
+        LOGGER.warn("Failed to parse master data from input stream.");
+        throw new XmlMappingException("Unable to parse master data") {};
+    }
+
+    @Override
+    public boolean isActive(LocalDate date) {
+        return false;
+    }
+
+    private static class UnclosableBufferedInputStream extends BufferedInputStream {
+        public UnclosableBufferedInputStream(InputStream in) {
+            super(in);
+            super.mark(Integer.MAX_VALUE);
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.reset();
+        }
+
+        public void forceClose() {
+            try {
+                super.close();
+            } catch (IOException e) {
+                LOGGER.warn("Failed to close input stream", e);
+            }
+        }
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/Address01p33.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/Address01p33.java
@@ -1,0 +1,57 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.StreetC;
+import energy.eddie.regionconnector.at.eda.dto.masterdata.Address;
+import jakarta.annotation.Nullable;
+
+public record Address01p33(
+        at.ebutilities.schemata.customerprocesses.masterdata._01p33.Address address) implements Address {
+    @Nullable
+    @Override
+    public String zipCode() {
+        var zip = address.getZIP();
+        return zip == null ? null : zip.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String city() {
+        var city = address.getCity();
+        return city == null ? null : city.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String street() {
+        StreetC street = address.getStreet();
+        return street == null ? null : street.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String streetNumber() {
+        var streetNo = address.getStreetNo();
+        return streetNo == null ? null : streetNo.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String staircase() {
+        var staircase = address.getStaircase();
+        return staircase == null ? null : staircase.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String floor() {
+        var floor = address.getFloor();
+        return floor == null ? null : floor.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String door() {
+        var door = address.getDoorNumber();
+        return door == null ? null : door.getValue();
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/BillingData01p33.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/BillingData01p33.java
@@ -1,0 +1,51 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import energy.eddie.regionconnector.at.eda.dto.masterdata.BillingData;
+import jakarta.annotation.Nullable;
+
+public record BillingData01p33(
+        at.ebutilities.schemata.customerprocesses.masterdata._01p33.BillingData billingData) implements BillingData {
+    @Override
+    public String referenceNumber() {
+        return billingData.getReferenceNumber();
+    }
+
+    @Override
+    @Nullable
+    public String gridInvoiceRecipient() {
+        var gridInvoiceRecipient = billingData.getGridInvoiceRecipient();
+        return gridInvoiceRecipient == null ? null : gridInvoiceRecipient.getValue().value();
+    }
+
+    @Override
+    @Nullable
+    public String budgetBillingCycle() {
+        var budgetBillingCycle = billingData.getBudgetBillingCycle();
+        return budgetBillingCycle == null ? null : budgetBillingCycle.getValue();
+    }
+
+    @Override
+    public short meterReadingMonth() {
+        var meterReadingMonth = billingData.getMeterReadingMonth();
+        return meterReadingMonth == null ? 0 : meterReadingMonth.getValue();
+    }
+
+    @Override
+    @Nullable
+    public String consumptionBillingCycle() {
+        var consumptionBillingCycle = billingData.getConsumptionBillingCycle();
+        return consumptionBillingCycle == null ? null : consumptionBillingCycle.getValue();
+    }
+
+    @Override
+    public short consumptionBillingMonth() {
+        var consumptionBillingMonth = billingData.getConsumptionBillingMonth();
+        return consumptionBillingMonth == null ? 0 : consumptionBillingMonth.getValue();
+    }
+
+    @Override
+    @Nullable
+    public String yearMonthOfNextBill() {
+        return billingData.getYearMonthOfNextBill();
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/ContractPartner01p33.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/ContractPartner01p33.java
@@ -1,0 +1,82 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.NameC;
+import energy.eddie.regionconnector.at.eda.dto.masterdata.ContractPartner;
+import jakarta.annotation.Nullable;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.stream.Stream;
+
+public record ContractPartner01p33(
+        at.ebutilities.schemata.customerprocesses.masterdata._01p33.ContractPartner contractPartner) implements ContractPartner {
+    @Override
+    @Nullable
+    public String salutation() {
+        return contractPartner.getSalutation();
+    }
+
+    @Override
+    @Nullable
+    public String surname() {
+        return getName(contractPartner.getName1());
+    }
+
+    @Override
+    @Nullable
+    public String firstName() {
+        return getName(contractPartner.getName2());
+    }
+
+    @Nullable
+    @Override
+    public String companyName() {
+        return Stream.of(
+                             getName(contractPartner.getName1()),
+                             getName(contractPartner.getName2())
+                     )
+                     .filter(name -> name != null && !name.isBlank())
+                     .reduce((a, b) -> a + " " + b)
+                     .orElse(null);
+    }
+
+    @Override
+    @Nullable
+    public String contractPartnerNumber() {
+        return contractPartner.getContractPartnerNumber();
+    }
+
+    @Override
+    @Nullable
+    public XMLGregorianCalendar dateOfBirth() {
+        return contractPartner.getDateOfBirth();
+    }
+
+    @Override
+    @Nullable
+    public XMLGregorianCalendar dateOfDeath() {
+        return contractPartner.getDateOfDeath();
+    }
+
+    @Override
+    @Nullable
+    public String companyRegisterNumber() {
+        return contractPartner.getCompanyRegistryNo();
+    }
+
+    @Override
+    @Nullable
+    public String vatNumber() {
+        return contractPartner.getVATNumber();
+    }
+
+    @Override
+    @Nullable
+    public String email() {
+        return contractPartner.getEmail();
+    }
+
+    @Nullable
+    private String getName(NameC name) {
+        return name != null ? name.getValue() : null;
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/DeliveryAddress01p33.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/DeliveryAddress01p33.java
@@ -1,0 +1,64 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.StreetC;
+import energy.eddie.regionconnector.at.eda.dto.masterdata.DeliveryAddress;
+import jakarta.annotation.Nullable;
+
+public record DeliveryAddress01p33(
+        at.ebutilities.schemata.customerprocesses.masterdata._01p33.DeliveryAddress deliveryAddress) implements DeliveryAddress {
+    @Nullable
+    @Override
+    public String zipCode() {
+        var zip = deliveryAddress.getZIP();
+        return zip == null ? null : zip.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String city() {
+        var city = deliveryAddress.getCity();
+        return city == null ? null : city.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String street() {
+        StreetC street = deliveryAddress.getStreet();
+        return street == null ? null : street.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String streetNumber() {
+        var streetNo = deliveryAddress.getStreetNo();
+        return streetNo == null ? null : streetNo.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String staircase() {
+        var staircase = deliveryAddress.getStaircase();
+        return staircase == null ? null : staircase.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String floor() {
+        var floor = deliveryAddress.getFloor();
+        return floor == null ? null : floor.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String door() {
+        var door = deliveryAddress.getDoorNumber();
+        return door == null ? null : door.getValue();
+    }
+
+    @Nullable
+    @Override
+    public String addressAddition() {
+        var addressAddition = deliveryAddress.getDeliveryAddressData();
+        return addressAddition == null ? null : addressAddition.getValue();
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/EdaMasterData01p33.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/EdaMasterData01p33.java
@@ -1,0 +1,87 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.MasterData;
+import energy.eddie.regionconnector.at.eda.dto.EdaMasterData;
+import energy.eddie.regionconnector.at.eda.dto.masterdata.*;
+import energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p32.NullMeteringPointData;
+import energy.eddie.regionconnector.at.eda.processing.utils.XmlGregorianCalenderUtils;
+import energy.eddie.regionconnector.at.eda.xml.helper.Sector;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public record EdaMasterData01p33(MasterData masterData) implements EdaMasterData {
+    @Override
+    public String conversationId() {
+        return masterData.getProcessDirectory().getConversationId();
+    }
+
+    @Override
+    public String messageId() {
+        return masterData.getProcessDirectory().getMessageId();
+    }
+
+    @Override
+    public Sector sector() {
+        return Sector.fromValue(masterData.getMarketParticipantDirectory().getSector());
+    }
+
+    @Override
+    public ZonedDateTime documentCreationDateTime() {
+        return XmlGregorianCalenderUtils.toUtcZonedDateTime(masterData.getMarketParticipantDirectory()
+                                                                      .getRoutingHeader()
+                                                                      .getDocumentCreationDateTime());
+    }
+
+    @Override
+    public String senderMessageAddress() {
+        return masterData.getMarketParticipantDirectory().getRoutingHeader().getSender().getMessageAddress();
+    }
+
+    @Override
+    public String receiverMessageAddress() {
+        return masterData.getMarketParticipantDirectory().getRoutingHeader().getReceiver().getMessageAddress();
+    }
+
+    @Override
+    public String meteringPoint() {
+        return masterData.getProcessDirectory().getMeteringPoint();
+    }
+
+    @Override
+    public MeteringPointData meteringPointData() {
+        var meteringPointData = masterData.getProcessDirectory().getMeteringPointData();
+        return meteringPointData == null
+                ? new NullMeteringPointData()
+                : new MeteringPointData01p33(meteringPointData);
+    }
+
+    @Override
+    public Optional<BillingData> billingData() {
+        var billingData = masterData.getProcessDirectory().getBillingData();
+        return billingData == null ? Optional.empty() : Optional.of(new BillingData01p33(billingData));
+    }
+
+    @Override
+    public Optional<ContractPartner> contractPartner() {
+        var contractPartner = masterData.getProcessDirectory().getContractPartner();
+        return contractPartner == null ? Optional.empty() : Optional.of(new ContractPartner01p33(contractPartner));
+    }
+
+    @Override
+    public Optional<DeliveryAddress> installationAddress() {
+        var installationAddress = masterData.getProcessDirectory().getDeliveryAddress();
+        return installationAddress == null ? Optional.empty() : Optional.of(new DeliveryAddress01p33(installationAddress));
+    }
+
+    @Override
+    public Optional<InvoiceRecipient> invoiceRecipient() {
+        var invoiceRecipient = masterData.getProcessDirectory().getInvoiceRecipient();
+        return invoiceRecipient == null ? Optional.empty() : Optional.of(new InvoiceRecipient01p33(invoiceRecipient));
+    }
+
+    @Override
+    public Object originalMasterData() {
+        return masterData;
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/EdaMasterData01p33InboundMessageFactory.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/EdaMasterData01p33InboundMessageFactory.java
@@ -1,0 +1,36 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.MasterData;
+import energy.eddie.regionconnector.at.eda.dto.EdaMasterData;
+import energy.eddie.regionconnector.at.eda.ponton.messages.masterdata.EdaMasterDataInboundMessageFactory;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.springframework.stereotype.Component;
+
+import javax.xml.transform.stream.StreamSource;
+import java.io.InputStream;
+import java.time.LocalDate;
+
+@Component
+public class EdaMasterData01p33InboundMessageFactory implements EdaMasterDataInboundMessageFactory {
+    /**
+     * The active from date of the message. The message is active from this date.
+     * <p>From <a href="https://www.ebutilities.at/schemas/234">ebutilities</a>
+     */
+    private static final LocalDate ACTIVE_FROM = LocalDate.of(2025, 4, 7);
+    private final Jaxb2Marshaller marshaller;
+
+    public EdaMasterData01p33InboundMessageFactory(Jaxb2Marshaller marshaller) {
+        this.marshaller = marshaller;
+    }
+
+    @Override
+    public boolean isActive(LocalDate date) {
+        return !ACTIVE_FROM.isAfter(date);
+    }
+
+    @Override
+    public EdaMasterData parseInputStream(InputStream inputStream) {
+        var masterData = (MasterData) marshaller.unmarshal(new StreamSource(inputStream));
+        return new EdaMasterData01p33(masterData);
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/InvoiceRecipient01p33.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/InvoiceRecipient01p33.java
@@ -1,0 +1,18 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import energy.eddie.regionconnector.at.eda.dto.masterdata.Address;
+import energy.eddie.regionconnector.at.eda.dto.masterdata.ContractPartner;
+import energy.eddie.regionconnector.at.eda.dto.masterdata.InvoiceRecipient;
+
+public record InvoiceRecipient01p33(
+        at.ebutilities.schemata.customerprocesses.masterdata._01p33.InvoiceRecipient invoiceRecipient) implements InvoiceRecipient {
+    @Override
+    public ContractPartner contractPartner() {
+        return new ContractPartner01p33(invoiceRecipient.getPartnerData());
+    }
+
+    @Override
+    public Address address() {
+        return new Address01p33(invoiceRecipient.getAddressData());
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/MeteringPointData01p33.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/MeteringPointData01p33.java
@@ -1,0 +1,64 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.regionconnector.at.eda.dto.masterdata.MeteringPointData;
+import energy.eddie.regionconnector.at.eda.xml.helper.EnergyDirection;
+import jakarta.annotation.Nullable;
+
+import static at.ebutilities.schemata.customerprocesses.masterdata._01p33.DeviceType.IME;
+
+public record MeteringPointData01p33(
+        at.ebutilities.schemata.customerprocesses.masterdata._01p33.MeteringPointData meteringPointData) implements MeteringPointData {
+
+    @Override
+    @Nullable
+    public String supStatus() {
+        var supStatus = meteringPointData.getSupStatus();
+        return supStatus == null ? null : supStatus.value();
+    }
+
+    @Override
+    @Nullable
+    public String dsoTariff() {
+        var dsoTariffClass = meteringPointData.getDSOTariffClass();
+        return dsoTariffClass == null ? null : dsoTariffClass.getValue().value();
+    }
+
+    @Override
+    public EnergyDirection energyDirection() {
+        return switch (meteringPointData.getEnergyDirection()) {
+            case CONSUMPTION -> EnergyDirection.CONSUMPTION;
+            case GENERATION -> EnergyDirection.GENERATION;
+        };
+    }
+
+    @Override
+    @Nullable
+    public String energyCommunity() {
+        var energyCommunity = meteringPointData.getEnergyCommunity();
+        return energyCommunity == null ? null : energyCommunity.getValue().value();
+    }
+
+    @Override
+    @Nullable
+    public String typeOfGeneration() {
+        var typeOfGeneration = meteringPointData.getTypeOfGeneration();
+        return typeOfGeneration == null ? null : typeOfGeneration.getValue().value();
+    }
+
+    @Override
+    @Nullable
+    public String loadProfileType() {
+        var loadProfileType = meteringPointData.getLoadProfileType();
+        return loadProfileType == null ? null : loadProfileType.getValue();
+    }
+
+    @Override
+    public Granularity granularity() {
+        var deviceType = meteringPointData.getDeviceType();
+        if (deviceType == null) {
+            return Granularity.P1D;
+        }
+        return deviceType.getValue() == IME ? Granularity.PT15M : Granularity.P1D;
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/schemas/eda/xsd/MasterData_01p33.xsd
+++ b/region-connectors/region-connector-at-eda/src/main/schemas/eda/xsd/MasterData_01p33.xsd
@@ -1,0 +1,900 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Mit XMLSpy v2020 rel. 2 sp1 (x64) (http://www.altova.com) von Illwerke VKW Aktiengesellschaft (illwerke vkw Aktiengesellschaft) bearbeitet -->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:ct="http://www.ebutilities.at/schemata/customerprocesses/common/types/01p20"
+            xmlns:cp="http://www.ebutilities.at/schemata/customerprocesses/masterdata/01p33"
+            targetNamespace="http://www.ebutilities.at/schemata/customerprocesses/masterdata/01p33"
+            elementFormDefault="qualified">
+    <xsd:import namespace="http://www.ebutilities.at/schemata/customerprocesses/common/types/01p20"
+                schemaLocation="CPCommonTypes_01p20.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>
+            schema version: 01.33
+            autor: Reinhold Hansmann
+            valid from: 2025-04
+            changes:
+            MeteringPointData:
+            Zählwerkskennung optional
+            Zonen-IDs für EEG
+            ContractPartner:
+            Änderung Namensfelder
+            Aufnahme Telefonnummer
+            Adressdaten:
+            Einführung Country
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:element name="MasterData">
+        <xsd:annotation>
+            <xsd:documentation>Datenabgleich</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="MarketParticipantDirectory" type="cp:MarketParticipantDirectory"/>
+                <xsd:element name="ProcessDirectory" type="cp:ProcessDirectory"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:complexType name="MarketParticipantDirectory">
+        <xsd:complexContent>
+            <xsd:extension base="ct:MarketParticipantDirectory">
+                <xsd:sequence>
+                    <xsd:element name="MessageCode" type="ct:MessageCode"/>
+                </xsd:sequence>
+                <xsd:attribute name="SchemaVersion" use="required">
+                    <xsd:simpleType>
+                        <xsd:restriction base="xsd:token">
+                            <xsd:enumeration value="01.33"/>
+                        </xsd:restriction>
+                    </xsd:simpleType>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="ProcessDirectory">
+        <xsd:complexContent>
+            <xsd:extension base="ct:ProcessDirectory">
+                <xsd:sequence>
+                    <xsd:element name="ContractPartner" type="cp:ContractPartner" minOccurs="0"/>
+                    <xsd:element name="DeliveryAddress" type="cp:DeliveryAddress" minOccurs="0"/>
+                    <xsd:element name="BillingData" type="cp:BillingData" minOccurs="0"/>
+                    <xsd:element name="MeteringPointData" type="cp:MeteringPointData" minOccurs="0"/>
+                    <xsd:element name="InvoiceRecipient" type="cp:InvoiceRecipient" minOccurs="0"/>
+                    <xsd:element name="AdditionalData" type="ct:AdditionalData" minOccurs="0" maxOccurs="1000"/>
+                    <xsd:element name="VerificationDocument" type="ct:VerificationDocument" minOccurs="0"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="Address">
+        <xsd:annotation>
+            <xsd:documentation>Adresse</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="Country" type="cp:Country"/>
+            <xsd:element name="ZIP" type="cp:ZIPC"/>
+            <xsd:element name="City" type="cp:CityC"/>
+            <xsd:element name="POBoxNo" type="cp:POBoxNoC" minOccurs="0"/>
+            <xsd:element name="Street" type="cp:StreetC" minOccurs="0"/>
+            <xsd:element name="StreetNo" type="cp:StreetNoC" minOccurs="0"/>
+            <xsd:element name="Staircase" type="cp:StaircaseC" minOccurs="0"/>
+            <xsd:element name="Floor" type="cp:FloorC" minOccurs="0"/>
+            <xsd:element name="DoorNumber" type="cp:DoorNumberC" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BillingData">
+        <xsd:annotation>
+            <xsd:documentation>Abrechnungsdaten</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="ReferenceNumber" type="cp:ReferenceNumber" minOccurs="0"/>
+            <xsd:element name="GridInvoiceRecipient" type="cp:GridInvoiceRecipientC"/>
+            <xsd:element name="BudgetBillingCycle" type="cp:BudgetBillingCycleC" minOccurs="0"/>
+            <xsd:element name="MeterReadingMonth" type="cp:Months_0C" minOccurs="0"/>
+            <xsd:element name="ConsumptionBillingCycle" type="cp:ConsumptionBillingCycleC" minOccurs="0"/>
+            <xsd:element name="ConsumptionBillingMonth" type="cp:Months_0C" minOccurs="0"/>
+            <xsd:element name="YearMonthOfNextBill" type="cp:YearMonth" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BudgetBillingCycleC">
+        <xsd:annotation>
+            <xsd:documentation>Abschlagszyklus - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:BudgetBillingCycle">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="CityC">
+        <xsd:annotation>
+            <xsd:documentation>Ort - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:City">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="ConsumptionBillingCycleC">
+        <xsd:annotation>
+            <xsd:documentation>Abrechnungszyklus - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:ConsumptionBillingCycle">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="ContractPartner">
+        <xsd:annotation>
+            <xsd:documentation>Kundendaten</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="Salutation" type="cp:Salutation" minOccurs="0"/>
+            <xsd:element name="Name1" type="cp:NameC">
+                <xsd:annotation>
+                    <xsd:documentation>Familienname / Firmenname Teil1</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Name2" type="cp:NameC" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Vorname / Firmenname Teil2</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ContractPartnerNumber" type="cp:ContractPartnerNumber" minOccurs="0"/>
+            <xsd:element name="DateOfBirth" type="xsd:date" minOccurs="0"/>
+            <xsd:element name="DateOfDeath" type="xsd:date" minOccurs="0"/>
+            <xsd:element name="CompanyRegistryNo" type="cp:CompanyRegistryNo" minOccurs="0"/>
+            <xsd:element name="VATNumber" type="cp:VATNumber" minOccurs="0"/>
+            <xsd:element name="Email" type="cp:Email" minOccurs="0"/>
+            <xsd:element name="Phone" type="cp:Phone" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DeliveryAddress">
+        <xsd:annotation>
+            <xsd:documentation>Lieferadresse</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="Country" type="cp:Country"/>
+            <xsd:element name="ZIP" type="cp:ZIPC"/>
+            <xsd:element name="City" type="cp:CityC"/>
+            <xsd:element name="Street" type="cp:StreetC"/>
+            <xsd:element name="StreetNo" type="cp:StreetNoC"/>
+            <xsd:element name="Staircase" type="cp:StaircaseC" minOccurs="0"/>
+            <xsd:element name="Floor" type="cp:FloorC" minOccurs="0"/>
+            <xsd:element name="DoorNumber" type="cp:DoorNumberC" minOccurs="0"/>
+            <xsd:element name="DeliveryAddressData" type="cp:DeliveryAddressDataC" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DeliveryAddressDataC">
+        <xsd:annotation>
+            <xsd:documentation>Adresszusatz - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:DeliveryAddressData">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="Device">
+        <xsd:annotation>
+            <xsd:documentation>Gerät</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="DeviceNumber" type="cp:DeviceNumberC"/>
+            <xsd:element name="MeterCode" type="cp:MeterCode" minOccurs="0" maxOccurs="1000"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DeviceNumberC">
+        <xsd:annotation>
+            <xsd:documentation>Gerätenummer - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:DeviceNumber">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="DeviceTypeC">
+        <xsd:annotation>
+            <xsd:documentation>Gerätetyp - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:DeviceType">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="DoorNumberC">
+        <xsd:annotation>
+            <xsd:documentation>Türnummer - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:DoorNumber">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="ElectricityGridLevelC">
+        <xsd:annotation>
+            <xsd:documentation>Spannungsebene - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:ElectricityGridLevel">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="ElectricitySpecificData">
+        <xsd:annotation>
+            <xsd:documentation>stromspezifische ZP-Daten</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="GridUsageLevel" type="cp:ElectricityGridLevelC"/>
+            <xsd:element name="GridLossLevel" type="cp:ElectricityGridLevelC"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="FloorC">
+        <xsd:annotation>
+            <xsd:documentation>Stock - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:Floor">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="GasGridLevelC">
+        <xsd:annotation>
+            <xsd:documentation>Gasnetzebene - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:GasGridLevel">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="GasSpecificData">
+        <xsd:annotation>
+            <xsd:documentation>gasspezifische ZP-Daten</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="PeakPower" type="cp:PeakPowerC"/>
+            <xsd:element name="GridUsageLevel" type="cp:GasGridLevelC"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="GridInvoiceRecipientC">
+        <xsd:annotation>
+            <xsd:documentation>Netzrechnungsempfänger - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:GridInvoiceRecipient">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="InvoiceRecipient">
+        <xsd:annotation>
+            <xsd:documentation>Rechnungsempfänger</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="PartnerData" type="cp:ContractPartner"/>
+            <xsd:element name="AddressData" type="cp:Address"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="LoadProfileTypeC">
+        <xsd:annotation>
+            <xsd:documentation>Lastprofiltyp - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:LoadProfileType">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="MeteringPointData">
+        <xsd:annotation>
+            <xsd:documentation>ZP-Daten</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="DeviceType" type="cp:DeviceTypeC"/>
+            <xsd:element name="TransmissionCycle" type="cp:TransmissionCycleC" minOccurs="0"/>
+            <xsd:element name="Device" type="cp:Device" minOccurs="0" maxOccurs="1000"/>
+            <xsd:element name="SupStatus" type="cp:SupStatus"/>
+            <xsd:element name="DSOTariffClass" type="cp:DSOTariffClassC"/>
+            <xsd:element name="EnergyDirection" type="cp:EnergyDirection"/>
+            <xsd:element name="EnergyCommunity" type="cp:EnergyCommunityC"/>
+            <xsd:element name="TypeOfGeneration" type="cp:TypeOfGenerationC"/>
+            <xsd:element name="ShortageCapacity" type="cp:ShortageCapacityC" minOccurs="0"/>
+            <xsd:element name="ForecastConsumption" type="cp:ForecastConsumption"/>
+            <xsd:element name="SupplyOfLastResort" type="cp:SupplyOfLastResort"/>
+            <xsd:element name="LoadProfileType" type="cp:LoadProfileTypeC"/>
+            <xsd:element name="LocalID" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>ID lokale EEG</xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                        <xsd:minLength value="1"/>
+                        <xsd:maxLength value="100"/>
+                        <xsd:whiteSpace value="collapse"/>
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:element>
+            <xsd:element name="RegionalID" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>ID regionale EEG</xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                        <xsd:minLength value="1"/>
+                        <xsd:maxLength value="100"/>
+                        <xsd:whiteSpace value="collapse"/>
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:element>
+            <xsd:choice>
+                <xsd:element name="ElectricitySpecificData" type="cp:ElectricitySpecificData" minOccurs="0"/>
+                <xsd:element name="GasSpecificData" type="cp:GasSpecificData" minOccurs="0"/>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DSOTariffClassC">
+        <xsd:annotation>
+            <xsd:documentation>Tarifklasse Netzbetreiber (lt. SNVo) - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:DSOTariffClass">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="ECData">
+        <xsd:annotation>
+            <xsd:documentation>Daten einer Energiegemeinschaft</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="ECID" type="ct:MeteringPoint">
+                <xsd:annotation>
+                    <xsd:documentation>Energiegemeinschafts-ID</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ECPartitionModell" type="cp:PartitionModell">
+                <xsd:annotation>
+                    <xsd:documentation>Verteilungsmodell</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ECShare" type="cp:ECShare" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Anteil bei statischem Modell von Energiegemeinschaften in Prozent
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="EnergyCommunityC">
+        <xsd:annotation>
+            <xsd:documentation>Energiegemeinschaft - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:EnergyCommunity">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="Months_0C">
+        <xsd:annotation>
+            <xsd:documentation>Anzahl Monate - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:Months_0">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="NameC">
+        <xsd:annotation>
+            <xsd:documentation>Name - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:Name">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="PeakPowerC">
+        <xsd:annotation>
+            <xsd:documentation>Gas-Höchstleistung - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:PeakPower">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="POBoxNoC">
+        <xsd:annotation>
+            <xsd:documentation>Postfach - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="ShortageCapacityC">
+        <xsd:annotation>
+            <xsd:documentation>Engpassleistung - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:ShortageCapacity">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="StaircaseC">
+        <xsd:annotation>
+            <xsd:documentation>Stiege - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:Staircase">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="StreetC">
+        <xsd:annotation>
+            <xsd:documentation>Straße - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:Street">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="StreetNoC">
+        <xsd:annotation>
+            <xsd:documentation>HNr - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:StreetNo">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="TransmissionCycleC">
+        <xsd:annotation>
+            <xsd:documentation>Übertragungsintervall Verbrauchsdaten - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:TransmissionCycle">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="TypeOfGenerationC">
+        <xsd:annotation>
+            <xsd:documentation>Einspeiseart - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:TypeOfGeneration">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="ZIPC">
+        <xsd:annotation>
+            <xsd:documentation>PLZ - mit Änderungskennzeichen</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="cp:ZIP">
+                <xsd:attribute name="Changed" type="xsd:boolean" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:simpleType name="BudgetBillingCycle">
+        <xsd:annotation>
+            <xsd:documentation>Abschlagszyklus</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="00"/>
+            <xsd:enumeration value="01"/>
+            <xsd:enumeration value="02"/>
+            <xsd:enumeration value="03"/>
+            <xsd:enumeration value="04"/>
+            <xsd:enumeration value="06"/>
+            <xsd:enumeration value="12"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="City">
+        <xsd:annotation>
+            <xsd:documentation>Ort</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="40"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="CompanyRegistryNo">
+        <xsd:annotation>
+            <xsd:documentation>Firmenbuchnummer</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="14"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="ConsumptionBillingCycle">
+        <xsd:annotation>
+            <xsd:documentation>Abrechnungszyklus</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="01"/>
+            <xsd:enumeration value="02"/>
+            <xsd:enumeration value="03"/>
+            <xsd:enumeration value="04"/>
+            <xsd:enumeration value="06"/>
+            <xsd:enumeration value="12"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="ContractPartnerNumber">
+        <xsd:annotation>
+            <xsd:documentation>Kundennummer</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="20"/>
+            <xsd:minLength value="1"/>
+            <xsd:pattern value="[0-9A-Za-z]*"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="DeliveryAddressData">
+        <xsd:annotation>
+            <xsd:documentation>Adresszusatz</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="255"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="DeviceNumber">
+        <xsd:annotation>
+            <xsd:documentation>Zählernummer</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="18"/>
+            <xsd:minLength value="1"/>
+            <xsd:pattern value="[0-9A-Za-z]*"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="DeviceType">
+        <xsd:annotation>
+            <xsd:documentation>Zählertyp</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="NONSMART"/>
+            <xsd:enumeration value="IMN"/>
+            <xsd:enumeration value="DSZ"/>
+            <xsd:enumeration value="IMS"/>
+            <xsd:enumeration value="IME"/>
+            <xsd:enumeration value="LPZ"/>
+            <xsd:enumeration value="PAUSCHAL"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="DoorNumber">
+        <xsd:annotation>
+            <xsd:documentation>Türnummer</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="10"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="DSOTariffClass">
+        <xsd:annotation>
+            <xsd:documentation>Tarifklasse Netzbetreiber (lt. SNVo)</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="G"/>
+            <xsd:enumeration value="GD"/>
+            <xsd:enumeration value="N"/>
+            <xsd:enumeration value="ND"/>
+            <xsd:enumeration value="U"/>
+            <xsd:enumeration value="UD"/>
+            <xsd:enumeration value="E"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="ECShare">
+        <xsd:annotation>
+            <xsd:documentation>Anteil bei statischem Modell in Prozent</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:decimal">
+            <xsd:fractionDigits value="4"/>
+            <xsd:minInclusive value="0.0001"/>
+            <xsd:maxInclusive value="100"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="ElectricityGridLevel">
+        <xsd:annotation>
+            <xsd:documentation>Strom Netzebene</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:unsignedByte">
+            <xsd:maxInclusive value="7"/>
+            <xsd:minInclusive value="1"/>
+            <xsd:totalDigits value="1"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Email">
+        <xsd:annotation>
+            <xsd:documentation>Email-Adresse</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="120"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="EnergyCommunity">
+        <xsd:annotation>
+            <xsd:documentation>Energiegemeinschaft</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="GC"/>
+            <xsd:enumeration value="RC_L"/>
+            <xsd:enumeration value="RC_R"/>
+            <xsd:enumeration value="CC"/>
+            <xsd:enumeration value="MULTI"/>
+            <xsd:enumeration value="NONE"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="EnergyDirection">
+        <xsd:annotation>
+            <xsd:documentation>Energierichtung (Erzeuger/Verbraucher)</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="CONSUMPTION"/>
+            <xsd:enumeration value="GENERATION"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Floor">
+        <xsd:annotation>
+            <xsd:documentation>Stock</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="10"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="ForecastConsumption">
+        <xsd:annotation>
+            <xsd:documentation>Prognostizierter Jahresverbrauch</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:decimal">
+            <xsd:totalDigits value="10"/>
+            <xsd:fractionDigits value="0"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="GasGridLevel">
+        <xsd:annotation>
+            <xsd:documentation>Gas Netzebene</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:unsignedByte">
+            <xsd:maxInclusive value="3"/>
+            <xsd:minInclusive value="1"/>
+            <xsd:totalDigits value="1"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="GridInvoiceRecipient">
+        <xsd:annotation>
+            <xsd:documentation>Netzrechnung an</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="CUSTOMER"/>
+            <xsd:enumeration value="SUPPLIER"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="LoadProfileType">
+        <xsd:annotation>
+            <xsd:documentation>Lastprofiltyp (inkl. Temperaturzone bei Gas)</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="10"/>
+            <xsd:minLength value="1"/>
+            <xsd:pattern value="[0-9A-Za-z\-\+]*"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="MeterCode">
+        <xsd:annotation>
+            <xsd:documentation>Zählwerkskennung</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="25"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Months_0">
+        <xsd:annotation>
+            <xsd:documentation>Monat; 0=monatlich; 1-12=entsprechender Monat; Angabe nur einer Zahl möglich
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:unsignedByte">
+            <xsd:maxInclusive value="12"/>
+            <xsd:minInclusive value="0"/>
+            <xsd:totalDigits value="2"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Name">
+        <xsd:annotation>
+            <xsd:documentation>Name</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="120"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="PartitionModell">
+        <xsd:annotation>
+            <xsd:documentation>Teilnahmemodell</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="DYNAMIC"/>
+            <xsd:enumeration value="STATIC"/>
+            <xsd:enumeration value="INDIVIDUAL"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="PeakPower">
+        <xsd:annotation>
+            <xsd:documentation>Gas Höchstleistung in kWh/h</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:decimal">
+            <xsd:totalDigits value="10"/>
+            <xsd:fractionDigits value="0"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Phone">
+        <xsd:annotation>
+            <xsd:documentation>Telefonnummer</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="50"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="ReferenceNumber">
+        <xsd:annotation>
+            <xsd:documentation>Referenznummer (z.B: Debitorenkontnummer, Vertragskontonummer)</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="20"/>
+            <xsd:minLength value="1"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Salutation">
+        <xsd:annotation>
+            <xsd:documentation>Anrede</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="30"/>
+            <xsd:minLength value="1"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="ShortageCapacity">
+        <xsd:annotation>
+            <xsd:documentation>Engpassleistung Einspeiseanlagen in kW</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:decimal">
+            <xsd:totalDigits value="15"/>
+            <xsd:fractionDigits value="3"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Staircase">
+        <xsd:annotation>
+            <xsd:documentation>Stiege</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="10"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Street">
+        <xsd:annotation>
+            <xsd:documentation>Strasse</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="60"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="StreetNo">
+        <xsd:annotation>
+            <xsd:documentation>Hausnummer</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="20"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="SupplyOfLastResort">
+        <xsd:annotation>
+            <xsd:documentation>Grundversorgung (Y/N)</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:boolean"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="SupStatus">
+        <xsd:annotation>
+            <xsd:documentation>Versorgungsstatus</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="ON"/>
+            <xsd:enumeration value="OFF"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="TransmissionCycle">
+        <xsd:annotation>
+            <xsd:documentation>Übertragungsintervall Verbrauchsdaten</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="D"/>
+            <xsd:enumeration value="M"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="TypeOfGeneration">
+        <xsd:annotation>
+            <xsd:documentation>Voll-/Überschusseinspeiser</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="NONE"/>
+            <xsd:enumeration value="FULL"/>
+            <xsd:enumeration value="SURPLUS"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="VATNumber">
+        <xsd:annotation>
+            <xsd:documentation>USt-ID</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="14"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="YearMonth">
+        <xsd:annotation>
+            <xsd:documentation>JahrMonat YYYYMM</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:length value="6"/>
+            <xsd:pattern value="[12][0-9]{3}[01][0-9]"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="ZIP">
+        <xsd:annotation>
+            <xsd:documentation>Postleitzahl</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="10"/>
+            <xsd:minLength value="1"/>
+            <xsd:whiteSpace value="collapse"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Country">
+        <xsd:annotation>
+            <xsd:documentation>Länderkennung gemäß ISO 3166-1 (z.B. AT)</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="2"/>
+            <xsd:minLength value="2"/>
+            <xsd:pattern value="[A-Z]*"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/MultiMasterDataInboundMessageFactoryTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/MultiMasterDataInboundMessageFactoryTest.java
@@ -1,0 +1,40 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata;
+
+import energy.eddie.regionconnector.at.eda.ponton.messages.MarshallerConfig;
+import energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p32.EdaMasterData01p32InboundMessageFactory;
+import energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33.EdaMasterData01p33InboundMessageFactory;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = MarshallerConfig.class)
+class MultiMasterDataInboundMessageFactoryTest {
+    @Autowired
+    private Jaxb2Marshaller marshaller;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"xsd/masterdata/_01p33/masterdata.xml", "xsd/masterdata/_01p32/masterdata.xml"})
+    void parseInputStream_forVersion_doesNotThrow(String masterdata) throws IOException {
+        // Given
+        var multiFactory = new MultiMasterDataInboundMessageFactory(Set.of(
+                new EdaMasterData01p32InboundMessageFactory(marshaller),
+                new EdaMasterData01p33InboundMessageFactory(marshaller)
+        ));
+
+        ClassLoader classLoader = getClass().getClassLoader();
+        try (var inputStream = classLoader.getResourceAsStream(masterdata)) {
+            // When & Then
+            assertDoesNotThrow(() -> multiFactory.parseInputStream(inputStream));
+        }
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/EdaMasterData01p33InboundMessageFactoryTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/EdaMasterData01p33InboundMessageFactoryTest.java
@@ -1,0 +1,65 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import energy.eddie.regionconnector.at.eda.ponton.messages.MarshallerConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = MarshallerConfig.class)
+class EdaMasterData01p33InboundMessageFactoryTest {
+
+    @Autowired
+    private Jaxb2Marshaller marshaller;
+
+    @Test
+    void isActive_on_07_04_2024_returnsFalse() {
+        // given
+        var factory = new EdaMasterData01p33InboundMessageFactory(marshaller);
+
+        // when
+        var active = factory.isActive(LocalDate.of(2024, 4, 7));
+
+        // then
+        assertFalse(active);
+    }
+
+    @Test
+    void isActive_on_07_04_2025_returnsTrue() {
+        // given
+        var factory = new EdaMasterData01p33InboundMessageFactory(marshaller);
+
+        // when
+        var active = factory.isActive(LocalDate.of(2025, 4, 7));
+
+        // then
+        assertTrue(active);
+    }
+
+
+    @Test
+    void parseInputStream() throws IOException {
+        // Given
+        ClassLoader classLoader = EdaMasterData01p33InboundMessageFactory.class.getClassLoader();
+        try (var inputStream = classLoader.getResourceAsStream("xsd/masterdata/_01p33/masterdata.xml")) {
+            var factory = new EdaMasterData01p33InboundMessageFactory(marshaller);
+            // When
+            var result = factory.parseInputStream(inputStream);
+
+            // Then
+            assertAll(
+                    () -> assertEquals("EP00000000000000000000", result.conversationId()),
+                    () -> assertEquals("AT0000000000000000000000000000000", result.meteringPoint()),
+                    () -> assertNotNull(result.originalMasterData())
+            );
+        }
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/EdaMasterData01p33Test.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messages/masterdata/_01p33/EdaMasterData01p33Test.java
@@ -1,0 +1,51 @@
+package energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p33;
+
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.MasterData;
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.MeteringPointData;
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.ProcessDirectory;
+import at.ebutilities.schemata.customerprocesses.masterdata._01p33.SupStatus;
+import energy.eddie.regionconnector.at.eda.ponton.messages.masterdata._01p32.NullMeteringPointData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class EdaMasterData01p33Test {
+    @Test
+    void testMeteringPointData_withMeteringPointData_returnsNonNullObject() {
+        // Given
+        var masterData = new EdaMasterData01p33(
+                new MasterData()
+                        .withProcessDirectory(
+                                new ProcessDirectory()
+                                        .withMeteringPointData(
+                                                new MeteringPointData()
+                                                        .withSupStatus(SupStatus.ON)
+                                        )
+                        )
+        );
+
+        // When
+        var res = masterData.meteringPointData();
+
+        // Then
+        assertNotNull(res.supStatus());
+    }
+
+    @Test
+    void testMeteringPointData_withoutMeteringPointData_returnsNullObject() {
+        // Given
+        var masterData = new EdaMasterData01p33(
+                new MasterData()
+                        .withProcessDirectory(
+                                new ProcessDirectory()
+                        )
+        );
+
+        // When
+        var res = masterData.meteringPointData();
+
+        // Then
+        assertEquals(new NullMeteringPointData(), res);
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/test/resources/xsd/masterdata/_01p33/masterdata-forCompany.xml
+++ b/region-connectors/region-connector-at-eda/src/test/resources/xsd/masterdata/_01p33/masterdata-forCompany.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cp:MasterData
+        xmlns:cp="http://www.ebutilities.at/schemata/customerprocesses/masterdata/01p33"
+        xmlns:ct="http://www.ebutilities.at/schemata/customerprocesses/common/types/01p20">
+    <cp:MarketParticipantDirectory DocumentMode="PROD" Duplicate="false"
+                                   SchemaVersion="01.33">
+        <ct:RoutingHeader>
+            <ct:Sender AddressType="ECNumber">
+                <ct:MessageAddress>AT099999</ct:MessageAddress>
+            </ct:Sender>
+            <ct:Receiver AddressType="ECNumber">
+                <ct:MessageAddress>AT100000</ct:MessageAddress>
+            </ct:Receiver>
+            <ct:DocumentCreationDateTime>2023-12-17T09:30:47Z</ct:DocumentCreationDateTime>
+        </ct:RoutingHeader>
+        <ct:Sector>01</ct:Sector>
+        <cp:MessageCode>ANTWORT_GN</cp:MessageCode>
+    </cp:MarketParticipantDirectory>
+    <cp:ProcessDirectory>
+        <ct:MessageId>AT09999901234572022081314235688</ct:MessageId>
+        <ct:ConversationId>AT09999901234562022081314235688</ct:ConversationId>
+        <ct:ProcessDate>2022-08-13</ct:ProcessDate>
+        <ct:MeteringPoint>AT099999012340000000000123456789</ct:MeteringPoint>
+        <cp:ContractPartner>
+            <cp:Salutation>a</cp:Salutation>
+            <cp:Name1 Changed="false">Random Company</cp:Name1>
+            <cp:ContractPartnerNumber>123456789</cp:ContractPartnerNumber>
+            <cp:CompanyRegistryNo>123456789</cp:CompanyRegistryNo>
+            <cp:VATNumber>123456789</cp:VATNumber>
+            <cp:Email>random@company.at</cp:Email>
+        </cp:ContractPartner>
+        <cp:DeliveryAddress>
+            <cp:Country>AT</cp:Country>
+            <cp:ZIP Changed="false">1234</cp:ZIP>
+            <cp:City Changed="false">Neustadt</cp:City>
+            <cp:Street Changed="false">Obere Straße</cp:Street>
+            <cp:StreetNo Changed="false">27</cp:StreetNo>
+            <cp:DoorNumber Changed="false">3</cp:DoorNumber>
+        </cp:DeliveryAddress>
+        <cp:BillingData>
+            <cp:ReferenceNumber>123456</cp:ReferenceNumber>
+            <cp:GridInvoiceRecipient Changed="false">CUSTOMER</cp:GridInvoiceRecipient>
+            <cp:BudgetBillingCycle Changed="false">01</cp:BudgetBillingCycle>
+            <cp:MeterReadingMonth Changed="false">5</cp:MeterReadingMonth>
+            <cp:ConsumptionBillingCycle Changed="false">12</cp:ConsumptionBillingCycle>
+            <cp:ConsumptionBillingMonth Changed="false">5</cp:ConsumptionBillingMonth>
+            <cp:YearMonthOfNextBill>202305</cp:YearMonthOfNextBill>
+        </cp:BillingData>
+        <cp:MeteringPointData>
+            <cp:DeviceType Changed="false">IME</cp:DeviceType>
+            <cp:Device>
+                <cp:DeviceNumber Changed="false">123456789</cp:DeviceNumber>
+                <cp:MeterCode>1-1:1.8.1</cp:MeterCode>
+                <cp:MeterCode>1-1:1.8.2</cp:MeterCode>
+            </cp:Device>
+            <cp:SupStatus>ON</cp:SupStatus>
+            <cp:DSOTariffClass Changed="false">N</cp:DSOTariffClass>
+            <cp:EnergyDirection>GENERATION</cp:EnergyDirection>
+            <cp:EnergyCommunity Changed="false">NONE</cp:EnergyCommunity>
+            <cp:TypeOfGeneration Changed="false">NONE</cp:TypeOfGeneration>
+            <cp:ForecastConsumption>2500</cp:ForecastConsumption>
+            <cp:SupplyOfLastResort>false</cp:SupplyOfLastResort>
+            <cp:LoadProfileType Changed="false">H0</cp:LoadProfileType>
+            <cp:ElectricitySpecificData>
+                <cp:GridUsageLevel Changed="false">7</cp:GridUsageLevel>
+                <cp:GridLossLevel Changed="false">7</cp:GridLossLevel>
+            </cp:ElectricitySpecificData>
+        </cp:MeteringPointData>
+        <cp:InvoiceRecipient>
+            <cp:PartnerData>
+                <cp:Salutation>a</cp:Salutation>
+                <cp:Name1 Changed="false">Muster</cp:Name1>
+                <cp:Name2 Changed="false">Max</cp:Name2>
+                <cp:ContractPartnerNumber>123456789</cp:ContractPartnerNumber>
+                <cp:DateOfBirth>1957-08-13</cp:DateOfBirth>
+                <cp:Email>max@muster.at</cp:Email>
+            </cp:PartnerData>
+            <cp:AddressData>
+                <cp:Country>AT</cp:Country>
+                <cp:ZIP Changed="false">1234</cp:ZIP>
+                <cp:City Changed="false">Neustadt</cp:City>
+                <cp:Street Changed="false">Obere Straße</cp:Street>
+                <cp:StreetNo Changed="false">27</cp:StreetNo>
+                <cp:DoorNumber Changed="false">3</cp:DoorNumber>
+            </cp:AddressData>
+        </cp:InvoiceRecipient>
+    </cp:ProcessDirectory>
+</cp:MasterData>

--- a/region-connectors/region-connector-at-eda/src/test/resources/xsd/masterdata/_01p33/masterdata-without-metering-point-data.xml
+++ b/region-connectors/region-connector-at-eda/src/test/resources/xsd/masterdata/_01p33/masterdata-without-metering-point-data.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cp:MasterData
+        xmlns:cp="http://www.ebutilities.at/schemata/customerprocesses/masterdata/01p33"
+        xmlns:ct="http://www.ebutilities.at/schemata/customerprocesses/common/types/01p20">
+    <cp:MarketParticipantDirectory DocumentMode="PROD" Duplicate="false"
+                                   SchemaVersion="01.33">
+        <ct:RoutingHeader>
+            <ct:Sender AddressType="ECNumber">
+                <ct:MessageAddress>AT099999</ct:MessageAddress>
+            </ct:Sender>
+            <ct:Receiver AddressType="ECNumber">
+                <ct:MessageAddress>AT100000</ct:MessageAddress>
+            </ct:Receiver>
+            <ct:DocumentCreationDateTime>2023-12-17T09:30:47Z</ct:DocumentCreationDateTime>
+        </ct:RoutingHeader>
+        <ct:Sector>01</ct:Sector>
+        <cp:MessageCode>ANTWORT_GN</cp:MessageCode>
+    </cp:MarketParticipantDirectory>
+    <cp:ProcessDirectory>
+        <ct:MessageId>AT09999901234572022081314235688</ct:MessageId>
+        <ct:ConversationId>AT09999901234562022081314235688</ct:ConversationId>
+        <ct:ProcessDate>2022-08-13</ct:ProcessDate>
+        <ct:MeteringPoint>AT099999012340000000000123456789</ct:MeteringPoint>
+        <cp:ContractPartner>
+            <cp:Salutation>a</cp:Salutation>
+            <cp:Name1 Changed="false">Muster</cp:Name1>
+            <cp:Name2 Changed="false">Max</cp:Name2>
+            <cp:ContractPartnerNumber>123456789</cp:ContractPartnerNumber>
+            <cp:DateOfBirth>1957-08-13</cp:DateOfBirth>
+            <cp:Email>max@muster.at</cp:Email>
+        </cp:ContractPartner>
+        <cp:DeliveryAddress>
+            <cp:Country>AT</cp:Country>
+            <cp:ZIP Changed="false">1234</cp:ZIP>
+            <cp:City Changed="false">Neustadt</cp:City>
+            <cp:Street Changed="false">Obere Straße</cp:Street>
+            <cp:StreetNo Changed="false">27</cp:StreetNo>
+            <cp:DoorNumber Changed="false">3</cp:DoorNumber>
+        </cp:DeliveryAddress>
+        <cp:BillingData>
+            <cp:ReferenceNumber>123456</cp:ReferenceNumber>
+            <cp:GridInvoiceRecipient Changed="false">CUSTOMER</cp:GridInvoiceRecipient>
+            <cp:BudgetBillingCycle Changed="false">01</cp:BudgetBillingCycle>
+            <cp:MeterReadingMonth Changed="false">5</cp:MeterReadingMonth>
+            <cp:ConsumptionBillingCycle Changed="false">12</cp:ConsumptionBillingCycle>
+            <cp:ConsumptionBillingMonth Changed="false">5</cp:ConsumptionBillingMonth>
+            <cp:YearMonthOfNextBill>202305</cp:YearMonthOfNextBill>
+        </cp:BillingData>
+    </cp:ProcessDirectory>
+</cp:MasterData>

--- a/region-connectors/region-connector-at-eda/src/test/resources/xsd/masterdata/_01p33/masterdata.xml
+++ b/region-connectors/region-connector-at-eda/src/test/resources/xsd/masterdata/_01p33/masterdata.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ns:MasterData xmlns:ns="http://www.ebutilities.at/schemata/customerprocesses/masterdata/01p33"
+               xmlns:ct="http://www.ebutilities.at/schemata/customerprocesses/common/types/01p20">
+    <ns:MarketParticipantDirectory DocumentMode="PROD" Duplicate="false" SchemaVersion="01.33">
+        <ct:RoutingHeader>
+            <ct:Sender AddressType="ECNumber">
+                <ct:MessageAddress>AT001000</ct:MessageAddress>
+            </ct:Sender>
+            <ct:Receiver AddressType="ECNumber">
+                <ct:MessageAddress>EP100000</ct:MessageAddress>
+            </ct:Receiver>
+            <ct:DocumentCreationDateTime>2025-07-10T04:43:11.296+02:00</ct:DocumentCreationDateTime>
+        </ct:RoutingHeader>
+        <ct:Sector>01</ct:Sector>
+        <ns:MessageCode>ANTWORT_GN</ns:MessageCode>
+    </ns:MarketParticipantDirectory>
+    <ns:ProcessDirectory>
+        <ct:MessageId>AT000000000000000000000000000000000</ct:MessageId>
+        <ct:ConversationId>EP00000000000000000000</ct:ConversationId>
+        <ct:ProcessDate>2025-07-09+02:00</ct:ProcessDate>
+        <ct:MeteringPoint>AT0000000000000000000000000000000</ct:MeteringPoint>
+        <ns:ContractPartner>
+            <ns:Name1 Changed="false">Max</ns:Name1>
+            <ns:Name2 Changed="false">Muster</ns:Name2>
+            <ns:DateOfBirth>1970-01-01+01:00</ns:DateOfBirth>
+            <ns:Email>example@domain.com</ns:Email>
+        </ns:ContractPartner>
+        <ns:DeliveryAddress>
+            <ns:Country>AT</ns:Country>
+            <ns:ZIP Changed="false">1234</ns:ZIP>
+            <ns:City Changed="false">Wien</ns:City>
+            <ns:Street Changed="false">Musterstrasse</ns:Street>
+            <ns:StreetNo Changed="false">1</ns:StreetNo>
+            <ns:DoorNumber Changed="false">1</ns:DoorNumber>
+            <ns:DeliveryAddressData Changed="false">1/1</ns:DeliveryAddressData>
+        </ns:DeliveryAddress>
+        <ns:BillingData>
+            <ns:ReferenceNumber>000000000000</ns:ReferenceNumber>
+            <ns:GridInvoiceRecipient Changed="false">CUSTOMER</ns:GridInvoiceRecipient>
+            <ns:BudgetBillingCycle Changed="false">01</ns:BudgetBillingCycle>
+            <ns:MeterReadingMonth Changed="false">02</ns:MeterReadingMonth>
+            <ns:ConsumptionBillingCycle Changed="false">12</ns:ConsumptionBillingCycle>
+            <ns:ConsumptionBillingMonth Changed="false">02</ns:ConsumptionBillingMonth>
+            <ns:YearMonthOfNextBill>202602</ns:YearMonthOfNextBill>
+        </ns:BillingData>
+        <ns:MeteringPointData>
+            <ns:DeviceType Changed="false">IMS</ns:DeviceType>
+            <ns:TransmissionCycle Changed="false">M</ns:TransmissionCycle>
+            <ns:SupStatus>ON</ns:SupStatus>
+            <ns:DSOTariffClass Changed="false">N</ns:DSOTariffClass>
+            <ns:EnergyDirection>CONSUMPTION</ns:EnergyDirection>
+            <ns:EnergyCommunity Changed="false">NONE</ns:EnergyCommunity>
+            <ns:TypeOfGeneration Changed="false">NONE</ns:TypeOfGeneration>
+            <ns:ForecastConsumption>200</ns:ForecastConsumption>
+            <ns:SupplyOfLastResort>false</ns:SupplyOfLastResort>
+            <ns:LoadProfileType Changed="false">H0</ns:LoadProfileType>
+            <ns:LocalID>00HK11-12796p</ns:LocalID>
+            <ns:RegionalID>00HK11</ns:RegionalID>
+            <ns:ElectricitySpecificData>
+                <ns:GridUsageLevel Changed="false">7</ns:GridUsageLevel>
+                <ns:GridLossLevel Changed="false">7</ns:GridLossLevel>
+            </ns:ElectricitySpecificData>
+        </ns:MeteringPointData>
+    </ns:ProcessDirectory>
+</ns:MasterData>


### PR DESCRIPTION
There are currently two master data schemas that are active in parallel and DSOs use both versions.
This PR adds the feature to parse both of them, without failing if an older version is used.