### PR TITLE
GH-1591 AIIDA: Show latest message for datasource and permission

### DIFF
--- a/aiida/src/main/java/energy/eddie/aiida/dtos/datasource/DataSourceDto.java
+++ b/aiida/src/main/java/energy/eddie/aiida/dtos/datasource/DataSourceDto.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
         property = "dataSourceType"
 )
 @JsonSubTypes({

--- a/aiida/src/main/java/energy/eddie/aiida/dtos/record/AiidaRecordStreamingDto.java
+++ b/aiida/src/main/java/energy/eddie/aiida/dtos/record/AiidaRecordStreamingDto.java
@@ -1,4 +1,4 @@
-package energy.eddie.aiida.dtos;
+package energy.eddie.aiida.dtos.record;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import energy.eddie.aiida.models.record.AiidaRecordValue;

--- a/aiida/src/main/java/energy/eddie/aiida/dtos/record/AiidaRecordValueDto.java
+++ b/aiida/src/main/java/energy/eddie/aiida/dtos/record/AiidaRecordValueDto.java
@@ -1,0 +1,17 @@
+package energy.eddie.aiida.dtos.record;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import energy.eddie.aiida.models.record.UnitOfMeasurement;
+import energy.eddie.aiida.utils.ObisCode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AiidaRecordValueDto(
+        @JsonProperty String obisCode,
+        @JsonProperty ObisCode rawTag,
+        @JsonProperty String rawValue,
+        @JsonProperty UnitOfMeasurement rawUnit,
+        @JsonProperty String value,
+        @JsonProperty UnitOfMeasurement unit,
+        @JsonProperty String sourceKey
+) {}

--- a/aiida/src/main/java/energy/eddie/aiida/dtos/record/LatestDataSourceRecordDto.java
+++ b/aiida/src/main/java/energy/eddie/aiida/dtos/record/LatestDataSourceRecordDto.java
@@ -1,0 +1,20 @@
+package energy.eddie.aiida.dtos.record;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import energy.eddie.dataneeds.needs.aiida.AiidaAsset;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Contains the data of an {@link energy.eddie.aiida.models.record.AiidaRecord}
+ */
+public record LatestDataSourceRecordDto(
+        @JsonProperty Instant timestamp,
+        @JsonProperty String name,
+        @JsonProperty AiidaAsset asset,
+        @JsonProperty UUID dataSourceId,
+        @JsonProperty("values") List<AiidaRecordValueDto> aiidaRecordValues
+) {
+}

--- a/aiida/src/main/java/energy/eddie/aiida/dtos/record/LatestInboundPermissionRecordDto.java
+++ b/aiida/src/main/java/energy/eddie/aiida/dtos/record/LatestInboundPermissionRecordDto.java
@@ -1,0 +1,13 @@
+package energy.eddie.aiida.dtos.record;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import energy.eddie.dataneeds.needs.aiida.AiidaAsset;
+
+import java.time.Instant;
+
+public record LatestInboundPermissionRecordDto(
+        @JsonProperty Instant timestamp,
+        @JsonProperty AiidaAsset asset,
+        @JsonProperty String payload
+) {
+}

--- a/aiida/src/main/java/energy/eddie/aiida/dtos/record/LatestOutboundPermissionRecordDto.java
+++ b/aiida/src/main/java/energy/eddie/aiida/dtos/record/LatestOutboundPermissionRecordDto.java
@@ -1,0 +1,13 @@
+package energy.eddie.aiida.dtos.record;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.UUID;
+
+public record LatestOutboundPermissionRecordDto(
+        @JsonProperty UUID permissionId,
+        @JsonProperty String topic,
+        @JsonProperty String serverUri,
+        @JsonProperty List<LatestSchemaRecordDto> messages
+) {
+}

--- a/aiida/src/main/java/energy/eddie/aiida/dtos/record/LatestSchemaRecordDto.java
+++ b/aiida/src/main/java/energy/eddie/aiida/dtos/record/LatestSchemaRecordDto.java
@@ -1,0 +1,13 @@
+package energy.eddie.aiida.dtos.record;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import energy.eddie.dataneeds.needs.aiida.AiidaSchema;
+
+import java.time.Instant;
+
+public record LatestSchemaRecordDto(
+        @JsonProperty AiidaSchema schema,
+        @JsonProperty Instant sentAt,
+        @JsonProperty String message
+) {
+}

--- a/aiida/src/main/java/energy/eddie/aiida/errors/LatestAiidaRecordNotFoundException.java
+++ b/aiida/src/main/java/energy/eddie/aiida/errors/LatestAiidaRecordNotFoundException.java
@@ -1,0 +1,13 @@
+package energy.eddie.aiida.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.UUID;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class LatestAiidaRecordNotFoundException extends Exception {
+    public LatestAiidaRecordNotFoundException(UUID dataSourceId) {
+        super("Latest Aiida Record not found for data source with ID: %s".formatted(dataSourceId));
+    }
+}

--- a/aiida/src/main/java/energy/eddie/aiida/errors/LatestPermissionRecordNotFoundException.java
+++ b/aiida/src/main/java/energy/eddie/aiida/errors/LatestPermissionRecordNotFoundException.java
@@ -1,0 +1,13 @@
+package energy.eddie.aiida.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.UUID;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class LatestPermissionRecordNotFoundException extends Exception {
+    public LatestPermissionRecordNotFoundException(UUID permissionId) {
+        super("Latest permission record not found for permission: %s".formatted(permissionId));
+    }
+}

--- a/aiida/src/main/java/energy/eddie/aiida/models/record/LatestRecordSchema.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/record/LatestRecordSchema.java
@@ -1,0 +1,6 @@
+package energy.eddie.aiida.models.record;
+
+import java.time.Instant;
+
+public record LatestRecordSchema(Instant sentAt, String message) {
+}

--- a/aiida/src/main/java/energy/eddie/aiida/models/record/PermissionLatestRecord.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/record/PermissionLatestRecord.java
@@ -1,0 +1,34 @@
+package energy.eddie.aiida.models.record;
+
+import energy.eddie.dataneeds.needs.aiida.AiidaSchema;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class PermissionLatestRecord {
+    private final String topic;
+    private final String serverUri;
+    private final ConcurrentHashMap<AiidaSchema, LatestRecordSchema> messages;
+
+    public PermissionLatestRecord(String topic, String serverUri) {
+        this.topic = topic;
+        this.serverUri = serverUri;
+        this.messages = new ConcurrentHashMap<>();
+    }
+
+    public void putSchema(AiidaSchema schema, LatestRecordSchema message) {
+        messages.put(schema, message);
+    }
+
+    public ConcurrentMap<AiidaSchema, LatestRecordSchema> messages() {
+        return messages;
+    }
+
+    public String topic() {
+        return topic;
+    }
+
+    public String serverUri() {
+        return serverUri;
+    }
+}

--- a/aiida/src/main/java/energy/eddie/aiida/models/record/PermissionLatestRecordMap.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/record/PermissionLatestRecordMap.java
@@ -1,0 +1,21 @@
+package energy.eddie.aiida.models.record;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class PermissionLatestRecordMap {
+    private final ConcurrentHashMap<UUID, PermissionLatestRecord>
+            permissionRecordMap = new ConcurrentHashMap<>();
+
+    public void put(UUID permissionId, PermissionLatestRecord permissionRecord) {
+        permissionRecordMap.put(permissionId, permissionRecord);
+    }
+
+    public Optional<PermissionLatestRecord> get(UUID permissionId) {
+        return Optional.ofNullable(permissionRecordMap.get(permissionId));
+    }
+}

--- a/aiida/src/main/java/energy/eddie/aiida/repositories/AiidaRecordRepository.java
+++ b/aiida/src/main/java/energy/eddie/aiida/repositories/AiidaRecordRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface AiidaRecordRepository extends JpaRepository<AiidaRecord, Long> {
+    Optional<AiidaRecord> findFirstByDataSourceIdOrderByIdDesc(UUID dataSourceId);
     long deleteAiidaRecordsByTimestampBefore(Instant threshold);
 }

--- a/aiida/src/main/java/energy/eddie/aiida/streamers/StreamerFactory.java
+++ b/aiida/src/main/java/energy/eddie/aiida/streamers/StreamerFactory.java
@@ -3,6 +3,7 @@ package energy.eddie.aiida.streamers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.models.record.AiidaRecord;
+import energy.eddie.aiida.models.record.PermissionLatestRecordMap;
 import energy.eddie.aiida.repositories.FailedToSendRepository;
 import energy.eddie.aiida.streamers.mqtt.MqttStreamer;
 import energy.eddie.aiida.streamers.mqtt.MqttStreamingContext;
@@ -40,7 +41,8 @@ public class StreamerFactory {
             ObjectMapper mapper,
             Permission permission,
             Flux<AiidaRecord> recordFlux,
-            Sinks.One<UUID> terminationRequestSink
+            Sinks.One<UUID> terminationRequestSink,
+            PermissionLatestRecordMap permissionLatestRecordMap
     ) throws MqttException {
         var mqttFilePersistenceDirectory = "mqtt-persistence/{eddieId}/{permissionId}";
         var streamingConfig = requireNonNull(permission.mqttStreamingConfig());
@@ -50,7 +52,7 @@ public class StreamerFactory {
                                                             mqttFilePersistenceDirectory).expand(permission.eddieId(),
                                                                                                  permission.permissionId())
                                                                                          .getPath()));
-        var streamingContext = new MqttStreamingContext(client, streamingConfig);
+        var streamingContext = new MqttStreamingContext(client, streamingConfig, permissionLatestRecordMap);
 
         return new MqttStreamer(aiidaId,
                                 failedToSendRepository,

--- a/aiida/src/main/java/energy/eddie/aiida/streamers/mqtt/MqttStreamingContext.java
+++ b/aiida/src/main/java/energy/eddie/aiida/streamers/mqtt/MqttStreamingContext.java
@@ -1,7 +1,9 @@
 package energy.eddie.aiida.streamers.mqtt;
 
 import energy.eddie.aiida.models.permission.MqttStreamingConfig;
+import energy.eddie.aiida.models.record.PermissionLatestRecordMap;
 import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
 
-public record MqttStreamingContext(MqttAsyncClient client, MqttStreamingConfig streamingConfig) {
+public record MqttStreamingContext(MqttAsyncClient client, MqttStreamingConfig streamingConfig,
+                                   PermissionLatestRecordMap permissionLatestRecordMap) {
 }

--- a/aiida/src/main/java/energy/eddie/aiida/utils/AiidaRecordConverter.java
+++ b/aiida/src/main/java/energy/eddie/aiida/utils/AiidaRecordConverter.java
@@ -1,8 +1,12 @@
 package energy.eddie.aiida.utils;
 
-import energy.eddie.aiida.dtos.AiidaRecordStreamingDto;
+import energy.eddie.aiida.dtos.record.AiidaRecordStreamingDto;
+import energy.eddie.aiida.dtos.record.AiidaRecordValueDto;
+import energy.eddie.aiida.dtos.record.LatestDataSourceRecordDto;
+import energy.eddie.aiida.models.datasource.DataSource;
 import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.models.record.AiidaRecord;
+import energy.eddie.aiida.models.record.AiidaRecordValue;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,5 +34,36 @@ public class AiidaRecordConverter {
                                            permission.permissionId(),
                                            aiidaRecord.dataSourceId(),
                                            aiidaRecord.aiidaRecordValues());
+    }
+
+    /**
+     * Converts an {@link AiidaRecord} to a {@link LatestDataSourceRecordDto}.
+     *
+     * @param aiidaRecord The record to convert.
+     * @param dataSource The data source which contains the metadata that should be added to the DTO.
+     * @return LatestAiidaRecordDto with its fields populated.
+     */
+    public static LatestDataSourceRecordDto recordToLatestDto(AiidaRecord aiidaRecord, DataSource dataSource) {
+        return new LatestDataSourceRecordDto(aiidaRecord.timestamp(),
+                                             dataSource.name(),
+                                             aiidaRecord.asset(),
+                                             dataSource.id(),
+                                             aiidaRecord.aiidaRecordValues()
+                                                   .stream()
+                                                   .map(AiidaRecordConverter::toValueDto)
+                                                   .toList());
+    }
+
+    @SuppressWarnings("NullAway")
+    private static AiidaRecordValueDto toValueDto(AiidaRecordValue value) {
+        return new AiidaRecordValueDto(
+                value.rawTag(),
+                value.dataTag(),
+                value.rawValue(),
+                value.rawUnitOfMeasurement(),
+                value.value(),
+                value.unitOfMeasurement(),
+                value.sourceKey()
+        );
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/web/GlobalExceptionHandler.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/GlobalExceptionHandler.java
@@ -193,6 +193,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(errors);
     }
 
+    @ExceptionHandler(LatestAiidaRecordNotFoundException.class)
+    public ResponseEntity<Map<String, List<EddieApiError>>> handleLatestAiidaRecordNotFound(LatestAiidaRecordNotFoundException exception) {
+        var errors = Map.of(ERRORS_PROPERTY_NAME, List.of(new EddieApiError(exception.getMessage())));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errors);
+    }
+
+    @ExceptionHandler(LatestPermissionRecordNotFoundException.class)
+    public ResponseEntity<Map<String, List<EddieApiError>>> handleLatestPermissionRecordNotFound(LatestPermissionRecordNotFoundException exception) {
+        var errors = Map.of(ERRORS_PROPERTY_NAME, List.of(new EddieApiError(exception.getMessage())));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errors);
+    }
+
     @ExceptionHandler(value = {SinapsiAlflaEmptyConfigException.class})
     protected ResponseEntity<Map<String, List<EddieApiError>>> handleSinapsiAlflaEmptyConfigException(SinapsiAlflaEmptyConfigException exception) {
         var errors = Map.of(ERRORS_PROPERTY_NAME, List.of(new EddieApiError(exception.getMessage())));

--- a/aiida/src/main/java/energy/eddie/aiida/web/InboundController.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/InboundController.java
@@ -49,6 +49,6 @@ public class InboundController {
             throw new UnauthorizedException("API key missing: provide X-API-Key header or ?apiKey= query param.");
         }
 
-        return ResponseEntity.ok(inboundService.latestRecord(apiKey, permissionId));
+        return ResponseEntity.ok(inboundService.latestRecord(permissionId, apiKey));
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/web/LatestRecordController.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/LatestRecordController.java
@@ -1,0 +1,67 @@
+package energy.eddie.aiida.web;
+
+import energy.eddie.aiida.dtos.record.LatestDataSourceRecordDto;
+import energy.eddie.aiida.dtos.record.LatestInboundPermissionRecordDto;
+import energy.eddie.aiida.dtos.record.LatestOutboundPermissionRecordDto;
+import energy.eddie.aiida.errors.*;
+import energy.eddie.aiida.services.LatestRecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/messages")
+@Tag(name = "Latest Record Controller")
+public class LatestRecordController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LatestRecordController.class);
+    private final LatestRecordService latestRecordService;
+
+    @Autowired
+    public LatestRecordController(LatestRecordService service) {
+        this.latestRecordService = service;
+    }
+
+    @Operation(summary = "Gets the latest data source record for a given datasource ID",
+            operationId = "latestDataSourceRecord",
+            tags = {"dataSourceRecord"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Latest data source record found",
+                    content = @Content(schema = @Schema(implementation = LatestDataSourceRecordDto.class))),
+            @ApiResponse(responseCode = "404", description = "Datasource not found",
+                    content = @Content(schema = @Schema(implementation = String.class)))
+    })
+    @GetMapping(value = "data-source/{id}/latest")
+    public LatestDataSourceRecordDto latestDataSourceRecord(@PathVariable("id") UUID dataSourceId)
+            throws LatestAiidaRecordNotFoundException, DataSourceNotFoundException {
+        LOGGER.info("Fetching latest data source record for datasource with ID: {}", dataSourceId);
+
+        return latestRecordService.latestDataSourceRecord(dataSourceId);
+    }
+
+    @GetMapping(value = "permission/{id}/outbound/latest")
+    public LatestOutboundPermissionRecordDto latestOutboundPermissionRecord(@PathVariable("id") UUID permissionId)
+            throws LatestPermissionRecordNotFoundException {
+        LOGGER.info("Fetching latest outbound permission record for permission with ID: {}", permissionId);
+
+        return latestRecordService.latestOutboundPermissionRecord(permissionId);
+    }
+
+    @GetMapping(value = "permission/{id}/inbound/latest")
+    public LatestInboundPermissionRecordDto latestInboundPermissionRecord (
+            @PathVariable("id") UUID permissionId
+    ) throws PermissionNotFoundException, InvalidDataSourceTypeException, InboundRecordNotFoundException {
+        LOGGER.info("Fetching latest inbound permission record for permission with ID: {}", permissionId);
+
+        return latestRecordService.latestInboundPermissionRecord(permissionId);
+    }
+}

