### PR TITLE
NOISSUE e2e-tests: Fix fluvius test where button was not correctly selected

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/tests/e2e/be/BeFluviusTest.java
+++ b/e2e-tests/src/test/java/energy/eddie/tests/e2e/be/BeFluviusTest.java
@@ -13,7 +13,7 @@ class BeFluviusTest extends E2eTestSetup {
         this.navigateToRegionConnector(null, "Belgium", null);
 
         // Click create button
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create")).click();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Connect").setExact(true)).click();
 
         // Check if button shows the correct page
         assertThat(page.getByText("Permission granted")).isVisible();


### PR DESCRIPTION
The failing e2e test is related to the austrian region connector.