### PR TITLE
NOISSUE Fix AIIDA CIM naming issues

### DIFF
--- a/aiida/build.gradle.kts
+++ b/aiida/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.eclipse.paho.mqttv5.client)
     // enable Jackson support to fetch Hibernate lazy loaded properties when serializing
     implementation(libs.jackson.hibernate6)
+    implementation(libs.jackson.jakarta.xmlbind.annotations)
     implementation(libs.j2mod)
     implementation(libs.mvel2)
 

--- a/aiida/src/main/java/energy/eddie/aiida/config/AiidaConfiguration.java
+++ b/aiida/src/main/java/energy/eddie/aiida/config/AiidaConfiguration.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.hibernate6.Hibernate6Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import energy.eddie.aiida.adapters.datasource.at.transformer.OesterreichsEnergieAdapterJson;
 import energy.eddie.aiida.adapters.datasource.at.transformer.OesterreichsEnergieAdapterValueDeserializer;
 import energy.eddie.aiida.adapters.datasource.fr.transformer.MicroTeleinfoV3DataField;
@@ -42,6 +43,7 @@ public class AiidaConfiguration {
                 .failOnUnknownProperties(true)
                 .modules(
                         new JavaTimeModule(),
+                        new JakartaXmlBindAnnotationModule(),
                         new Hibernate6Module().enable(Hibernate6Module.Feature.FORCE_LAZY_LOADING)
                                               .disable(Hibernate6Module.Feature.USE_TRANSIENT_ANNOTATION),
                         new SimpleModule().addDeserializer(OesterreichsEnergieAdapterJson.AdapterValue.class,


### PR DESCRIPTION
Currently AIIDA serializes CIM messages in JSON and the json elements have "wrong" namings.
E.g. the attribute `messageDocumentHeaderCreationDateTime` of the `RTDEnvelope` is serialized as `messageDocumentHeaderCreationDateTime`, but we are expecting it to be serialized as `messageDocumentHeader.creationDateTime`.

In this PR, the XML Annotations extension was registered at the ObjectMapper, so the `@XmlElement` annotations are recognized and the messages are serialized as expected.
