### PR TITLE
NOISSUE cleanup redirects in deadlink check

### DIFF
--- a/.github/workflows/deadlink-check.yml
+++ b/.github/workflows/deadlink-check.yml
@@ -25,7 +25,7 @@ jobs:
           # Ignores private github links and localhost links, which would make it fail.
           # Furthermore, it ignores specific links that do not accept requests using automated means, such as npmjs.
           # User agent is set to Mozilla for most compatibility.
-          args: --exclude '^https://github\.com/eddie-energy/' --exclude '^https://gw.ext.prod.api.enedis.fr' --exclude '^https://www.eancodeboek.nl' --exclude '^https://particulier.edf.fr/en/home/contract-and-consumption/meter/linky-meter.html$' --exclude '^https://www.npmjs.com/' --exclude 'https://.+\.sharepoint.com' --exclude-all-private --user-agent 'Mozilla/5.0' --exclude-path 'node_modules' --hidden --extensions md --root-dir $(pwd) --insecure .
+          args: --exclude '^https://github\.com/eddie-energy/' --exclude '^https://gw.ext.prod.api.enedis.fr' --exclude '^https://www.eancodeboek.nl' --exclude '^https://particulier.edf.fr/en/home/contract-and-consumption/meter/linky-meter.html$' --exclude '^https://www.npmjs.com/' --exclude 'https://.+\.sharepoint.com' --exclude 'https://eddie.energy/metadata-sharing' --exclude '^https://mvnrepository\.com/' --exclude-all-private --user-agent 'Mozilla/5.0' --exclude-path 'node_modules' --hidden --extensions md --root-dir $(pwd) --insecure .
           fail: 'true'
       - name: Comment Broken Links
         uses: marocchino/sticky-pull-request-comment@v2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [![EDDIE - European Distributed Data Infrastructure for Energy](docs/images/eddie-horizontal.svg)](https://eddie.energy)
 
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11443/badge)](https://www.bestpractices.dev/projects/11443)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11443/badge)](https://www.bestpractices.dev/en/projects/11443)
 
 [EDDIE](https://eddie.energy) provides a unified interface for requesting energy data from various MDAs (Metered Data Administrators) throughout
 the European Union.

--- a/aiida/docs-legacy/datasources/shelly/Shelly.md
+++ b/aiida/docs-legacy/datasources/shelly/Shelly.md
@@ -24,7 +24,7 @@ After wiring and mounting, connect the device to your Wi-Fi network and configur
 
 - **Three-phase**
 - **Shelly Pro 3 EM Gen2:** https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen2/ShellyPro3EM/
-- **Shelly 3EM:** https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/Shelly3EMG3
+- **Shelly 3EM:** https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/Shelly3EMG3/
 
 #### Data
 
@@ -48,8 +48,8 @@ In the `monophase` profile there are three energy meters `EM1`, one per measured
 ![Shelly EM Gen3](ShellyEMGen3.png)
 
 - **Single-phase**
-- **Shelly Pro EM Gen2:** https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen2/ShellyProEM
-- **Shelly EM Gen3:** https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/ShellyEMG3
+- **Shelly Pro EM Gen2:** https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen2/ShellyProEM/
+- **Shelly EM Gen3:** https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/ShellyEMG3/
 
 #### Data
 

--- a/docs/1-running/region-connectors/region-connector-us-green-button.md
+++ b/docs/1-running/region-connectors/region-connector-us-green-button.md
@@ -14,7 +14,7 @@ Currently, it emits the following information:
 - Register at [UtilityAPI](https://utilityapi.com/register)
 - Register at the utility you want to support, those can be found [here](https://utilityapi.com/docs/utilities)
 - After registration, all your utilities will be listed under _Utility Registration_ in
-  your [settings](https://utilityapi.com/settings)
+  your [settings](https://utilityapi.com/login?next=/settings)
 - For each registered utility, you will have OAuth settings in which you can find the following needed information for
   the configuration:
     - `Client ID`


### PR DESCRIPTION
## Changes
- exclude maven repo since those sometimes fail
- exclude specific URLs like eddie.energy/metadata-sharing  since we know those cause redirects
- fix other links that caused redirects