### PR TITLE
GH-1932 align permission view look

### DIFF
--- a/aiida/ui/src/assets/main.css
+++ b/aiida/ui/src/assets/main.css
@@ -52,6 +52,10 @@
   @media (min-width: 1620px) {
     --content-padding: 10rem;
   }
+  @media screen and (min-width: 2565px) {
+    --max-content-width: 70vw;
+    font-size: clamp(16px, 1vw, 32px);
+  }
 }
 
 *,
@@ -121,7 +125,7 @@ body {
 }
 
 main {
-  height: 100%;
+  height: fit-content;
   border-radius: var(--border-radius);
   scrollbar-color: var(--eddie-primary) var(--light);
   display: flex;
@@ -227,6 +231,10 @@ select {
   border-radius: 9999px;
   left: calc(50% - 2rem);
   top: calc(50% - 2rem);
+}
+
+svg {
+  width: 1rem;
 }
 
 @keyframes spin {

--- a/aiida/ui/src/components/AlertToast.vue
+++ b/aiida/ui/src/components/AlertToast.vue
@@ -102,7 +102,7 @@ const progressBarDuration = `${duration}ms`
 }
 
 .icon {
-  min-width: 40px;
+  min-width: 2.5rem;
   border-radius: var(--border-radius);
   background: linear-gradient(322.21deg, var(--severity-color) -3.82%, #ffffff 96.51%);
 }

--- a/aiida/ui/src/components/AlertToastList.vue
+++ b/aiida/ui/src/components/AlertToastList.vue
@@ -44,7 +44,7 @@ const { toasts } = useToast()
 .v-enter-from,
 .v-leave-to {
   opacity: 0;
-  transform: translateY(30px);
+  transform: translateY(--spacing-xxl);
 }
 
 @media screen and (min-width: 1024px) {

--- a/aiida/ui/src/components/Button.vue
+++ b/aiida/ui/src/components/Button.vue
@@ -17,7 +17,6 @@ const { buttonStyle = 'primary', size = 'normal' } = defineProps<{
   --button-block-padding: var(--spacing-sm);
   --button-color: var(--light);
   --button-bg-color: var(--eddie-primary);
-
   display: flex;
   align-items: center;
   gap: var(--spacing-md);
@@ -30,6 +29,7 @@ const { buttonStyle = 'primary', size = 'normal' } = defineProps<{
   background-color: var(--button-bg-color);
   border: 1px solid var(--button-bg-color);
   border-radius: 2rem;
+  font-size: 1rem;
   font-weight: 600;
   width: fit-content;
   height: fit-content;

--- a/aiida/ui/src/components/Header.vue
+++ b/aiida/ui/src/components/Header.vue
@@ -56,6 +56,7 @@ import { selectedPermissionCategory } from '@/stores/selectedPermissionCategory'
 
 .logo {
   height: 3rem;
+  width: auto;
 }
 
 .header-nav {

--- a/aiida/ui/src/components/ModalDialog.vue
+++ b/aiida/ui/src/components/ModalDialog.vue
@@ -61,7 +61,7 @@ defineExpose({ showModal, close })
 
 @media screen and (min-width: 1024px) {
   .dialog {
-    overflow: unset;
+    overflow: auto;
   }
 }
 </style>

--- a/aiida/ui/src/components/Modals/DataSourceModal.vue
+++ b/aiida/ui/src/components/Modals/DataSourceModal.vue
@@ -455,7 +455,7 @@ defineExpose({ showModal })
   color: var(--light);
   top: 50%;
   transform: translateY(-50%);
-  margin-left: 4px;
+  margin-left: var(--spacing-xs);
 }
 
 .column {

--- a/aiida/ui/src/components/PermissionDropdown.vue
+++ b/aiida/ui/src/components/PermissionDropdown.vue
@@ -18,19 +18,23 @@ const isOpen = ref(false)
 <template>
   <li class="permission" :class="{ 'is-open': isOpen }">
     <header class="permission-header" @click="isOpen = !isOpen">
-      <PermissionIcon class="icon" />
-      <h2 class="heading-5 title">{{ permission.serviceName }}</h2>
+      <div class="header-title">
+        <PermissionIcon class="icon" />
+        <h2 class="heading-5 title">{{ permission.serviceName }}</h2>
+      </div>
       <p v-if="permission.unimplemented" class="small-data-graph">Placeholder</p>
-      <time class="non-essential">{{
-        new Date(permission.startTime).toLocaleDateString(undefined, {
-          day: '2-digit',
-          month: '2-digit',
-          year: 'numeric',
-        })
-      }}</time>
-      <time v-if="permission.grantTime" class="non-essential">
-        {{ new Date(permission.grantTime).toLocaleTimeString() }}
-      </time>
+      <div class="non-essential">
+        <time>{{
+          new Date(permission.startTime).toLocaleDateString(undefined, {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+          })
+        }}</time>
+        <time v-if="permission.grantTime">
+          {{ new Date(permission.grantTime).toLocaleTimeString() }}
+        </time>
+      </div>
       <StatusTag :status-type="status !== 'Complete' ? 'healthy' : 'unhealthy'" minimal-on-mobile>
         {{ STATUS[permission.status].title }}
       </StatusTag>
@@ -58,7 +62,7 @@ const isOpen = ref(false)
     }
     .permission-header {
       margin-bottom: var(--spacing-lg);
-      & > :not(button, h2, .icon) {
+      & > :not(button, .header-title) {
         opacity: 0;
         visibility: hidden;
       }
@@ -66,11 +70,21 @@ const isOpen = ref(false)
   }
 }
 
-.permission-header {
+.header-title {
   display: flex;
   align-items: center;
+  gap: var(--spacing-xlg);
+  justify-self: start;
+}
+
+.permission-header {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr)) auto auto;
+  align-items: center;
+  justify-items: center;
   width: 100%;
   gap: var(--spacing-xlg);
+  cursor: pointer;
   transition: margin-bottom 0.3s ease-out;
   > * {
     transition: opacity 0.5s ease-in;
@@ -85,6 +99,7 @@ const isOpen = ref(false)
 .chevron {
   cursor: pointer;
   justify-self: end;
+  align-self: flex-end;
   margin-left: auto;
   padding: 0.5rem;
   transition: transform 0.3s ease-in-out;
@@ -104,7 +119,6 @@ const isOpen = ref(false)
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  width: 100%;
 }
 
 .non-essential {
@@ -119,8 +133,9 @@ const isOpen = ref(false)
     display: flex;
   }
 
-  .title {
-    max-width: 50%;
+  .permission-header {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   }
 }
 
@@ -128,11 +143,13 @@ const isOpen = ref(false)
   .permission {
     padding: var(--spacing-lg) var(--spacing-xlg);
   }
-  .title {
-    width: 50%;
+  .permission-header {
+    grid-template-columns: minmax(0, 1.5fr) repeat(2, minmax(0, 1fr)) auto;
   }
+
   .non-essential {
-    display: block;
+    display: flex;
+    gap: var(--spacing-sm);
   }
 }
 </style>

--- a/aiida/ui/src/components/PermissionList.vue
+++ b/aiida/ui/src/components/PermissionList.vue
@@ -166,10 +166,6 @@ const handleCategoryChange = (category: string) => {
   width: 100%;
 }
 
-.icon {
-  min-width: 1rem;
-}
-
 .no-permissions {
   padding: var(--spacing-md);
 }
@@ -188,6 +184,7 @@ const handleCategoryChange = (category: string) => {
   grid-template-columns: 1fr 1fr 1fr;
   border-radius: 0.5rem 0.5rem 0 0;
   overflow: hidden;
+  margin-top: var(--spacing-md);
   height: fit-content;
   min-height: fit-content;
 

--- a/aiida/ui/src/components/StatusTag.vue
+++ b/aiida/ui/src/components/StatusTag.vue
@@ -8,7 +8,7 @@ const { statusType = 'healthy', minimalOnMobile } = defineProps<{
 
 <template>
   <div class="status-tag text-xsmall" :class="[statusType, minimalOnMobile && 'minimal']">
-    <StatusDotIcon />
+    <StatusDotIcon class="dot" />
     <span>
       <slot />
     </span>
@@ -40,6 +40,10 @@ const { statusType = 'healthy', minimalOnMobile } = defineProps<{
     > span {
       display: none;
     }
+  }
+
+  .dot {
+    width: 0.5rem;
   }
 
   @media screen and (min-width: 640px) {

--- a/aiida/ui/vite.config.ts
+++ b/aiida/ui/vite.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
       },
     }),
     vueDevTools(),
-    svgLoader(),
+    svgLoader({
+      svgoConfig: {
+        plugins: ["removeDimensions"]
+      }
+    }),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## Changes in PR
- media query for super large screens (bigger then 2k)
- nicer SVG handling
	- they now scale nicely thanks to SVGO & general 1rem width
- aligned items in permission header so that permissions always have a uniform look

## Screenshots 
OLD
<img width="2825" height="1180" alt="image" src="https://github.com/user-attachments/assets/31cc0f26-cbfa-4c9b-a57d-93e94d64e673" />
NEW
<img width="2825" height="1180" alt="image" src="https://github.com/user-attachments/assets/44c4f161-50c3-49eb-baac-444c3fa5ea30" />