--- a/aiida/src/test/java/energy/eddie/aiida/services/InboundServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/InboundServiceTest.java
@@ -67,7 +67,7 @@ class InboundServiceTest {
                 INBOUND_RECORD));
 
         // When
-        var inboundRecord = inboundService.latestRecord(ACCESS_CODE, PERMISSION_ID);
+        var inboundRecord = inboundService.latestRecord(PERMISSION_ID, ACCESS_CODE);
 
         // Then
         assertEquals(DATA_SOURCE_ID, inboundRecord.dataSourceId());
@@ -83,7 +83,7 @@ class InboundServiceTest {
 
         // When, Then
         assertThrows(InvalidDataSourceTypeException.class,
-                     () -> inboundService.latestRecord(ACCESS_CODE, PERMISSION_ID));
+                     () -> inboundService.latestRecord(PERMISSION_ID, ACCESS_CODE));
     }
 
     @Test
@@ -92,7 +92,7 @@ class InboundServiceTest {
         when(permissionRepository.findById(PERMISSION_ID)).thenReturn(Optional.of(PERMISSION));
 
         // When, Then
-        assertThrows(UnauthorizedException.class, () -> inboundService.latestRecord("wrong", PERMISSION_ID));
+        assertThrows(UnauthorizedException.class, () -> inboundService.latestRecord(PERMISSION_ID, "wrong"));
     }
 
     @Test
