### PR TITLE
NOISSUE Use setup-gradle action over separate cache actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,18 +43,9 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradlew', 'gradlew.bat', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-wrapper
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build and analyze
         env:


### PR DESCRIPTION
Removes the need for custom caching code and adds the following (according to the [plugin documentation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md)).

<img width="1283" height="467" alt="Screenshot From 2025-11-18 10-31-24" src="https://github.com/user-attachments/assets/fc6179f4-5f82-43b2-a441-39123d0edb7e" />

No noticeable performance change for now.