### PR TITLE
GH-2046: AIIDA show permission streaming details in permission view

### DIFF
--- a/aiida/src/main/java/energy/eddie/aiida/models/permission/MqttStreamingConfig.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/permission/MqttStreamingConfig.java
@@ -1,5 +1,6 @@
 package energy.eddie.aiida.models.permission;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import energy.eddie.api.agnostic.aiida.mqtt.MqttDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,8 +20,10 @@ public class MqttStreamingConfig {
     @Column(name = "password", nullable = false)
     private String password;
     @Column(name = "server_uri", nullable = false)
+    @JsonProperty
     private String serverUri;
     @Column(name = "data_topic", nullable = false)
+    @JsonProperty
     private String dataTopic;
     @Column(name = "status_topic", nullable = false)
     private String statusTopic;

--- a/aiida/src/main/java/energy/eddie/aiida/models/permission/Permission.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/permission/Permission.java
@@ -63,7 +63,7 @@ public class Permission {
     private String connectionId;
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @PrimaryKeyJoinColumn
-    @JsonIgnore
+    @JsonProperty
     @Nullable
     private MqttStreamingConfig mqttStreamingConfig;
     @Column(nullable = false)

--- a/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
+++ b/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
@@ -74,7 +74,11 @@ const dataSourceOptions = computed(() => {
 
       <div class="two-item-pair">
         <Button button-style="error-secondary" @click="handleInput(false)">Reject</Button>
-        <Button @click="handleInput(true)" :disabled="!selectedDataSource">Accept</Button>
+        <Button
+          @click="handleInput(true)"
+          :disabled="!selectedDataSource && permission?.dataNeed.type === 'outbound-aiida'"
+          >Accept
+        </Button>
       </div>
     </div>
     <div v-if="loading" class="loading-indicator"></div>

--- a/aiida/ui/src/components/PermissionDetails.vue
+++ b/aiida/ui/src/components/PermissionDetails.vue
@@ -135,6 +135,20 @@ onClickOutside(target, () => (showToolTip.value = false))
           <dt>Data Source</dt>
           <dd>{{ permission.dataSource?.name ?? 'undefined' }}</dd>
         </div>
+        <div
+          class="permission-field"
+          v-if="permission.mqttStreamingConfig && permission.mqttStreamingConfig.serverUri"
+        >
+          <dt>Streaming Uri</dt>
+          <dd>{{ permission.mqttStreamingConfig.serverUri }}</dd>
+        </div>
+        <div
+          class="permission-field"
+          v-if="permission.mqttStreamingConfig && permission.mqttStreamingConfig.dataTopic"
+        >
+          <dt>Streaming Topic</dt>
+          <dd>{{ permission.mqttStreamingConfig.dataTopic }}</dd>
+        </div>
       </template>
       <template v-if="permission.dataNeed.type === 'inbound-aiida' && permission.dataSource">
         <div

--- a/aiida/ui/src/types.d.ts
+++ b/aiida/ui/src/types.d.ts
@@ -46,12 +46,18 @@ export type AiidaPermission = {
   grantTime?: string
   dataNeed: AiidaDataNeed
   dataSource?: AiidaDataSource
+  mqttStreamingConfig?: AiidaPermissionStreamingConfig
   userId: string
   unimplemented: {
     packageGraph: any
     targetIP: any
     lastPackageSent: any
   }
+}
+
+export type AiidaPermissionStreamingConfig = {
+  dataTopic: string
+  serverUri: string
 }
 
 export type AiidaDataSourceType = {


### PR DESCRIPTION
Show permission streaming details: `dataTopic` and `serviceUri`. Therefore the user can see directly where the data is going to.

<img width="1223" height="544" alt="image" src="https://github.com/user-attachments/assets/a1f54cfd-aca8-4a4a-86de-2e15e3de8b83" />