@@ -101,7 +101,7 @@ class InboundServiceTest {
         when(permissionRepository.findById(PERMISSION_ID)).thenReturn(Optional.empty());
 
         // When, Then
-        assertThrows(PermissionNotFoundException.class, () -> inboundService.latestRecord(ACCESS_CODE, PERMISSION_ID));
+        assertThrows(PermissionNotFoundException.class, () -> inboundService.latestRecord(PERMISSION_ID, ACCESS_CODE));
     }
 
     @Test
@@ -111,6 +111,6 @@ class InboundServiceTest {
 
         // When, Then
         assertThrows(InboundRecordNotFoundException.class,
-                     () -> inboundService.latestRecord(ACCESS_CODE, PERMISSION_ID));
+                     () -> inboundService.latestRecord(PERMISSION_ID, ACCESS_CODE));
     }
 }

--- a/aiida/src/test/java/energy/eddie/aiida/services/LatestRecordServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/LatestRecordServiceTest.java
@@ -1,0 +1,333 @@
+package energy.eddie.aiida.services;
+
+import energy.eddie.aiida.dtos.record.AiidaRecordValueDto;
+import energy.eddie.aiida.dtos.record.LatestDataSourceRecordDto;
+import energy.eddie.aiida.errors.*;
+import energy.eddie.aiida.models.datasource.DataSource;
+import energy.eddie.aiida.models.record.AiidaRecord;
+import energy.eddie.aiida.models.record.InboundRecord;
+import energy.eddie.aiida.models.record.LatestRecordSchema;
+import energy.eddie.aiida.models.record.PermissionLatestRecord;
+import energy.eddie.aiida.models.record.PermissionLatestRecordMap;
+import energy.eddie.aiida.models.record.UnitOfMeasurement;
+import energy.eddie.aiida.repositories.AiidaRecordRepository;
+import energy.eddie.aiida.repositories.DataSourceRepository;
+import energy.eddie.aiida.utils.AiidaRecordConverter;
+import energy.eddie.aiida.utils.ObisCode;
+import energy.eddie.dataneeds.needs.aiida.AiidaAsset;
+import energy.eddie.dataneeds.needs.aiida.AiidaSchema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LatestRecordServiceTest {
+    private static final UUID DATA_SOURCE_ID = UUID.fromString("4211ea05-d4ab-48ff-8613-8f4791a56606");
+    private static final UUID PERMISSION_ID = UUID.fromString("5211ea05-d4ab-48ff-8613-8f4791a56606");
+    private static final String TOPIC = "test/topic";
+    private static final String SERVER_URI = "mqtt://test.server.com";
+    private static final String PAYLOAD = "test-payload-data";
+    private static final Instant TIMESTAMP = Instant.parse("2024-01-15T10:30:00Z");
+    private static final List<AiidaRecordValueDto> RECORD_VALUES = List.of(
+            new AiidaRecordValueDto(
+                    ObisCode.POSITIVE_ACTIVE_ENERGY.toString(),
+                    ObisCode.POSITIVE_ACTIVE_ENERGY,
+                    "25.5",
+                    UnitOfMeasurement.WATT,
+                    "25.5",
+                    UnitOfMeasurement.WATT,
+                    ""
+            ),
+            new AiidaRecordValueDto(
+                    ObisCode.NEGATIVE_ACTIVE_ENERGY.toString(),
+                    ObisCode.NEGATIVE_ACTIVE_ENERGY,
+                    "60.0",
+                    UnitOfMeasurement.WATT,
+                    "60.0",
+                    UnitOfMeasurement.WATT,
+                    ""
+            )
+    );
+
+    @Mock
+    private Logger logger;
+    @Mock
+    private AiidaRecordRepository repository;
+    @Mock
+    private DataSourceRepository dataSourceRepository;
+    @Mock
+    private PermissionLatestRecordMap permissionLatestRecordMap;
+    @Mock
+    private InboundService inboundService;
+
+    @InjectMocks
+    private LatestRecordService aiidaRecordService;
+
+    @Test
+    void latestAiidaRecord_shouldReturnLatestRecord_whenFound() throws LatestAiidaRecordNotFoundException, DataSourceNotFoundException {
+        var aiidaRecord = mock(AiidaRecord.class);
+        var dataSource = mock(DataSource.class);
+        when(aiidaRecord.timestamp()).thenReturn(TIMESTAMP);
+        when(dataSource.id()).thenReturn(DATA_SOURCE_ID);
+        when(dataSourceRepository.findById(DATA_SOURCE_ID))
+                .thenReturn(Optional.of(dataSource));
+        when(repository.findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID))
+                .thenReturn(Optional.of(aiidaRecord));
+
+        var expectedDto = new LatestDataSourceRecordDto(
+                TIMESTAMP,
+                "datasource",
+                AiidaAsset.SUBMETER,
+                DATA_SOURCE_ID,
+                RECORD_VALUES
+        );
+
+        try (MockedStatic<AiidaRecordConverter> mockedConverter = mockStatic(AiidaRecordConverter.class)) {
+            mockedConverter.when(() -> AiidaRecordConverter.recordToLatestDto(aiidaRecord, dataSource))
+                           .thenReturn(expectedDto);
+
+            var result = aiidaRecordService.latestDataSourceRecord(DATA_SOURCE_ID);
+
+            assertEquals(expectedDto, result);
+            verify(dataSourceRepository, times(1)).findById(DATA_SOURCE_ID);
+            verify(repository, times(1)).findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID);
+            mockedConverter.verify(() -> AiidaRecordConverter.recordToLatestDto(aiidaRecord, dataSource), times(1));
+        }
+    }
+
+    @Test
+    void latestAiidaRecord_shouldThrow_whenRecordNotFound() {
+        var dataSource = mock(DataSource.class);
+        when(dataSourceRepository.findById(DATA_SOURCE_ID))
+                .thenReturn(Optional.of(dataSource));
+        when(repository.findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID))
+                .thenReturn(Optional.empty());
+
+        var exception = assertThrows(LatestAiidaRecordNotFoundException.class, () ->
+                aiidaRecordService.latestDataSourceRecord(DATA_SOURCE_ID)
+        );
+
+        assertTrue(exception.getMessage().contains(DATA_SOURCE_ID.toString()));
+        verify(dataSourceRepository, times(1)).findById(DATA_SOURCE_ID);
+        verify(repository, times(1)).findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID);
+    }
+
+    @Test
+    void latestAiidaRecord_shouldThrow_whenDataSourceNotFound() {
+        when(dataSourceRepository.findById(DATA_SOURCE_ID))
+                .thenReturn(Optional.empty());
+
+        var exception = assertThrows(DataSourceNotFoundException.class, () ->
+                aiidaRecordService.latestDataSourceRecord(DATA_SOURCE_ID)
+        );
+
+        assertTrue(exception.getMessage().contains(DATA_SOURCE_ID.toString()));
+        verify(dataSourceRepository, times(1)).findById(DATA_SOURCE_ID);
+        verify(repository, never()).findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID);
+    }
+
+    @Test
+    void latestAiidaRecord_shouldLogTimestamp_whenRecordFound() throws LatestAiidaRecordNotFoundException, DataSourceNotFoundException {
+        var aiidaRecord = mock(AiidaRecord.class);
+        var dataSource = mock(DataSource.class);
+        when(aiidaRecord.timestamp()).thenReturn(TIMESTAMP);
+        when(dataSource.id()).thenReturn(DATA_SOURCE_ID);
+        when(dataSourceRepository.findById(DATA_SOURCE_ID))
+                .thenReturn(Optional.of(dataSource));
+        when(repository.findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID))
+                .thenReturn(Optional.of(aiidaRecord));
+
+        var expectedDto = new LatestDataSourceRecordDto(
+                TIMESTAMP,
+                "datasource",
+                AiidaAsset.SUBMETER,
+                DATA_SOURCE_ID,
+                RECORD_VALUES
+        );
+
+        try (MockedStatic<AiidaRecordConverter> mockedConverter = mockStatic(AiidaRecordConverter.class)) {
+            mockedConverter.when(() -> AiidaRecordConverter.recordToLatestDto(aiidaRecord, dataSource))
+                           .thenReturn(expectedDto);
+
+            aiidaRecordService.latestDataSourceRecord(DATA_SOURCE_ID);
+
+            verify(aiidaRecord, times(1)).timestamp();
+        }
+    }
+
+    @Test
+    void latestAiidaRecord_shouldHandleDifferentDataSourceIds() throws LatestAiidaRecordNotFoundException, DataSourceNotFoundException {
+        var differentDataSourceId = UUID.fromString("5211ea05-d4ab-48ff-8613-8f4791a56606");
+        var aiidaRecord = mock(AiidaRecord.class);
+        var dataSource = mock(DataSource.class);
+        when(aiidaRecord.timestamp()).thenReturn(TIMESTAMP);
+        when(dataSource.id()).thenReturn(differentDataSourceId);
+        when(dataSourceRepository.findById(differentDataSourceId))
+                .thenReturn(Optional.of(dataSource));
+        when(repository.findFirstByDataSourceIdOrderByIdDesc(differentDataSourceId))
+                .thenReturn(Optional.of(aiidaRecord));
+
+        var expectedDto = new LatestDataSourceRecordDto(
+                TIMESTAMP,
+                "datasource",
+                AiidaAsset.SUBMETER,
+                differentDataSourceId,
+                RECORD_VALUES
+        );
+
+        try (MockedStatic<AiidaRecordConverter> mockedConverter = mockStatic(AiidaRecordConverter.class)) {
+            mockedConverter.when(() -> AiidaRecordConverter.recordToLatestDto(aiidaRecord, dataSource))
+                           .thenReturn(expectedDto);
+
+            var result = aiidaRecordService.latestDataSourceRecord(differentDataSourceId);
+
+            assertEquals(expectedDto, result);
+            verify(dataSourceRepository, times(1)).findById(differentDataSourceId);
+            verify(repository, times(1)).findFirstByDataSourceIdOrderByIdDesc(differentDataSourceId);
+        }
+    }
+
+    @Test
+    void latestAiidaRecord_shouldPropagateConverterExceptions() {
+        var aiidaRecord = mock(AiidaRecord.class);
+        var dataSource = mock(DataSource.class);
+        when(aiidaRecord.timestamp()).thenReturn(TIMESTAMP);
+        when(dataSource.id()).thenReturn(DATA_SOURCE_ID);
+        when(dataSourceRepository.findById(DATA_SOURCE_ID))
+                .thenReturn(Optional.of(dataSource));
+        when(repository.findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID))
+                .thenReturn(Optional.of(aiidaRecord));
+
+        try (MockedStatic<AiidaRecordConverter> mockedConverter = mockStatic(AiidaRecordConverter.class)) {
+            mockedConverter.when(() -> AiidaRecordConverter.recordToLatestDto(aiidaRecord, dataSource))
+                           .thenThrow(new RuntimeException("Conversion failed"));
+
+            assertThrows(RuntimeException.class, () ->
+                    aiidaRecordService.latestDataSourceRecord(DATA_SOURCE_ID)
+            );
+
+            verify(dataSourceRepository, times(1)).findById(DATA_SOURCE_ID);
+            verify(repository, times(1)).findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID);
+        }
+    }
+
+    @Test
+    void latestOutboundPermissionRecord_shouldReturnLatestRecord_whenFound() throws LatestPermissionRecordNotFoundException {
+        var permissionRecord = mock(PermissionLatestRecord.class);
+        var latestSchema1 = new LatestRecordSchema(TIMESTAMP, "message1");
+        var latestSchema2 = new LatestRecordSchema(TIMESTAMP.plusSeconds(10), "message2");
+        var messages = new java.util.concurrent.ConcurrentHashMap<AiidaSchema, LatestRecordSchema>();
+        messages.put(AiidaSchema.SMART_METER_P1_CIM, latestSchema1);
+        messages.put(AiidaSchema.SMART_METER_P1_RAW, latestSchema2);
+
+        when(permissionRecord.topic()).thenReturn(TOPIC);
+        when(permissionRecord.serverUri()).thenReturn(SERVER_URI);
+        when(permissionRecord.messages()).thenReturn(messages);
+        when(permissionLatestRecordMap.get(PERMISSION_ID))
+                .thenReturn(Optional.of(permissionRecord));
+
+        var result = aiidaRecordService.latestOutboundPermissionRecord(PERMISSION_ID);
+
+        assertNotNull(result);
+        assertEquals(PERMISSION_ID, result.permissionId());
+        assertEquals(TOPIC, result.topic());
+        assertEquals(SERVER_URI, result.serverUri());
+        assertEquals(2, result.messages().size());
+        
+        verify(permissionLatestRecordMap, times(1)).get(PERMISSION_ID);
+    }
+
+    @Test
+    void latestOutboundPermissionRecord_shouldThrow_whenPermissionNotFound() {
+        when(permissionLatestRecordMap.get(PERMISSION_ID))
+                .thenReturn(Optional.empty());
+
+        var exception = assertThrows(LatestPermissionRecordNotFoundException.class, () ->
+                aiidaRecordService.latestOutboundPermissionRecord(PERMISSION_ID)
+        );
+
+        assertTrue(exception.getMessage().contains(PERMISSION_ID.toString()));
+        verify(permissionLatestRecordMap, times(1)).get(PERMISSION_ID);
+    }
+
+    @Test
+    void latestOutboundPermissionRecord_shouldHandleEmptyMessages() throws LatestPermissionRecordNotFoundException {
+        var permissionRecord = mock(PermissionLatestRecord.class);
+        var emptyMessages = new java.util.concurrent.ConcurrentHashMap<AiidaSchema, LatestRecordSchema>();
+
+        when(permissionRecord.topic()).thenReturn(TOPIC);
+        when(permissionRecord.serverUri()).thenReturn(SERVER_URI);
+        when(permissionRecord.messages()).thenReturn(emptyMessages);
+        when(permissionLatestRecordMap.get(PERMISSION_ID))
+                .thenReturn(Optional.of(permissionRecord));
+
+        var result = aiidaRecordService.latestOutboundPermissionRecord(PERMISSION_ID);
+
+        assertNotNull(result);
+        assertEquals(PERMISSION_ID, result.permissionId());
+        assertEquals(TOPIC, result.topic());
+        assertEquals(SERVER_URI, result.serverUri());
+        assertEquals(0, result.messages().size());
+        
+        verify(permissionLatestRecordMap, times(1)).get(PERMISSION_ID);
+    }
+
+    @Test
+    void latestInboundPermissionRecord_shouldReturnLatestRecord_whenFound() 
+            throws PermissionNotFoundException, InvalidDataSourceTypeException, InboundRecordNotFoundException {
+        var inboundRecord = mock(InboundRecord.class);
+        when(inboundRecord.timestamp()).thenReturn(TIMESTAMP);
+        when(inboundRecord.asset()).thenReturn(AiidaAsset.SUBMETER);
+        when(inboundRecord.payload()).thenReturn(PAYLOAD);
+        
+        when(inboundService.latestRecord(PERMISSION_ID))
+                .thenReturn(inboundRecord);
+
+        var result = aiidaRecordService.latestInboundPermissionRecord(PERMISSION_ID);
+
+        assertNotNull(result);
+        assertEquals(TIMESTAMP, result.timestamp());
+        assertEquals(AiidaAsset.SUBMETER, result.asset());
+        assertEquals(PAYLOAD, result.payload());
+        
+        verify(inboundService, times(1)).latestRecord(PERMISSION_ID);
+    }
+
+    @Test
+    void latestInboundPermissionRecord_shouldPropagatePermissionNotFoundException() 
+            throws PermissionNotFoundException, InvalidDataSourceTypeException, InboundRecordNotFoundException {
+        when(inboundService.latestRecord(PERMISSION_ID))
+                .thenThrow(new PermissionNotFoundException(PERMISSION_ID));
+
+        assertThrows(PermissionNotFoundException.class, () ->
+                aiidaRecordService.latestInboundPermissionRecord(PERMISSION_ID)
+        );
+        
+        verify(inboundService, times(1)).latestRecord(PERMISSION_ID);
+    }
+
+    @Test
+    void latestInboundPermissionRecord_shouldPropagateInboundRecordNotFoundException() 
+            throws PermissionNotFoundException, InvalidDataSourceTypeException, InboundRecordNotFoundException {
+        when(inboundService.latestRecord(PERMISSION_ID))
+                .thenThrow(new InboundRecordNotFoundException(UUID.randomUUID()));
+
+        assertThrows(InboundRecordNotFoundException.class, () ->
+                aiidaRecordService.latestInboundPermissionRecord(PERMISSION_ID)
+        );
+        
+        verify(inboundService, times(1)).latestRecord(PERMISSION_ID);
+    }
+}

