### PR TITLE
NOISSUE fallback to root html for vue paths

### DIFF
--- a/aiida/src/main/java/energy/eddie/aiida/web/HomeController.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/HomeController.java
@@ -12,9 +12,10 @@ public class HomeController {
     public static final Duration MAX_CONNECTION_ID_LIFETIME = Duration.ofHours(24);
     public static final String CONNECTION_ID_COOKIE_NAME = "connectionId";
 
-   @GetMapping(value = {"/", 
-                         "/{path:^(?!api$)[^\\.]*}", 
-                         "/**/{path:^(?!api$)[^\\.]*}"})
+    // Sonar wants to add a @PathVariable here, but we do NOT need it since we don't consume it
+    @SuppressWarnings("java:S6856")
+    @GetMapping(value = {"/",
+            "/{path:^(?!api$)[^.]*}"})
     public String vue(
             Model model,
             @Value("${aiida.public.url}") String aiidaPublicUrl,


### PR DESCRIPTION
we need to specifically redirect to the base .html file for sub paths so that vue router handles these files instead of the server!

admin console uses /** which can work but is probably to broad