### PR TITLE
NOISSUE make aiida QR code base64 encoded

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/aiida/AiidaTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/aiida/AiidaTest.java
@@ -14,7 +14,7 @@ class AiidaTest extends E2eTestSetup {
 
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 
-        assertThat(page.getByLabel("\"permissionId\":\"")).isVisible();
+        assertThat(page.getByLabel("AIIDA QR code")).isVisible();
         assertThat(page.getByLabel("AIIDA code")).isVisible();
     }
 }

--- a/region-connectors/region-connector-aiida/src/main/web/permission-request-form.js
+++ b/region-connectors/region-connector-aiida/src/main/web/permission-request-form.js
@@ -68,7 +68,8 @@ class PermissionRequestForm extends PermissionRequestFormBase {
           </sl-button>`
         : html`
             <sl-qr-code
-              value="${this._aiidaCode}"
+              value="${this.convertToBase64(this._aiidaCode)}"
+              label="AIIDA QR code"
               radius="0.5"
               size="256"
             ></sl-qr-code>


### PR DESCRIPTION
as talked about in the daily


The QR code of the AIIDA app does not contain the same information as the AIIDA Code below it.
The aiida code itself is a base64 encoded json obj while the QR Code is just the json obj itself.
Developers (and users) expect these to be identical and it does not make sense to process both values differently!
This PR address this issue and changes the value of the QR code value to be the same as the AIIDA Code!