--- a/aiida/src/test/java/energy/eddie/aiida/streamers/StreamerManagerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/streamers/StreamerManagerTest.java
@@ -7,6 +7,7 @@ import energy.eddie.aiida.dtos.ConnectionStatusMessage;
 import energy.eddie.aiida.models.datasource.DataSource;
 import energy.eddie.aiida.models.permission.dataneed.AiidaLocalDataNeed;
 import energy.eddie.aiida.models.permission.Permission;
+import energy.eddie.aiida.models.record.PermissionLatestRecordMap;
 import energy.eddie.aiida.repositories.FailedToSendRepository;
 import energy.eddie.aiida.services.ApplicationInformationService;
 import energy.eddie.dataneeds.needs.aiida.AiidaAsset;
@@ -64,6 +65,8 @@ class StreamerManagerTest {
     private AiidaStreamer mockAiidaStreamer;
     @Mock
     private Map<UUID, AiidaStreamer> mockMap;
+    @Mock
+    private PermissionLatestRecordMap mockLatestRecordMap;
 
     @BeforeEach
     void setUp() {
@@ -74,7 +77,8 @@ class StreamerManagerTest {
         manager = new StreamerManager(aggregatorMock,
                                       applicationInformationServiceMock,
                                       mockRepository,
-                                      mapper);
+                                      mapper,
+                                      mockLatestRecordMap);
     }
 
     @Test
@@ -91,7 +95,7 @@ class StreamerManagerTest {
         when(mockDataNeed.asset()).thenReturn(AiidaAsset.SUBMETER);
         when(mockDataNeed.transmissionSchedule()).thenReturn(CronExpression.parse("* * * * * *"));
         try (MockedStatic<StreamerFactory> utilities = Mockito.mockStatic(StreamerFactory.class)) {
-            utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any(), any()))
+            utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any(), any(), any()))
                      .thenReturn(mockAiidaStreamer);
 
             // first time should result in valid creation
