### PR TITLE
GH-2113 AT-EDA: Rework revoke queries

### DIFF
--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/api/AtPermissionRequestRepository.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/api/AtPermissionRequestRepository.java
@@ -49,12 +49,12 @@ public interface AtPermissionRequestRepository extends PermissionRequestReposito
      * @param date            to filter time relevant permission requests
      * @return a list of matching permission requests
      */
-    List<AtPermissionRequest> findAcceptedAndFulfilledByMeteringPointIdAndDate(
+    List<AtPermissionRequestProjection> findAcceptedAndFulfilledByMeteringPointIdAndDate(
             String meteringPointId,
             LocalDate date
     );
 
-    Optional<AtPermissionRequest> findByConsentId(String consentId);
+    Optional<AtPermissionRequestProjection> findByConsentId(String consentId);
 
     List<AtPermissionRequest> findByStatusIn(Set<PermissionProcessStatus> status);
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/persistence/JpaPermissionRequestRepository.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/persistence/JpaPermissionRequestRepository.java
@@ -69,21 +69,73 @@ public interface JpaPermissionRequestRepository extends PagingAndSortingReposito
     );
 
     @Override
-    @Query("""
-             SELECT pr FROM EdaPermissionRequest pr
-             WHERE pr.meteringPointId = :meteringPointId
-                 AND (pr.status = energy.eddie.api.v0.PermissionProcessStatus.ACCEPTED
-                    OR pr.status = energy.eddie.api.v0.PermissionProcessStatus.FULFILLED)
-                 AND pr.start <= :date
-                 AND (pr.end >= :date OR pr.end IS NULL)
-            """)
-    List<AtPermissionRequest> findAcceptedAndFulfilledByMeteringPointIdAndDate(
+    @Query(value = """
+             WITH permissions_for_metering_point AS (SELECT DISTINCT ON (permission_id) permission_id
+                                                     FROM at_eda.permission_event
+                                                     WHERE metering_point_id = :meteringPointId),
+              permission_result AS (SELECT DISTINCT ON (pe.permission_id) pe.permission_id,
+                                      at_eda.firstval_agg(cm_request_id) OVER w     AS cm_request_id,
+                                      at_eda.firstval_agg(connection_id) OVER w     AS connection_id,
+                                      at_eda.firstval_agg(conversation_id) OVER w   AS conversation_id,
+                                      at_eda.firstval_agg(created) OVER w           AS created,
+                                      at_eda.firstval_agg(data_need_id) OVER w      AS data_need_id,
+                                      at_eda.firstval_agg(dso_id) OVER w            AS dso_id,
+                                      at_eda.firstval_agg(granularity) OVER w       AS granularity,
+                                      at_eda.firstval_agg(metering_point_id) OVER w AS metering_point_id,
+                                      at_eda.firstval_agg(permission_start) OVER w  AS permission_start,
+                                      at_eda.firstval_agg(permission_end) OVER w    AS permission_end,
+                                      at_eda.firstval_agg(cm_consent_id) OVER w     AS cm_consent_id,
+                                      at_eda.firstval_agg(message) OVER w           AS message,
+                                      at_eda.firstval_agg(status) OVER w            AS status,
+                                      at_eda.firstval_agg(cause) OVER w             AS cause
+                                    FROM at_eda.permission_event pe, permissions_for_metering_point pm
+                                    WHERE pe.permission_id = pm.permission_id
+                                    WINDOW w AS (PARTITION BY pe.permission_id ORDER BY event_created DESC)
+                                    ORDER BY pe.permission_id, pe.event_created)
+             SELECT pr
+             FROM permission_result pr
+             where pr.permission_start <= :date
+               AND (pr.permission_end >= :date OR pr.permission_end IS NULL)
+               AND pr.status IN ('ACCEPTED','FULFILLED');
+            """, nativeQuery = true)
+    List<AtPermissionRequestProjection> findAcceptedAndFulfilledByMeteringPointIdAndDate(
             @Param("meteringPointId") String meteringPointId,
             @Param("date") LocalDate date
     );
 
     @Override
-    Optional<AtPermissionRequest> findByConsentId(@Param("consentId") String consentId);
+    @Query(value = """
+        WITH permissions AS (
+            SELECT DISTINCT ON (permission_id) permission_id
+            FROM at_eda.permission_event
+            WHERE cm_consent_id = :consentId
+        )
+        SELECT DISTINCT ON (pe.permission_id)
+            pe.permission_id,
+            at_eda.firstval_agg(pe.cm_request_id)     OVER w AS cm_request_id,
+            at_eda.firstval_agg(pe.connection_id)     OVER w AS connection_id,
+            at_eda.firstval_agg(pe.conversation_id)   OVER w AS conversation_id,
+            at_eda.firstval_agg(pe.created)           OVER w AS created,
+            at_eda.firstval_agg(pe.data_need_id)      OVER w AS data_need_id,
+            at_eda.firstval_agg(pe.dso_id)            OVER w AS dso_id,
+            at_eda.firstval_agg(pe.granularity)       OVER w AS granularity,
+            at_eda.firstval_agg(pe.metering_point_id) OVER w AS metering_point_id,
+            at_eda.firstval_agg(pe.permission_start)  OVER w AS permission_start,
+            at_eda.firstval_agg(pe.permission_end)    OVER w AS permission_end,
+            at_eda.firstval_agg(pe.cm_consent_id)     OVER w AS cm_consent_id,
+            at_eda.firstval_agg(pe.message)           OVER w AS message,
+            at_eda.firstval_agg(pe.status)            OVER w AS status,
+            at_eda.firstval_agg(pe.cause)             OVER w AS cause
+        FROM at_eda.permission_event pe
+                 JOIN permissions USING (permission_id)
+        WINDOW w AS (
+                PARTITION BY pe.permission_id
+                ORDER BY pe.event_created DESC
+                ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                )
+        ORDER BY pe.permission_id, pe.event_created DESC;
+        """, nativeQuery = true)
+    Optional<AtPermissionRequestProjection> findByConsentId(@Param("consentId") String consentId);
 
     @Override
     List<AtPermissionRequest> findByStatusIn(Set<PermissionProcessStatus> status);


### PR DESCRIPTION
Rework Revoke queries to filter the `permission_table` before applying the window functions. Therefore the query time is reduced from 60s to 1-2s.