### PR TITLE
NOISSUE Remove caching of SonarCloud packages as it slows down builds on the self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
       - ".sonarlint/**"
       - ".run/**"
       - "**.md"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Ran two builds and the total run time was significantly lower than the previous runs.

Sonar complains about our action dependencies not having version hashes. Will not address this here.

<img width="1590" height="1247" alt="image" src="https://github.com/user-attachments/assets/00928edf-b9a1-4392-8f7b-7be5781ffc50" />