@@ -134,7 +138,7 @@ class StreamerManagerTest {
         when(mockDataNeed.asset()).thenReturn(AiidaAsset.SUBMETER);
         when(mockDataNeed.transmissionSchedule()).thenReturn(CronExpression.parse("* * * * * *"));
         try (MockedStatic<StreamerFactory> utilities = Mockito.mockStatic(StreamerFactory.class)) {
-            utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any(), any()))
+            utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any(), any(), any()))
                      .thenReturn(mockAiidaStreamer);
 
             // When
@@ -181,7 +185,7 @@ class StreamerManagerTest {
         when(mockDataNeed.transmissionSchedule()).thenReturn(CronExpression.parse("* * * * * *"));
         when(aggregatorMock.getFilteredFlux(any(), any(), any(), any(), any(), any())).thenReturn(Flux.empty());
         try (MockedStatic<StreamerFactory> utilities = Mockito.mockStatic(StreamerFactory.class)) {
-            utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any(), any()))
+            utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any(), any(), any(), any(), any()))
                      .thenReturn(mockAiidaStreamer);
 
             manager.createNewStreamer(mockPermission);

--- a/aiida/src/test/java/energy/eddie/aiida/streamers/mqtt/MqttStreamerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/streamers/mqtt/MqttStreamerTest.java
@@ -9,6 +9,7 @@ import energy.eddie.aiida.models.permission.dataneed.AiidaLocalDataNeed;
 import energy.eddie.aiida.models.record.AiidaRecord;
 import energy.eddie.aiida.models.record.AiidaRecordValue;
 import energy.eddie.aiida.models.record.FailedToSendEntity;
+import energy.eddie.aiida.models.record.PermissionLatestRecordMap;
 import energy.eddie.aiida.repositories.FailedToSendRepository;
 import energy.eddie.api.agnostic.aiida.mqtt.MqttDto;
 import energy.eddie.dataneeds.needs.aiida.AiidaAsset;
