### PR TITLE
GH-2224 fix mqtt show password button

### DIFF
--- a/aiida/src/main/resources/application.yml
+++ b/aiida/src/main/resources/application.yml
@@ -48,7 +48,7 @@ aiida:
       inbound-record:
         retention: P1D
   public:
-    url: ${AIIDA_EXTERNAL_HOST:http://localhost:${server.port}}
+    url: ${AIIDA_EXTERNAL_HOST:http://localhost:${server.port:8080}}
   installer:
     host: http://aiida-installer:8010
   mqtt:

--- a/aiida/ui/src/components/CopyButton.vue
+++ b/aiida/ui/src/components/CopyButton.vue
@@ -19,7 +19,13 @@ const isCopied = computed(() => {
 </script>
 
 <template>
-  <button class="copy-button" :disabled="isCopied" :class="{ isCopied }" @click="handleCopy">
+  <button
+    class="copy-button"
+    :disabled="isCopied"
+    :class="{ isCopied }"
+    @click="handleCopy"
+    type="button"
+  >
     <Transition mode="out-in">
       <component :is="isCopied ? CheckmarkIcon : CopyIcon" />
     </Transition>

--- a/aiida/ui/src/components/Modals/MqttPasswordModal.vue
+++ b/aiida/ui/src/components/Modals/MqttPasswordModal.vue
@@ -11,7 +11,7 @@ import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 const modal = useTemplateRef<HTMLDialogElement>('modal')
 const pass = ref<string | undefined>()
-const show = ref(false)
+const showPassword = ref(false)
 const title = ref('')
 
 const showModal = (password?: string, isNew?: boolean) => {
@@ -21,11 +21,11 @@ const showModal = (password?: string, isNew?: boolean) => {
 }
 
 const handleShow = () => {
-  show.value = !show.value
+  showPassword.value = !showPassword.value
 }
 
 const closeModal = () => {
-  show.value = false
+  showPassword.value = false
 }
 
 defineExpose({ showModal })
@@ -40,19 +40,22 @@ defineExpose({ showModal })
       <input
         readonly
         autocomplete="off"
-        :type="show ? 'text' : 'password'"
+        :type="showPassword ? 'text' : 'password'"
         :value="pass"
         name="password"
       />
       <div class="actions">
         <CopyButton :copy-text="pass" :aria-label="t('permissions.copyMqttPassword')" />
         <button
-          class="show-button"
+          class="showPassword-button"
           @click="handleShow"
-          :aria-label="show ? t('permissions.hideMqttPassword') : t('permissions.showMqttPassword')"
+          :aria-label="
+            showPassword ? t('permissions.hideMqttPassword') : t('permissions.showMqttPassword')
+          "
+          type="button"
         >
           <Transition mode="out-in">
-            <component :is="show ? EyeIcon : CrossedOutEyeIcon" />
+            <component :is="showPassword ? EyeIcon : CrossedOutEyeIcon" />
           </Transition>
         </button>
       </div>
@@ -71,7 +74,7 @@ defineExpose({ showModal })
 
 .actions {
   display: flex;
-  gap: var(--spacing-sm);
+  gap: var(--spacing-md);
   align-items: center;
   position: absolute;
   right: var(--spacing-md);
@@ -96,8 +99,13 @@ button.copied {
   color: var(--eddie-green);
 }
 
-.show-button {
+.showPassword-button {
   color: var(--eddie-grey-medium);
+  padding: unset;
+  svg {
+    height: 1rem;
+    width: 1rem;
+  }
 }
 
 .input-field {


### PR DESCRIPTION
Issue was that without the `type="button"` prop the :eye: button was considered as a submit button for the form  which caused the page to reload on click 

## changes in pr
- renamed show ref to showPassword ref for more clearity
- added type button to copy button and mqtt password button to prevent form submission
- adapted aiida application.yml since application run would fail if this is not fixed
	- noticed this when i reset aiida for this bug and thought it is probably because we all usually have an application-local.yml. Let me know if i should revert it :sweat:  