### PR TITLE
GH-2184 Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+* @eddie-energy/fh-dev
+ 
+# fh-dev is used as a fallback in case the main reviewer is unavailable
+admin-console @re1 @eddie-energy/fh-dev
+aiida @stefanpenzinger @tformatix @Maikaru-Sensei @eddie-energy/fh-dev
+aiida/ui @GoodVibezOnly @re1 @eddie-energy/fh-dev
+cim @fweingartshofer @eddie-energy/fh-dev
+core/src/main/js @re1 @eddie-energy/fh-dev
+e2e-tests @re1 @eddie-energy/fh-dev
+european-masterdata @re1 @eddie-energy/fh-dev
+outbound-connectors @fweingartshofer @eddie-energy/fh-dev
+region-connectors @fweingartshofer @eddie-energy/fh-dev
+region-connectors/region-connector-aiida @stefanpenzinger @tformatix @Maikaru-Sensei @eddie-energy/fh-dev
+region-connectors/*.js @re1 @eddie-energy/fh-dev


### PR DESCRIPTION
> A CODEOWNERS or COMMITTERS file to define individuals or teams that are responsible for code in a repository, as well as documenting current project owners and current and emeritus committers. 

PR declares that all code in the repository is owned by the fh-dev team.

We might want to specify narrower responsibilities in addition, like for AIIDA, (each) RCS, Button, Admin, CIM, etc. We can discuss this here and in the JF.

Closes #2184.