@@ -86,6 +87,8 @@ class MqttStreamerTest {
     private ObjectMapper mockMapper;
     @Mock
     private ConnectionStatusMessage mockStatusMessage;
+    @Mock
+    private PermissionLatestRecordMap mockLatestRecordMap;
     private MqttStreamingConfig mqttStreamingConfig;
     private MqttStreamer streamer;
 
@@ -101,7 +104,7 @@ class MqttStreamerTest {
         mqttStreamingConfig = new MqttStreamingConfig(permissionId, mqttDto);
         Permission permissionMock = mock(Permission.class);
         when(mockClient.getPendingTokens()).thenReturn(new IMqttToken[]{});
-        var streamingContext = new MqttStreamingContext(mockClient, mqttStreamingConfig);
+        var streamingContext = new MqttStreamingContext(mockClient, mqttStreamingConfig, mockLatestRecordMap);
 
         streamer = new MqttStreamer(aiidaId,
                                     mockRepository,

--- a/aiida/src/test/java/energy/eddie/aiida/web/InboundControllerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/web/InboundControllerTest.java
@@ -30,7 +30,7 @@ class InboundControllerTest {
 
     @Test
     void latestRecord_withHeader_isOk() throws Exception {
-        when(inboundService.latestRecord(ACCESS_CODE, DATA_SOURCE_ID)).thenReturn(mock(InboundRecord.class));
+        when(inboundService.latestRecord(DATA_SOURCE_ID, ACCESS_CODE)).thenReturn(mock(InboundRecord.class));
 
         mockMvc.perform(get("/inbound/latest/" + DATA_SOURCE_ID)
                                 .header("X-API-Key", ACCESS_CODE)
@@ -40,7 +40,7 @@ class InboundControllerTest {
 
     @Test
     void latestRecord_withQueryParam_isOk() throws Exception {
-        when(inboundService.latestRecord(ACCESS_CODE, DATA_SOURCE_ID)).thenReturn(mock(InboundRecord.class));
+        when(inboundService.latestRecord(DATA_SOURCE_ID, ACCESS_CODE)).thenReturn(mock(InboundRecord.class));
 
         mockMvc.perform(get("/inbound/latest/" + DATA_SOURCE_ID + "?apiKey=" + ACCESS_CODE))
                .andExpect(status().isOk());

--- a/aiida/src/test/java/energy/eddie/aiida/web/LatestRecordControllerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/web/LatestRecordControllerTest.java
@@ -1,0 +1,259 @@
+package energy.eddie.aiida.web;
+
+import energy.eddie.aiida.dtos.record.AiidaRecordValueDto;
+import energy.eddie.aiida.dtos.record.LatestDataSourceRecordDto;
+import energy.eddie.aiida.dtos.record.LatestInboundPermissionRecordDto;
+import energy.eddie.aiida.dtos.record.LatestOutboundPermissionRecordDto;
+import energy.eddie.aiida.dtos.record.LatestSchemaRecordDto;
+import energy.eddie.aiida.errors.*;
+import energy.eddie.aiida.models.record.UnitOfMeasurement;
+import energy.eddie.aiida.services.LatestRecordService;
+import energy.eddie.aiida.utils.ObisCode;
+import energy.eddie.dataneeds.needs.aiida.AiidaAsset;
+import energy.eddie.dataneeds.needs.aiida.AiidaSchema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(LatestRecordController.class)
+class LatestRecordControllerTest {
+    private static final UUID DATA_SOURCE_ID = UUID.fromString("4211ea05-d4ab-48ff-8613-8f4791a56606");
+    private static final UUID PERMISSION_ID = UUID.fromString("5211ea05-d4ab-48ff-8613-8f4791a56606");
+    private static final String TOPIC = "test/topic";
+    private static final String SERVER_URI = "mqtt://test.server.com";
+    private static final String PAYLOAD = "test-payload-data";
+    private static final Instant TIMESTAMP = Instant.parse("2024-01-15T10:30:00Z");
+    private static final List<AiidaRecordValueDto> RECORD_VALUES = List.of(
+            new AiidaRecordValueDto(
+                    ObisCode.POSITIVE_ACTIVE_ENERGY.toString(),
+                    ObisCode.POSITIVE_ACTIVE_ENERGY,
+                    "25.5",
+                    UnitOfMeasurement.WATT,
+                    "25.5",
+                    UnitOfMeasurement.WATT,
+                    ""
+            ),
+            new AiidaRecordValueDto(
+                    ObisCode.NEGATIVE_ACTIVE_ENERGY.toString(),
+                    ObisCode.NEGATIVE_ACTIVE_ENERGY,
+                    "60.0",
+                    UnitOfMeasurement.WATT,
+                    "60.0",
+                    UnitOfMeasurement.WATT,
+                    ""
+            )
+    );
+    private static final LatestDataSourceRecordDto LATEST_RECORD = new LatestDataSourceRecordDto(
+            TIMESTAMP,
+            "datasource",
+            AiidaAsset.SUBMETER,
+            DATA_SOURCE_ID,
+            RECORD_VALUES
+    );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LatestRecordService service;
+
+    @Test
+    @WithMockUser
+    void latestAiidaRecord_shouldReturnLatestRecord() throws Exception {
+        when(service.latestDataSourceRecord(DATA_SOURCE_ID)).thenReturn(LATEST_RECORD);
+
+        mockMvc.perform(get("/messages/data-source/4211ea05-d4ab-48ff-8613-8f4791a56606/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.timestamp").value("2024-01-15T10:30:00Z"))
+               .andExpect(jsonPath("$.asset").value("SUBMETER"))
+               .andExpect(jsonPath("$.dataSourceId").value("4211ea05-d4ab-48ff-8613-8f4791a56606"))
+               .andExpect(jsonPath("$.values.length()").value(2))
+               .andExpect(jsonPath("$.values[0].rawTag").value("1-0:1.8.0"))
+               .andExpect(jsonPath("$.values[0].rawValue").value(25.5))
+               .andExpect(jsonPath("$.values[1].rawTag").value("1-0:2.8.0"))
+               .andExpect(jsonPath("$.values[1].rawValue").value(60.0));
+
+        verify(service, times(1)).latestDataSourceRecord(DATA_SOURCE_ID);
+    }
+
+    @Test
+    @WithMockUser
+    void latestAiidaRecord_shouldReturn404WhenDataSourceNotFound() throws Exception {
+        when(service.latestDataSourceRecord(DATA_SOURCE_ID))
+                .thenThrow(new LatestAiidaRecordNotFoundException(UUID.randomUUID()));
+
+        mockMvc.perform(get("/messages/data-source/4211ea05-d4ab-48ff-8613-8f4791a56606/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isNotFound());
+
+        verify(service, times(1)).latestDataSourceRecord(DATA_SOURCE_ID);
+    }
+
+    @Test
+    @WithMockUser
+    void latestAiidaRecord_shouldReturnRecordWithEmptyValues() throws Exception {
+        var recordWithEmptyValues = new LatestDataSourceRecordDto(
+                TIMESTAMP,
+                "datasource",
+                AiidaAsset.SUBMETER,
+                DATA_SOURCE_ID,
+                List.of()
+        );
+
+        when(service.latestDataSourceRecord(DATA_SOURCE_ID)).thenReturn(recordWithEmptyValues);
+
+        mockMvc.perform(get("/messages/data-source/4211ea05-d4ab-48ff-8613-8f4791a56606/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.timestamp").value("2024-01-15T10:30:00Z"))
+               .andExpect(jsonPath("$.asset").value("SUBMETER"))
+               .andExpect(jsonPath("$.dataSourceId").value("4211ea05-d4ab-48ff-8613-8f4791a56606"))
+               .andExpect(jsonPath("$.values.length()").value(0));
+
+        verify(service, times(1)).latestDataSourceRecord(DATA_SOURCE_ID);
+    }
+
+    @Test
+    @WithMockUser
+    void latestAiidaRecord_shouldHandleDifferentAssetTypes() throws Exception {
+        var recordWithDifferentAsset = new LatestDataSourceRecordDto(
+                TIMESTAMP,
+                "datasource",
+                AiidaAsset.CONNECTION_AGREEMENT_POINT,
+                DATA_SOURCE_ID,
+                RECORD_VALUES
+        );
+
+        when(service.latestDataSourceRecord(DATA_SOURCE_ID)).thenReturn(recordWithDifferentAsset);
+
+        mockMvc.perform(get("/messages/data-source/4211ea05-d4ab-48ff-8613-8f4791a56606/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.asset").value("CONNECTION-AGREEMENT-POINT"));
+
+        verify(service, times(1)).latestDataSourceRecord(DATA_SOURCE_ID);
+    }
+
+    @Test
+    @WithMockUser
+    void latestAiidaRecord_shouldReturn400ForInvalidUUID() throws Exception {
+        mockMvc.perform(get("/messages/data-source/invalid-uuid/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isBadRequest());
+
+        verify(service, never()).latestDataSourceRecord(any());
+    }
+
+    @Test
+    @WithMockUser
+    void latestOutboundPermissionRecord_shouldReturnLatestRecord() throws Exception {
+        var schemaRecords = List.of(
+                new LatestSchemaRecordDto(AiidaSchema.SMART_METER_P1_CIM, TIMESTAMP, "message1"),
+                new LatestSchemaRecordDto(AiidaSchema.SMART_METER_P1_RAW, TIMESTAMP.plusSeconds(10), "message2")
+        );
+        var outboundRecord = new LatestOutboundPermissionRecordDto(
+                PERMISSION_ID,
+                TOPIC,
+                SERVER_URI,
+                schemaRecords
+        );
+
+        when(service.latestOutboundPermissionRecord(PERMISSION_ID)).thenReturn(outboundRecord);
+
+        mockMvc.perform(get("/messages/permission/5211ea05-d4ab-48ff-8613-8f4791a56606/outbound/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.permissionId").value("5211ea05-d4ab-48ff-8613-8f4791a56606"))
+               .andExpect(jsonPath("$.topic").value(TOPIC))
+               .andExpect(jsonPath("$.serverUri").value(SERVER_URI))
+               .andExpect(jsonPath("$.messages.length()").value(2))
+               .andExpect(jsonPath("$.messages[0].schema").value("SMART-METER-P1-CIM"))
+               .andExpect(jsonPath("$.messages[0].message").value("message1"));
+
+        verify(service, times(1)).latestOutboundPermissionRecord(PERMISSION_ID);
+    }
+
+    @Test
+    @WithMockUser
+    void latestOutboundPermissionRecord_shouldReturn404WhenPermissionNotFound() throws Exception {
+        when(service.latestOutboundPermissionRecord(PERMISSION_ID))
+                .thenThrow(new LatestPermissionRecordNotFoundException(PERMISSION_ID));
+
+        mockMvc.perform(get("/messages/permission/5211ea05-d4ab-48ff-8613-8f4791a56606/outbound/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isNotFound());
+
+        verify(service, times(1)).latestOutboundPermissionRecord(PERMISSION_ID);
+    }
+
+    @Test
+    @WithMockUser
+    void latestOutboundPermissionRecord_shouldReturnRecordWithEmptyMessages() throws Exception {
+        var outboundRecord = new LatestOutboundPermissionRecordDto(
+                PERMISSION_ID,
+                TOPIC,
+                SERVER_URI,
+                List.of()
+        );
+
+        when(service.latestOutboundPermissionRecord(PERMISSION_ID)).thenReturn(outboundRecord);
+
+        mockMvc.perform(get("/messages/permission/5211ea05-d4ab-48ff-8613-8f4791a56606/outbound/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.permissionId").value("5211ea05-d4ab-48ff-8613-8f4791a56606"))
+               .andExpect(jsonPath("$.topic").value(TOPIC))
+               .andExpect(jsonPath("$.serverUri").value(SERVER_URI))
+               .andExpect(jsonPath("$.messages.length()").value(0));
+
+        verify(service, times(1)).latestOutboundPermissionRecord(PERMISSION_ID);
+    }
+
+    @Test
+    @WithMockUser
+    void latestInboundPermissionRecord_shouldReturnLatestRecord() throws Exception {
+        var inboundRecord = new LatestInboundPermissionRecordDto(
+                TIMESTAMP,
+                AiidaAsset.SUBMETER,
+                PAYLOAD
+        );
+
+        when(service.latestInboundPermissionRecord(PERMISSION_ID)).thenReturn(inboundRecord);
+
+        mockMvc.perform(get("/messages/permission/5211ea05-d4ab-48ff-8613-8f4791a56606/inbound/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.timestamp").value("2024-01-15T10:30:00Z"))
+               .andExpect(jsonPath("$.asset").value("SUBMETER"))
+               .andExpect(jsonPath("$.payload").value(PAYLOAD));
+
+        verify(service, times(1)).latestInboundPermissionRecord(PERMISSION_ID);
+    }
+
+    @Test
+    @WithMockUser
+    void latestOutboundPermissionRecord_shouldReturn400ForInvalidUUID() throws Exception {
+        mockMvc.perform(get("/messages/permission/invalid-uuid/outbound/latest")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isBadRequest());
+
+        verify(service, never()).latestOutboundPermissionRecord(any());
+    }
+}

--- a/aiida/ui/src/api.ts
+++ b/aiida/ui/src/api.ts
@@ -230,3 +230,21 @@ export async function getDataSourceImage(dataSourceId: string): Promise<Blob> {
     method: 'GET',
   })
 }
+
+export async function getLatestDataSourceMessage(id: string) {
+  return fetch(`/messages/data-source/${id}/latest`, {
+    method: 'GET',
+  })
+}
+
+export async function getLatestOutboundPermissionMessage(id: string) {
+  return fetch(`/messages/permission/${id}/outbound/latest`, {
+    method: 'GET',
+  })
+}
+
+export async function getLatestInboundPermissionMessage(id: string) {
+  return fetch(`/messages/permission/${id}/inbound/latest`, {
+    method: 'GET',
+  })
+}

--- a/aiida/ui/src/components/Button.vue
+++ b/aiida/ui/src/components/Button.vue
@@ -1,15 +1,33 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-const { buttonStyle = 'primary', size = 'normal' } = defineProps<{
+const {
+  buttonStyle,
+  size,
+  href,
+  download,
+  isLink = false,
+  disabled = undefined,
+} = defineProps<{
   buttonStyle?: 'primary' | 'secondary' | 'error' | 'error-secondary'
   size?: 'small' | 'normal' | 'medium'
+  href?: string
+  download?: string
+  disabled?: boolean
+  isLink?: boolean
 }>()
 </script>
 
 <template>
-  <button class="button" :class="[buttonStyle, size]">
+  <component
+    :is="isLink ? 'a' : 'button'"
+    class="button"
+    :class="[buttonStyle, size, { 'is-disabled': disabled }]"
+    :href
+    :download
+    :disabled
+  >
     <slot />
-  </button>
+  </component>
 </template>
 
 <style scoped>
@@ -33,17 +51,22 @@ const { buttonStyle = 'primary', size = 'normal' } = defineProps<{
   font-weight: 600;
   width: fit-content;
   height: fit-content;
+  text-decoration: none;
+}
 
-  &:hover {
-    color: var(--button-bg-color);
-    background-color: var(--button-color);
-  }
+.button:hover {
+  color: var(--button-bg-color);
+  background-color: var(--button-color);
+}
 
-  &:disabled {
-    color: var(--eddie-grey-medium);
-    border-color: var(--eddie-grey-medium);
-    background-color: var(--eddie-secondary);
-  }
+.button.is-disabled,
+.button[disabled],
+.button[aria-disabled='true'] {
+  color: var(--eddie-grey-medium);
+  border-color: var(--eddie-grey-medium);
+  background-color: var(--eddie-secondary);
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .secondary {

--- a/aiida/ui/src/components/DataSourceCard.vue
+++ b/aiida/ui/src/components/DataSourceCard.vue
@@ -3,12 +3,14 @@ import { BASE_URL } from '@/api'
 import Button from '@/components/Button.vue'
 import TrashIcon from '@/assets/icons/TrashIcon.svg'
 import PenIcon from '@/assets/icons/PenIcon.svg'
+import EyeIcon from '@/assets/icons/EyeIcon.svg'
 import DataSourceIcon from '@/components/DataSourceIcon.vue'
 import StatusDotIcon from '@/assets/icons/StatusDotIcon.svg'
 import ChevronDownIcon from '@/assets/icons/ChevronDownIcon.svg'
 import { computed, ref } from 'vue'
 import type { AiidaDataSource } from '@/types'
 import { dataSourceImages } from '@/stores/dataSources'
+import MessageDownloadButton from '@/components/MessageDownloadButton.vue'
 
 const COUNTRY_NAMES = new Intl.DisplayNames(['en'], { type: 'region' })
 
@@ -17,7 +19,7 @@ const { dataSource, startOpen } = defineProps<{
   startOpen?: boolean
 }>()
 const isOpen = ref(startOpen)
-const emit = defineEmits(['edit', 'delete', 'reset', 'enableToggle'])
+const emit = defineEmits(['edit', 'delete', 'reset', 'enableToggle', 'showLatestDataSourceMessage'])
 //TODO see #GH-1957
 const mqttCertificate = false
 
@@ -130,6 +132,9 @@ const image = computed(() => dataSourceImages.value[dataSource.id])
 
     <div class="actions">
       <Button button-style="error" @click="emit('delete')"><TrashIcon />Delete</Button>
+      <MessageDownloadButton :data="dataSource">
+        <EyeIcon /> Show Latest Message
+      </MessageDownloadButton>
       <Button @click="emit('edit')"><PenIcon />Edit</Button>
     </div>
   </article>

--- a/aiida/ui/src/components/DataSourceList.vue
+++ b/aiida/ui/src/components/DataSourceList.vue
@@ -40,6 +40,7 @@ onMounted(() => {
         @edit="emit('edit', dataSource)"
         @delete="handleDelete(dataSource.id)"
         @reset="emit('reset', dataSource.id)"
+        @showLatestDataSourceMessage="handleShowLatestDataSourceMessage(dataSource.id)"
         @enableToggle="handleEnableToggle(dataSource)"
       />
     </TransitionGroup>

--- a/aiida/ui/src/components/MessageDownloadButton.vue
+++ b/aiida/ui/src/components/MessageDownloadButton.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { ref, onBeforeUnmount, computed, useTemplateRef, nextTick } from 'vue'
+import Button from '@/components/Button.vue'
+import { createJsonBlobUrl, revokeUrl } from '@/utils/files'
+import type { AiidaDataSource, AiidaPermission } from '@/types'
+import {
+  getLatestDataSourceMessage,
+  getLatestInboundPermissionMessage,
+  getLatestOutboundPermissionMessage,
+} from '@/api'
+
+const { data } = defineProps<{
+  data: AiidaDataSource | AiidaPermission
+}>()
+
+const isPreparing = ref(false)
+const latestUrl = ref<string>('')
+const buttonRef = useTemplateRef('button')
+
+onBeforeUnmount(() => {
+  if (latestUrl.value) revokeUrl(latestUrl.value)
+  latestUrl.value = ''
+})
+
+const filename = computed(() => {
+  if ('id' in data) {
+    return `datasource_${data.id}_latest.json`
+  } else {
+    return `permission_${data.permissionId}_latest.json`
+  }
+})
+const handleClick = async () => {
+  if (isPreparing.value || latestUrl.value) return
+
+  isPreparing.value = true
+  try {
+    let latestMessage: unknown
+    if ('id' in data) {
+      latestMessage = await getLatestDataSourceMessage(data.id)
+    } else {
+      latestMessage =
+        data.dataNeed.type === 'inbound-aiida'
+          ? await getLatestInboundPermissionMessage(data.permissionId)
+          : await getLatestOutboundPermissionMessage(data.permissionId)
+    }
+    latestUrl.value = createJsonBlobUrl(latestMessage)
+    await nextTick()
+    buttonRef.value?.$el.click()
+
+    setTimeout(() => {
+      revokeUrl(latestUrl.value)
+      latestUrl.value = ''
+    }, 2000)
+  } catch (err) {
+    console.error(err)
+  } finally {
+    isPreparing.value = false
+  }
+}
+</script>
+
+<template>
+  <Button
+    :href="latestUrl || undefined"
+    ref="button"
+    button-style="primary"
+    :download="filename"
+    @click="handleClick"
+    is-link
+    :rel="'noopener'"
+  >
+    <slot>Show Latest Message</slot>
+  </Button>
+</template>

--- a/aiida/ui/src/components/PermissionDetails.vue
+++ b/aiida/ui/src/components/PermissionDetails.vue
@@ -15,6 +15,7 @@ import CrossedOutEyeIcon from '@/assets/icons/CrossedOutEyeIcon.svg'
 import ToolTipIcon from '@/assets/icons/ToolTipIcon.svg'
 import { onClickOutside } from '@vueuse/core'
 import CopyButton from './CopyButton.vue'
+import MessageDownloadButton from '@/components/MessageDownloadButton.vue'
 
 const { confirm } = useConfirmDialog()
 const target = useTemplateRef('target')
@@ -203,14 +204,15 @@ onClickOutside(target, () => (showToolTip.value = false))
         <dt>Last Data Package sent</dt>
         <dd>PLACEHOLDER</dd>
       </div>
-      <Button
-        button-style="error"
-        class="update-button"
-        v-if="status === 'Active'"
-        @click="handleRevoke"
-      >
-        <RevokeIcon /> Revoke
-      </Button>
+      <div v-if="status === 'Active'" class="actions-row">
+        <MessageDownloadButton :data="permission" class="action-btn">
+          <EyeIcon /> Show Latest Message
+        </MessageDownloadButton>
+
+        <Button button-style="error" class="action-btn" @click="handleRevoke">
+          <RevokeIcon /> Revoke
+        </Button>
+      </div>
       <Button
         v-if="status === 'Pending'"
         @click="updatePermission(permission)"
@@ -227,10 +229,9 @@ onClickOutside(target, () => (showToolTip.value = false))
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
-
-  &:first-child {
-    margin-bottom: var(--spacing-sm);
-  }
+}
+.column:first-child {
+  margin-bottom: var(--spacing-sm);
 }
 
 .permission-field {
@@ -285,6 +286,17 @@ onClickOutside(target, () => (showToolTip.value = false))
   width: 100%;
   justify-content: center;
   margin: auto 0 0 auto;
+}
+
+.actions-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  margin-top: auto;
+}
+.actions-row .action-btn {
+  width: 100%;
+  justify-content: center;
 }
 
 .access-code-field {
@@ -384,6 +396,11 @@ onClickOutside(target, () => (showToolTip.value = false))
     gap: calc(var(--spacing-xlg) + var(--spacing-sm) * 2 + 2px);
   }
   .update-button {
+    width: fit-content;
+    justify-content: flex-start;
+  }
+
+  .actions-row .action-btn {
     width: fit-content;
     justify-content: flex-start;
   }

--- a/aiida/ui/src/utils/files.ts
+++ b/aiida/ui/src/utils/files.ts
@@ -1,0 +1,10 @@
+export function createJsonBlobUrl(data: unknown): string {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: 'application/json;charset=utf-8',
+  })
+  return URL.createObjectURL(blob)
+}
+
+export function revokeUrl(url: string) {
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
The output contains the `timestamp`, `dataSourceId`, `asset` and the `aiidaRecordValues`.

Example:

```
{
  "timestamp": "2025-09-17T13:05:47.801701Z",
  "asset": "CONNECTION-AGREEMENT-POINT",
  "dataSourceId": "c05d6e63-ed06-4008-9e02-3d6fe5afe79b",
  "aiidaRecordValues": [
    {
      "obisCode": "1-0:1.8.0",
      "rawTag": "1-0:1.8.0",
      "rawValue": "1919",
      "rawUnit": "kWh",
      "value": "1919",
      "unit": "kWh",
      "sourceKey": ""
    },
    {
      "obisCode": "1-0:2.8.0",
      "rawTag": "1-0:2.8.0",
      "rawValue": "1033",
      "rawUnit": "kWh",
      "value": "1033",
      "unit": "kWh",
      "sourceKey": ""
    }
  ]
}
```

<img width="1084" height="733" alt="swappy-20250930_164222" src="https://github.com/user-attachments/assets/993bb3d1-d3d3-4819-b9e7-5063079aba17" />
<img width="565" height="624" alt="swappy-20250930_164157" src="https://github.com/user-attachments/assets/0f150372-aa66-4841-b573-6650e1082232" />
