### PR TITLE
GH-2191: Map validated historical data to CIM document

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
@@ -105,10 +105,11 @@ public class EtaPlusApiClient {
         List<EtaPlusMeteredData.MeterReading> domainReadings = readings.stream()
                 .filter(dto -> dto.timestamp() != null)
                 .map(dto -> new EtaPlusMeteredData.MeterReading(
-                        dto.timestamp().toString(),
+                        dto.timestamp().toZonedDateTime(),
                         dto.value(),
                         dto.unit(),
-                        dto.status()
+                        dto.status(),
+                        dto.direction()
                 ))
                 .toList();
 
@@ -185,6 +186,7 @@ public class EtaPlusApiClient {
             OffsetDateTime timestamp,
             Double value,
             String unit,
-            String status
+            String status,
+            String direction
     ) {}
 }

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusMeteredData.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusMeteredData.java
@@ -1,17 +1,16 @@
 package energy.eddie.regionconnector.de.eta.providers;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
- * Represents metered data from the ETA Plus API.
- * This is a placeholder structure that should be replaced with the actual
- * ETA Plus API response format once the API specification is available.
+ * Metered data fetched from the ETA Plus historical-readings endpoint for a single metering point.
  *
  * @param meteringPointId the metering point identifier
- * @param startDate       the start date of the metering period
- * @param endDate         the end date of the metering period
- * @param readings        the list of meter readings
+ * @param startDate       inclusive lower bound of the request window
+ * @param endDate         inclusive upper bound of the request window
+ * @param readings        readings returned for the window
  */
 public record EtaPlusMeteredData(
         String meteringPointId,
@@ -21,18 +20,19 @@ public record EtaPlusMeteredData(
 ) {
 
     /**
-     * Individual meter reading within a time series.
+     * One reading element from the ETA Plus historical-readings response.
      *
-     * @param timestamp the timestamp of the reading (ISO 8601)
-     * @param value     the measured value
-     * @param unit      the unit of measurement (e.g., kWh, Wh)
-     * @param quality   the quality indicator of the reading
+     * @param timestamp reading timestamp (UTC, per backend contract)
+     * @param value     measured value
+     * @param unit      wire unit string (e.g. {@code "kWh"}, {@code "m³"}); constant within a response
+     * @param quality   wire status string; backend always emits {@code "VALIDATED"} on this endpoint
+     * @param direction wire direction string; backend always emits {@code "Consumption"} or {@code "Generation"}
      */
     public record MeterReading(
-            String timestamp,
+            ZonedDateTime timestamp,
             Double value,
             String unit,
-            String quality
+            String quality,
+            String direction
     ) {}
 }
-

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappings.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappings.java
@@ -1,0 +1,52 @@
+package energy.eddie.regionconnector.de.eta.providers;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Shared wire-string-to-CIM mappings used by both v0.82 and v1.04 intermediate VHD documents.
+ *
+ * <p>Holds only logic that is identical across CIM versions; version-specific enum lookups stay in
+ * the intermediate docs themselves so each one keeps its own type signatures.
+ */
+public final class EtaPlusVhdMappings {
+
+    private EtaPlusVhdMappings() {}
+
+    /**
+     * Translates an ETA Plus wire {@code unit} string to its CIM XML schema unit code.
+     *
+     * <p>Throws {@link IllegalArgumentException} for unsupported units; callers catch this and skip
+     * the response with a warn log.
+     */
+    public static String translateUnit(String wireUnit) {
+        if (wireUnit == null) {
+            throw new IllegalArgumentException("null");
+        }
+        return switch (wireUnit) {
+            case "kWh", "KWH" -> "KWH";
+            case "MWh", "MWH" -> "MWH";
+            case "m³", "m3", "M3" -> "MTQ";
+            default -> throw new IllegalArgumentException(wireUnit);
+        };
+    }
+
+    /** {@code true} if the wire {@code direction} is {@code "Generation"} (prosumer feed-in). */
+    public static boolean isProduction(String direction) {
+        return "Generation".equals(direction);
+    }
+
+    /** {@code true} if the wire {@code status} is {@code "VALIDATED"} — the only value the
+     * /meters/historical endpoint emits per contract. */
+    public static boolean isValidatedStatus(String wireStatus) {
+        return "VALIDATED".equals(wireStatus);
+    }
+
+    /** Returns readings ordered by ascending timestamp. */
+    public static List<EtaPlusMeteredData.MeterReading> sortByTimestamp(
+            List<EtaPlusMeteredData.MeterReading> readings) {
+        return readings.stream()
+                .sorted(Comparator.comparing(EtaPlusMeteredData.MeterReading::timestamp))
+                .toList();
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappings.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappings.java
@@ -13,24 +13,6 @@ public final class EtaPlusVhdMappings {
 
     private EtaPlusVhdMappings() {}
 
-    /**
-     * Translates an ETA Plus wire {@code unit} string to its CIM XML schema unit code.
-     *
-     * <p>Throws {@link IllegalArgumentException} for unsupported units; callers catch this and skip
-     * the response with a warn log.
-     */
-    public static String translateUnit(String wireUnit) {
-        if (wireUnit == null) {
-            throw new IllegalArgumentException("null");
-        }
-        return switch (wireUnit) {
-            case "kWh", "KWH" -> "KWH";
-            case "MWh", "MWH" -> "MWH";
-            case "m³", "m3", "M3" -> "MTQ";
-            default -> throw new IllegalArgumentException(wireUnit);
-        };
-    }
-
     /** {@code true} if the wire {@code direction} is {@code "Generation"} (prosumer feed-in). */
     public static boolean isProduction(String direction) {
         return "Generation".equals(direction);

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeValidatedHistoricalDataEnvelopeProvider.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeValidatedHistoricalDataEnvelopeProvider.java
@@ -1,0 +1,39 @@
+package energy.eddie.regionconnector.de.eta.providers.v0_82;
+
+import energy.eddie.api.agnostic.MessageStream;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.cim.v0_82.vhd.ValidatedHistoricalDataEnvelope;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
+import energy.eddie.regionconnector.de.eta.providers.ValidatedHistoricalDataStream;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+/**
+ * CIM v0.82 Validated Historical Data provider for the German ETA Plus connector (backwards compatible).
+ */
+@Component
+public class DeValidatedHistoricalDataEnvelopeProvider {
+
+    private final Flux<IdentifiableValidatedHistoricalData> identifiableData;
+    private final CommonInformationModelConfiguration cimConfig;
+    private final DeEtaPlusConfiguration deConfiguration;
+
+    public DeValidatedHistoricalDataEnvelopeProvider(
+            ValidatedHistoricalDataStream stream,
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+            CommonInformationModelConfiguration cimConfig,
+            DeEtaPlusConfiguration deConfiguration
+    ) {
+        this.identifiableData = stream.validatedHistoricalData();
+        this.cimConfig = cimConfig;
+        this.deConfiguration = deConfiguration;
+    }
+
+    @MessageStream(ValidatedHistoricalDataEnvelope.class)
+    public Flux<ValidatedHistoricalDataEnvelope> getValidatedHistoricalDataMarketDocumentsStream() {
+        return identifiableData
+                .map(data -> new IntermediateValidatedHistoricalDataEnvelope(cimConfig, deConfiguration, data))
+                .flatMapIterable(IntermediateValidatedHistoricalDataEnvelope::toVhd);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelope.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelope.java
@@ -1,0 +1,209 @@
+package energy.eddie.regionconnector.de.eta.providers.v0_82;
+
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.cim.CommonInformationModelVersions;
+import energy.eddie.cim.v0_82.vhd.*;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusVhdMappings;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
+import energy.eddie.regionconnector.shared.cim.v0_82.EsmpDateTime;
+import energy.eddie.regionconnector.shared.cim.v0_82.EsmpTimeInterval;
+import energy.eddie.regionconnector.shared.cim.v0_82.vhd.VhdEnvelope;
+import jakarta.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Maps a single ETA Plus historical-readings response to a CIM v0.82
+ * {@link ValidatedHistoricalDataEnvelope} for backwards compatibility.
+ *
+ * <p>Same response shape as the v1.04 mapping: one MP, one unit, one direction, one TimeSeries.
+ */
+class IntermediateValidatedHistoricalDataEnvelope {
+    private static final Logger LOGGER = LoggerFactory.getLogger(IntermediateValidatedHistoricalDataEnvelope.class);
+
+    private final CommonInformationModelConfiguration cimConfig;
+    private final DeEtaPlusConfiguration deConfiguration;
+    private final IdentifiableValidatedHistoricalData identifiableData;
+
+    IntermediateValidatedHistoricalDataEnvelope(
+            CommonInformationModelConfiguration cimConfig,
+            DeEtaPlusConfiguration deConfiguration,
+            IdentifiableValidatedHistoricalData identifiableData
+    ) {
+        this.cimConfig = cimConfig;
+        this.deConfiguration = deConfiguration;
+        this.identifiableData = identifiableData;
+    }
+
+    public List<ValidatedHistoricalDataEnvelope> toVhd() {
+        var payload = identifiableData.payload();
+        var readings = payload.readings();
+        if (readings == null || readings.isEmpty()) {
+            return List.of();
+        }
+
+        var firstReading = readings.get(0);
+        UnitOfMeasureTypeList unit;
+        try {
+            unit = UnitOfMeasureTypeList.fromValue(EtaPlusVhdMappings.translateUnit(firstReading.unit()));
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Skipping VHD for metering point {}: unsupported unit '{}'",
+                    payload.meteringPointId(), firstReading.unit());
+            return List.of();
+        }
+
+        var sortedReadings = EtaPlusVhdMappings.sortByTimestamp(readings);
+        var start = sortedReadings.get(0).timestamp();
+        var end = sortedReadings.get(sortedReadings.size() - 1).timestamp();
+
+        var permissionRequest = identifiableData.permissionRequest();
+        var energyType = permissionRequest.energyType();
+        var direction = firstReading.direction();
+        var senderId = permissionRequest.dataSourceInformation().meteredDataAdministratorId();
+
+        var vhd = new ValidatedHistoricalDataMarketDocumentComplexType()
+                .withMRID(UUID.randomUUID().toString())
+                .withRevisionNumber(CommonInformationModelVersions.V0_82.version())
+                .withType(MessageTypeList.MEASUREMENT_VALUE_DOCUMENT)
+                .withCreatedDateTime(new EsmpDateTime(ZonedDateTime.now(ZoneOffset.UTC)).toString())
+                .withSenderMarketParticipantMarketRoleType(RoleTypeList.METERING_POINT_ADMINISTRATOR)
+                .withReceiverMarketParticipantMarketRoleType(RoleTypeList.CONSUMER)
+                .withProcessProcessType(ProcessTypeList.REALISED)
+                .withSenderMarketParticipantMRID(
+                        new PartyIDStringComplexType()
+                                .withCodingScheme(CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME)
+                                .withValue(senderId)
+                )
+                .withReceiverMarketParticipantMRID(
+                        new PartyIDStringComplexType()
+                                .withCodingScheme(cimConfig.eligiblePartyNationalCodingScheme())
+                                .withValue(deConfiguration.eligiblePartyId())
+                )
+                .withPeriodTimeInterval(esmpInterval(start, end))
+                .withTimeSeriesList(
+                        new ValidatedHistoricalDataMarketDocumentComplexType.TimeSeriesList()
+                                .withTimeSeries(timeSeries(payload, sortedReadings, energyType, unit, direction, start, end))
+                );
+
+        return List.of(new VhdEnvelope(vhd, permissionRequest).wrap());
+    }
+
+    private TimeSeriesComplexType timeSeries(
+            EtaPlusMeteredData payload,
+            List<EtaPlusMeteredData.MeterReading> sortedReadings,
+            EnergyType energyType,
+            UnitOfMeasureTypeList unit,
+            String direction,
+            ZonedDateTime start,
+            ZonedDateTime end
+    ) {
+        var ts = new TimeSeriesComplexType()
+                .withMRID(UUID.randomUUID().toString())
+                .withBusinessType(businessTypeFor(direction))
+                .withMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity(commodityKindFor(energyType))
+                .withFlowDirectionDirection(flowDirectionFor(direction))
+                .withEnergyMeasurementUnitName(unit)
+                .withMarketEvaluationPointMRID(
+                        new MeasurementPointIDStringComplexType()
+                                .withCodingScheme(CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME)
+                                .withValue(payload.meteringPointId())
+                )
+                .withReasonList(
+                        new TimeSeriesComplexType.ReasonList()
+                                .withReasons(new ReasonComplexType()
+                                        .withCode(ReasonCodeTypeList.ERRORS_NOT_SPECIFICALLY_IDENTIFIED))
+                )
+                .withSeriesPeriodList(
+                        new TimeSeriesComplexType.SeriesPeriodList()
+                                .withSeriesPeriods(seriesPeriod(sortedReadings, start, end))
+                );
+
+        // Q-2 (L1): set product only for electricity; CIM v0.82 has no gas-appropriate value.
+        var product = productFor(energyType);
+        if (product != null) {
+            ts.withProduct(product);
+        }
+        return ts;
+    }
+
+    private SeriesPeriodComplexType seriesPeriod(
+            List<EtaPlusMeteredData.MeterReading> sortedReadings,
+            ZonedDateTime start,
+            ZonedDateTime end
+    ) {
+        var granularity = identifiableData.permissionRequest().granularity();
+
+        var points = new ArrayList<PointComplexType>(sortedReadings.size());
+        for (int i = 0; i < sortedReadings.size(); i++) {
+            var reading = sortedReadings.get(i);
+            var point = new PointComplexType()
+                    .withPosition(String.valueOf(i + 1))
+                    .withEnergyQuantityQuantity(BigDecimal.valueOf(reading.value()));
+            var quality = qualityFor(reading.quality());
+            if (quality != null) {
+                point.withEnergyQuantityQuality(quality);
+            }
+            points.add(point);
+        }
+
+        return new SeriesPeriodComplexType()
+                .withResolution(granularity.toString())
+                .withTimeInterval(esmpInterval(start, end))
+                .withPointList(new SeriesPeriodComplexType.PointList().withPoints(points));
+    }
+
+    private static ESMPDateTimeIntervalComplexType esmpInterval(ZonedDateTime start, ZonedDateTime end) {
+        var interval = new EsmpTimeInterval(start, end);
+        return new ESMPDateTimeIntervalComplexType()
+                .withStart(interval.start())
+                .withEnd(interval.end());
+    }
+
+    private CommodityKind commodityKindFor(EnergyType energyType) {
+        return switch (energyType) {
+            case ELECTRICITY -> CommodityKind.ELECTRICITYPRIMARYMETERED;
+            case NATURAL_GAS -> CommodityKind.NATURALGAS;
+            default -> throw new IllegalStateException("Unsupported energy type: " + energyType);
+        };
+    }
+
+    private BusinessTypeList businessTypeFor(String direction) {
+        if (EtaPlusVhdMappings.isProduction(direction)) {
+            return BusinessTypeList.PRODUCTION;
+        }
+        if (!"Consumption".equals(direction)) {
+            LOGGER.warn("Unknown direction '{}' on metering point {}; defaulting to CONSUMPTION",
+                    direction, identifiableData.payload().meteringPointId());
+        }
+        return BusinessTypeList.CONSUMPTION;
+    }
+
+    private static DirectionTypeList flowDirectionFor(String direction) {
+        return EtaPlusVhdMappings.isProduction(direction) ? DirectionTypeList.UP : DirectionTypeList.DOWN;
+    }
+
+    @Nullable
+    private static EnergyProductTypeList productFor(EnergyType energyType) {
+        return energyType == EnergyType.ELECTRICITY ? EnergyProductTypeList.ACTIVE_ENERGY : null;
+    }
+
+    @Nullable
+    private QualityTypeList qualityFor(String wireStatus) {
+        if (EtaPlusVhdMappings.isValidatedStatus(wireStatus)) {
+            return QualityTypeList.AS_PROVIDED;
+        }
+        LOGGER.info("Unknown reading status '{}' on metering point {}; omitting quality",
+                wireStatus, identifiableData.payload().meteringPointId());
+        return null;
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelope.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelope.java
@@ -109,6 +109,7 @@ class IntermediateValidatedHistoricalDataEnvelope {
     ) {
         var ts = new TimeSeriesComplexType()
                 .withMRID(UUID.randomUUID().toString())
+                .withVersion("1")
                 .withBusinessType(businessTypeFor(direction))
                 .withMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity(commodityKindFor(energyType))
                 .withFlowDirectionDirection(flowDirectionFor(direction))
@@ -159,7 +160,8 @@ class IntermediateValidatedHistoricalDataEnvelope {
         return new SeriesPeriodComplexType()
                 .withResolution(granularity.toString())
                 .withTimeInterval(esmpInterval(start, end))
-                .withPointList(new SeriesPeriodComplexType.PointList().withPoints(points));
+                .withPointList(new SeriesPeriodComplexType.PointList().withPoints(points))
+                .withReasonList(new SeriesPeriodComplexType.ReasonList());
     }
 
     private static ESMPDateTimeIntervalComplexType esmpInterval(ZonedDateTime start, ZonedDateTime end) {

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelope.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelope.java
@@ -55,7 +55,7 @@ class IntermediateValidatedHistoricalDataEnvelope {
         var firstReading = readings.get(0);
         UnitOfMeasureTypeList unit;
         try {
-            unit = UnitOfMeasureTypeList.fromValue(EtaPlusVhdMappings.translateUnit(firstReading.unit()));
+            unit = translateUnit(firstReading.unit());
         } catch (IllegalArgumentException e) {
             LOGGER.warn("Skipping VHD for metering point {}: unsupported unit '{}'",
                     payload.meteringPointId(), firstReading.unit());
@@ -205,5 +205,17 @@ class IntermediateValidatedHistoricalDataEnvelope {
         LOGGER.info("Unknown reading status '{}' on metering point {}; omitting quality",
                 wireStatus, identifiableData.payload().meteringPointId());
         return null;
+    }
+
+    private static UnitOfMeasureTypeList translateUnit(String wireUnit) {
+        if (wireUnit == null) {
+            throw new IllegalArgumentException("null");
+        }
+        return switch (wireUnit) {
+            case "kWh", "KWH" -> UnitOfMeasureTypeList.KILOWATT_HOUR;
+            case "MWh", "MWH" -> UnitOfMeasureTypeList.MEGAWATT_HOURS;
+            case "m³", "m3", "M3" -> UnitOfMeasureTypeList.CUBIC_METRE;
+            default -> throw new IllegalArgumentException(wireUnit);
+        };
     }
 }

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v1_04/DeValidatedHistoricalDataMarketDocumentProvider.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v1_04/DeValidatedHistoricalDataMarketDocumentProvider.java
@@ -1,0 +1,39 @@
+package energy.eddie.regionconnector.de.eta.providers.v1_04;
+
+import energy.eddie.api.agnostic.MessageStream;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.cim.v1_04.vhd.VHDEnvelope;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
+import energy.eddie.regionconnector.de.eta.providers.ValidatedHistoricalDataStream;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+/**
+ * CIM v1.04 Validated Historical Data provider for the German ETA Plus connector.
+ */
+@Component("deValidatedHistoricalDataMarketDocumentProviderV104")
+public class DeValidatedHistoricalDataMarketDocumentProvider {
+
+    private final Flux<IdentifiableValidatedHistoricalData> identifiableData;
+    private final CommonInformationModelConfiguration cimConfig;
+    private final DeEtaPlusConfiguration deConfiguration;
+
+    public DeValidatedHistoricalDataMarketDocumentProvider(
+            ValidatedHistoricalDataStream stream,
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+            CommonInformationModelConfiguration cimConfig,
+            DeEtaPlusConfiguration deConfiguration
+    ) {
+        this.identifiableData = stream.validatedHistoricalData();
+        this.cimConfig = cimConfig;
+        this.deConfiguration = deConfiguration;
+    }
+
+    @MessageStream(VHDEnvelope.class)
+    public Flux<VHDEnvelope> getValidatedHistoricalDataMarketDocumentsStream() {
+        return identifiableData
+                .map(data -> new IntermediateValidatedHistoricalDataMarketDocument(cimConfig, deConfiguration, data))
+                .flatMapIterable(IntermediateValidatedHistoricalDataMarketDocument::toVhd);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocument.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocument.java
@@ -1,0 +1,204 @@
+package energy.eddie.regionconnector.de.eta.providers.v1_04;
+
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.cim.CommonInformationModelVersions;
+import energy.eddie.cim.v1_04.*;
+import energy.eddie.cim.v1_04.vhd.*;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusVhdMappings;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
+import energy.eddie.regionconnector.shared.cim.v0_82.EsmpTimeInterval;
+import energy.eddie.regionconnector.shared.cim.v1_04.VhdEnvelopeWrapper;
+import jakarta.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.datatype.DatatypeFactory;
+import java.math.BigDecimal;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Maps a single ETA Plus historical-readings response (one metering point, one unit, one direction)
+ * to a CIM v1.04 {@link VHDMarketDocument} wrapped in a {@link VHDEnvelope}.
+ *
+ * <p>Per the ETA Plus contract, {@code unit} and {@code direction} are constant within a response,
+ * so each response yields exactly one {@link TimeSeries}.
+ */
+class IntermediateValidatedHistoricalDataMarketDocument {
+    private static final Logger LOGGER = LoggerFactory.getLogger(IntermediateValidatedHistoricalDataMarketDocument.class);
+
+    private final CommonInformationModelConfiguration cimConfig;
+    private final DeEtaPlusConfiguration deConfiguration;
+    private final IdentifiableValidatedHistoricalData identifiableData;
+
+    IntermediateValidatedHistoricalDataMarketDocument(
+            CommonInformationModelConfiguration cimConfig,
+            DeEtaPlusConfiguration deConfiguration,
+            IdentifiableValidatedHistoricalData identifiableData
+    ) {
+        this.cimConfig = cimConfig;
+        this.deConfiguration = deConfiguration;
+        this.identifiableData = identifiableData;
+    }
+
+    public List<VHDEnvelope> toVhd() {
+        var payload = identifiableData.payload();
+        var readings = payload.readings();
+        if (readings == null || readings.isEmpty()) {
+            return List.of();
+        }
+
+        var firstReading = readings.get(0);
+        StandardUnitOfMeasureTypeList unit;
+        try {
+            unit = StandardUnitOfMeasureTypeList.fromValue(EtaPlusVhdMappings.translateUnit(firstReading.unit()));
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Skipping VHD for metering point {}: unsupported unit '{}'",
+                    payload.meteringPointId(), firstReading.unit());
+            return List.of();
+        }
+
+        var sortedReadings = EtaPlusVhdMappings.sortByTimestamp(readings);
+        var start = sortedReadings.get(0).timestamp();
+        var end = sortedReadings.get(sortedReadings.size() - 1).timestamp();
+
+        var permissionRequest = identifiableData.permissionRequest();
+        var energyType = permissionRequest.energyType();
+        var direction = firstReading.direction();
+        var senderId = permissionRequest.dataSourceInformation().meteredDataAdministratorId();
+
+        var vhd = new VHDMarketDocument()
+                .withMRID(UUID.randomUUID().toString())
+                .withRevisionNumber(CommonInformationModelVersions.V1_04.cimify())
+                .withType(StandardMessageTypeList.MEASUREMENT_VALUE_DOCUMENT.value())
+                .withCreatedDateTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .withSenderMarketParticipantMarketRoleType(StandardRoleTypeList.METERING_POINT_ADMINISTRATOR.value())
+                .withReceiverMarketParticipantMarketRoleType(StandardRoleTypeList.CONSUMER.value())
+                .withProcessProcessType(StandardProcessTypeList.REALISED.value())
+                .withSenderMarketParticipantMRID(
+                        new PartyIDString()
+                                .withCodingScheme(StandardCodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME.value())
+                                .withValue(senderId)
+                )
+                .withReceiverMarketParticipantMRID(
+                        new PartyIDString()
+                                .withCodingScheme(cimConfig.eligiblePartyNationalCodingScheme().value())
+                                .withValue(deConfiguration.eligiblePartyId())
+                )
+                .withPeriodTimeInterval(esmpInterval(start, end))
+                .withTimeSeries(timeSeries(payload, sortedReadings, energyType, unit, direction, start, end));
+
+        return List.of(new VhdEnvelopeWrapper(vhd, permissionRequest).wrap());
+    }
+
+    private TimeSeries timeSeries(
+            EtaPlusMeteredData payload,
+            List<EtaPlusMeteredData.MeterReading> sortedReadings,
+            EnergyType energyType,
+            StandardUnitOfMeasureTypeList unit,
+            String direction,
+            ZonedDateTime start,
+            ZonedDateTime end
+    ) {
+        var ts = new TimeSeries()
+                .withMRID(UUID.randomUUID().toString())
+                .withVersion("1")
+                .withBusinessType(businessTypeFor(direction).value())
+                .withMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity(commodityKindFor(energyType))
+                .withFlowDirectionDirection(flowDirectionFor(direction).value())
+                .withEnergyMeasurementUnitName(unit.value())
+                .withMarketEvaluationPointMRID(
+                        new MeasurementPointIDString()
+                                .withCodingScheme(StandardCodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME.value())
+                                .withValue(payload.meteringPointId())
+                )
+                .withReasonCode(StandardReasonCodeTypeList.ERRORS_NOT_SPECIFICALLY_IDENTIFIED.value())
+                .withPeriods(seriesPeriod(sortedReadings, start, end));
+
+        // Q-2 (L1): set product only for electricity; CIM v1.04 has no gas-appropriate value.
+        var product = productFor(energyType);
+        if (product != null) {
+            ts.withProduct(product.value());
+        }
+        return ts;
+    }
+
+    private SeriesPeriod seriesPeriod(
+            List<EtaPlusMeteredData.MeterReading> sortedReadings,
+            ZonedDateTime start,
+            ZonedDateTime end
+    ) {
+        var granularity = identifiableData.permissionRequest().granularity();
+        var resolution = DatatypeFactory.newDefaultInstance().newDuration(granularity.duration().toMillis());
+
+        var points = new java.util.ArrayList<Point>(sortedReadings.size());
+        for (int i = 0; i < sortedReadings.size(); i++) {
+            var reading = sortedReadings.get(i);
+            var point = new Point()
+                    .withPosition(i + 1)
+                    .withEnergyQuantityQuantity(BigDecimal.valueOf(reading.value()));
+            var quality = qualityFor(reading.quality());
+            if (quality != null) {
+                point.withEnergyQuantityQuality(quality.value());
+            }
+            points.add(point);
+        }
+
+        return new SeriesPeriod()
+                .withResolution(resolution)
+                .withTimeInterval(esmpInterval(start, end))
+                .withPoints(points);
+    }
+
+    private static ESMPDateTimeInterval esmpInterval(ZonedDateTime start, ZonedDateTime end) {
+        var interval = new EsmpTimeInterval(start, end);
+        return new ESMPDateTimeInterval()
+                .withStart(interval.start())
+                .withEnd(interval.end());
+    }
+
+    private CommodityKind commodityKindFor(EnergyType energyType) {
+        return switch (energyType) {
+            case ELECTRICITY -> CommodityKind.ELECTRICITYPRIMARYMETERED;
+            case NATURAL_GAS -> CommodityKind.NATURALGAS;
+            default -> throw new IllegalStateException("Unsupported energy type: " + energyType);
+        };
+    }
+
+    private StandardBusinessTypeList businessTypeFor(String direction) {
+        if (EtaPlusVhdMappings.isProduction(direction)) {
+            return StandardBusinessTypeList.PRODUCTION;
+        }
+        if (!"Consumption".equals(direction)) {
+            LOGGER.warn("Unknown direction '{}' on metering point {}; defaulting to CONSUMPTION",
+                    direction, identifiableData.payload().meteringPointId());
+        }
+        return StandardBusinessTypeList.CONSUMPTION;
+    }
+
+    private static StandardDirectionTypeList flowDirectionFor(String direction) {
+        return EtaPlusVhdMappings.isProduction(direction)
+                ? StandardDirectionTypeList.UP
+                : StandardDirectionTypeList.DOWN;
+    }
+
+    @Nullable
+    private static StandardEnergyProductTypeList productFor(EnergyType energyType) {
+        return energyType == EnergyType.ELECTRICITY ? StandardEnergyProductTypeList.ACTIVE_ENERGY : null;
+    }
+
+    @Nullable
+    private StandardQualityTypeList qualityFor(String wireStatus) {
+        if (EtaPlusVhdMappings.isValidatedStatus(wireStatus)) {
+            return StandardQualityTypeList.AS_PROVIDED;
+        }
+        LOGGER.info("Unknown reading status '{}' on metering point {}; omitting quality",
+                wireStatus, identifiableData.payload().meteringPointId());
+        return null;
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocument.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocument.java
@@ -56,7 +56,7 @@ class IntermediateValidatedHistoricalDataMarketDocument {
         var firstReading = readings.get(0);
         StandardUnitOfMeasureTypeList unit;
         try {
-            unit = StandardUnitOfMeasureTypeList.fromValue(EtaPlusVhdMappings.translateUnit(firstReading.unit()));
+            unit = translateUnit(firstReading.unit());
         } catch (IllegalArgumentException e) {
             LOGGER.warn("Skipping VHD for metering point {}: unsupported unit '{}'",
                     payload.meteringPointId(), firstReading.unit());
@@ -200,5 +200,17 @@ class IntermediateValidatedHistoricalDataMarketDocument {
         LOGGER.info("Unknown reading status '{}' on metering point {}; omitting quality",
                 wireStatus, identifiableData.payload().meteringPointId());
         return null;
+    }
+
+    private static StandardUnitOfMeasureTypeList translateUnit(String wireUnit) {
+        if (wireUnit == null) {
+            throw new IllegalArgumentException("null");
+        }
+        return switch (wireUnit) {
+            case "kWh", "KWH" -> StandardUnitOfMeasureTypeList.KILOWATT_HOUR;
+            case "MWh", "MWH" -> StandardUnitOfMeasureTypeList.MEGAWATT_HOURS;
+            case "m³", "m3", "M3" -> StandardUnitOfMeasureTypeList.CUBIC_METRE;
+            default -> throw new IllegalArgumentException(wireUnit);
+        };
     }
 }

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/AcceptedHandlerFlowTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/AcceptedHandlerFlowTest.java
@@ -104,10 +104,11 @@ class AcceptedHandlerFlowTest {
         when(repository.findByPermissionId(permissionId)).thenReturn(Optional.of(mockRequest));
 
         EtaPlusMeteredData.MeterReading reading = new EtaPlusMeteredData.MeterReading(
-                end.atStartOfDay().toString(),
+                end.atStartOfDay(EtaRegionConnectorMetadata.DE_ZONE_ID),
                 123.45,
                 "kWh",
-                "VALIDATED"
+                "VALIDATED",
+                "Consumption"
         );
 
         EtaPlusMeteredData mockApiData = new EtaPlusMeteredData(

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClientTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClientTest.java
@@ -100,7 +100,8 @@ class EtaPlusApiClientTest {
                     "timestamp": "2024-06-01T12:00:00Z",
                     "value": 42.5,
                     "unit": "kWh",
-                    "status": "VALIDATED"
+                    "status": "VALIDATED",
+                    "direction": "Consumption"
                   }
                 ]
                 """;
@@ -121,6 +122,7 @@ class EtaPlusApiClientTest {
                     assertThat(reading.value()).isEqualTo(42.5);
                     assertThat(reading.unit()).isEqualTo("kWh");
                     assertThat(reading.quality()).isEqualTo("VALIDATED");
+                    assertThat(reading.direction()).isEqualTo("Consumption");
                 })
                 .verifyComplete();
     }

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappingsTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappingsTest.java
@@ -3,43 +3,14 @@ package energy.eddie.regionconnector.de.eta.providers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class EtaPlusVhdMappingsTest {
-
-    @ParameterizedTest
-    @CsvSource({
-            "kWh,KWH",
-            "KWH,KWH",
-            "MWh,MWH",
-            "MWH,MWH",
-            "m³,MTQ",
-            "m3,MTQ",
-            "M3,MTQ"
-    })
-    void translateUnit_supportedWireValue_returnsCimCode(String wire, String expected) {
-        assertThat(EtaPlusVhdMappings.translateUnit(wire)).isEqualTo(expected);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"Wh", "GJ", "MJ", "unknown", ""})
-    void translateUnit_unsupportedWireValue_throws(String wire) {
-        assertThatThrownBy(() -> EtaPlusVhdMappings.translateUnit(wire))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void translateUnit_null_throws() {
-        assertThatThrownBy(() -> EtaPlusVhdMappings.translateUnit(null))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
 
     @ParameterizedTest
     @CsvSource({

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappingsTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappingsTest.java
@@ -1,0 +1,106 @@
+package energy.eddie.regionconnector.de.eta.providers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EtaPlusVhdMappingsTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "kWh,KWH",
+            "KWH,KWH",
+            "MWh,MWH",
+            "MWH,MWH",
+            "m³,MTQ",
+            "m3,MTQ",
+            "M3,MTQ"
+    })
+    void translateUnit_supportedWireValue_returnsCimCode(String wire, String expected) {
+        assertThat(EtaPlusVhdMappings.translateUnit(wire)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Wh", "GJ", "MJ", "unknown", ""})
+    void translateUnit_unsupportedWireValue_throws(String wire) {
+        assertThatThrownBy(() -> EtaPlusVhdMappings.translateUnit(wire))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void translateUnit_null_throws() {
+        assertThatThrownBy(() -> EtaPlusVhdMappings.translateUnit(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "Generation,true",
+            "Consumption,false",
+            "GENERATION,false",
+            "unknown,false",
+            "'',false"
+    })
+    void isProduction_recognisesGenerationOnly(String direction, boolean expected) {
+        assertThat(EtaPlusVhdMappings.isProduction(direction)).isEqualTo(expected);
+    }
+
+    @Test
+    void isProduction_null_returnsFalse() {
+        assertThat(EtaPlusVhdMappings.isProduction(null)).isFalse();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "VALIDATED,true",
+            "validated,false",
+            "ESTIMATED,false",
+            "MEASURED,false",
+            "'',false"
+    })
+    void isValidatedStatus_recognisesExactValidatedOnly(String wireStatus, boolean expected) {
+        assertThat(EtaPlusVhdMappings.isValidatedStatus(wireStatus)).isEqualTo(expected);
+    }
+
+    @Test
+    void isValidatedStatus_null_returnsFalse() {
+        assertThat(EtaPlusVhdMappings.isValidatedStatus(null)).isFalse();
+    }
+
+    @Test
+    void sortByTimestamp_returnsAscendingByTimestamp() {
+        var t0 = ZonedDateTime.of(2026, 4, 30, 22, 0, 0, 0, ZoneOffset.UTC);
+        var unsorted = List.of(
+                reading(t0.plusHours(2), 3.0),
+                reading(t0, 1.0),
+                reading(t0.plusHours(1), 2.0)
+        );
+
+        var sorted = EtaPlusVhdMappings.sortByTimestamp(unsorted);
+
+        assertThat(sorted).extracting(EtaPlusMeteredData.MeterReading::value)
+                .containsExactly(1.0, 2.0, 3.0);
+    }
+
+    @Test
+    void sortByTimestamp_alreadySortedListIsReturnedInOrder() {
+        var t0 = ZonedDateTime.of(2026, 4, 30, 22, 0, 0, 0, ZoneOffset.UTC);
+        var sortedInput = List.of(reading(t0, 1.0), reading(t0.plusHours(1), 2.0));
+
+        assertThat(EtaPlusVhdMappings.sortByTimestamp(sortedInput))
+                .extracting(EtaPlusMeteredData.MeterReading::value)
+                .containsExactly(1.0, 2.0);
+    }
+
+    private static EtaPlusMeteredData.MeterReading reading(ZonedDateTime ts, double value) {
+        return new EtaPlusMeteredData.MeterReading(ts, value, "kWh", "VALIDATED", "Consumption");
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeValidatedHistoricalDataEnvelopeProviderTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeValidatedHistoricalDataEnvelopeProviderTest.java
@@ -1,0 +1,61 @@
+package energy.eddie.regionconnector.de.eta.providers.v0_82;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
+import energy.eddie.regionconnector.de.eta.providers.ValidatedHistoricalDataStream;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DeValidatedHistoricalDataEnvelopeProviderTest {
+
+    private static final ZonedDateTime T0 = ZonedDateTime.of(2026, 4, 30, 22, 0, 0, 0, ZoneOffset.UTC);
+
+    @Test
+    void getValidatedHistoricalDataMarketDocumentsStream_emitsOneEnvelopePerInputPayload() {
+        var stream = mock(ValidatedHistoricalDataStream.class);
+        when(stream.validatedHistoricalData()).thenReturn(Flux.just(samplePayload()));
+
+        var provider = new DeValidatedHistoricalDataEnvelopeProvider(
+                stream,
+                new PlainCommonInformationModelConfiguration(
+                        CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME, "fallback"),
+                new DeEtaPlusConfiguration(
+                        "ep-id", "http://api.url", "client-id", "client-secret",
+                        "/meters/historical", "/v1/permissions/{id}", 30,
+                        3, 2, true, false, null, null)
+        );
+
+        StepVerifier.create(provider.getValidatedHistoricalDataMarketDocumentsStream())
+                .expectNextCount(1)
+                .verifyComplete();
+    }
+
+    private static IdentifiableValidatedHistoricalData samplePayload() {
+        DePermissionRequest pr = new DePermissionRequestBuilder()
+                .permissionId("pid").connectionId("cid").meteringPointId("mp")
+                .start(LocalDate.of(2026, 4, 30)).end(LocalDate.of(2026, 5, 1))
+                .granularity(Granularity.PT15M).energyType(EnergyType.ELECTRICITY)
+                .status(PermissionProcessStatus.ACCEPTED).created(T0).dataNeedId("dnid")
+                .build();
+        var reading = new EtaPlusMeteredData.MeterReading(T0, 1.0, "kWh", "VALIDATED", "Consumption");
+        var payload = new EtaPlusMeteredData("mp", pr.start(), pr.end(), List.of(reading));
+        return new IdentifiableValidatedHistoricalData(pr, payload);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelopeTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelopeTest.java
@@ -5,6 +5,10 @@ import energy.eddie.api.agnostic.data.needs.EnergyType;
 import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
 import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
 import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.cim.serde.SerdeInitializationException;
+import energy.eddie.cim.serde.SerializationException;
+import energy.eddie.cim.serde.XmlMessageSerde;
+import energy.eddie.cim.testing.XmlValidator;
 import energy.eddie.cim.v0_82.vhd.BusinessTypeList;
 import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
 import energy.eddie.cim.v0_82.vhd.CommodityKind;
@@ -19,18 +23,20 @@ import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
 import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IntermediateValidatedHistoricalDataEnvelopeTest {
 
     private static final ZonedDateTime T0 = ZonedDateTime.of(2026, 4, 30, 22, 0, 0, 0, ZoneOffset.UTC);
     private static final String METERING_POINT_ID = "DE0123456789012345678901234567890";
-    private static final String ELIGIBLE_PARTY_ID = "test-eligible-party-id";
+    private static final String ELIGIBLE_PARTY_ID = "test-ep-id";
 
     private final CommonInformationModelConfiguration cimConfig = new PlainCommonInformationModelConfiguration(
             CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME,
@@ -43,6 +49,9 @@ class IntermediateValidatedHistoricalDataEnvelopeTest {
             3, 2, true, false,
             null, null
     );
+    private final XmlMessageSerde serde = new XmlMessageSerde();
+
+    IntermediateValidatedHistoricalDataEnvelopeTest() throws SerdeInitializationException {}
 
     @Test
     void toVhd_emptyReadings_returnsEmptyList() {
@@ -97,6 +106,17 @@ class IntermediateValidatedHistoricalDataEnvelopeTest {
         var readings = List.of(reading(T0, 1.0, "Wh", "VALIDATED", "Consumption"));
 
         assertThat(build(EnergyType.ELECTRICITY, readings).toVhd()).isEmpty();
+    }
+
+    @Test
+    void toVhd_producesXsdValidV082MarketDocument() throws SerializationException {
+        var readings = List.of(reading(T0, 12.345, "kWh", "VALIDATED", "Consumption"));
+        var envelope = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst();
+
+        var xml = new String(serde.serialize(envelope), StandardCharsets.UTF_8);
+
+        assertTrue(XmlValidator.validateValidatedHistoricalMarketDocument(xml),
+                "Produced XML failed XSD validation:\n" + xml);
     }
 
     @Test

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelopeTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelopeTest.java
@@ -1,0 +1,141 @@
+package energy.eddie.regionconnector.de.eta.providers.v0_82;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.cim.v0_82.vhd.BusinessTypeList;
+import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
+import energy.eddie.cim.v0_82.vhd.CommodityKind;
+import energy.eddie.cim.v0_82.vhd.DirectionTypeList;
+import energy.eddie.cim.v0_82.vhd.EnergyProductTypeList;
+import energy.eddie.cim.v0_82.vhd.QualityTypeList;
+import energy.eddie.cim.v0_82.vhd.UnitOfMeasureTypeList;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IntermediateValidatedHistoricalDataEnvelopeTest {
+
+    private static final ZonedDateTime T0 = ZonedDateTime.of(2026, 4, 30, 22, 0, 0, 0, ZoneOffset.UTC);
+    private static final String METERING_POINT_ID = "DE0123456789012345678901234567890";
+    private static final String ELIGIBLE_PARTY_ID = "test-eligible-party-id";
+
+    private final CommonInformationModelConfiguration cimConfig = new PlainCommonInformationModelConfiguration(
+            CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME,
+            "unused-fallback"
+    );
+    private final DeEtaPlusConfiguration deConfiguration = new DeEtaPlusConfiguration(
+            ELIGIBLE_PARTY_ID,
+            "http://api.url", "client-id", "client-secret",
+            "/meters/historical", "/v1/permissions/{id}", 30,
+            3, 2, true, false,
+            null, null
+    );
+
+    @Test
+    void toVhd_emptyReadings_returnsEmptyList() {
+        assertThat(build(EnergyType.ELECTRICITY, List.of()).toVhd()).isEmpty();
+    }
+
+    @Test
+    void toVhd_electricityConsumption_setsV082EnumsAndKwhUnit() {
+        var readings = List.of(reading(T0, 12.345, "kWh", "VALIDATED", "Consumption"));
+
+        var ts = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst()
+                .getValidatedHistoricalDataMarketDocument().getTimeSeriesList().getTimeSeries().getFirst();
+
+        assertThat(ts.getBusinessType()).isEqualTo(BusinessTypeList.CONSUMPTION);
+        assertThat(ts.getFlowDirectionDirection()).isEqualTo(DirectionTypeList.DOWN);
+        assertThat(ts.getProduct()).isEqualTo(EnergyProductTypeList.ACTIVE_ENERGY);
+        assertThat(ts.getEnergyMeasurementUnitName()).isEqualTo(UnitOfMeasureTypeList.KILOWATT_HOUR);
+        assertThat(ts.getMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity())
+                .isEqualTo(CommodityKind.ELECTRICITYPRIMARYMETERED);
+        var period = ts.getSeriesPeriodList().getSeriesPeriods().getFirst();
+        assertThat(period.getPointList().getPoints()).hasSize(1);
+        assertThat(period.getPointList().getPoints().getFirst().getEnergyQuantityQuality())
+                .isEqualTo(QualityTypeList.AS_PROVIDED);
+    }
+
+    @Test
+    void toVhd_electricityGeneration_setsBusinessTypeProductionAndDirectionUp() {
+        var readings = List.of(reading(T0, 4.812, "kWh", "VALIDATED", "Generation"));
+
+        var ts = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst()
+                .getValidatedHistoricalDataMarketDocument().getTimeSeriesList().getTimeSeries().getFirst();
+
+        assertThat(ts.getBusinessType()).isEqualTo(BusinessTypeList.PRODUCTION);
+        assertThat(ts.getFlowDirectionDirection()).isEqualTo(DirectionTypeList.UP);
+    }
+
+    @Test
+    void toVhd_naturalGas_omitsProductAndUsesCubicMetre() {
+        var readings = List.of(reading(T0, 14.728, "m³", "VALIDATED", "Consumption"));
+
+        var ts = build(EnergyType.NATURAL_GAS, readings).toVhd().getFirst()
+                .getValidatedHistoricalDataMarketDocument().getTimeSeriesList().getTimeSeries().getFirst();
+
+        assertThat(ts.getProduct()).isNull();
+        assertThat(ts.getEnergyMeasurementUnitName()).isEqualTo(UnitOfMeasureTypeList.CUBIC_METRE);
+        assertThat(ts.getMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity())
+                .isEqualTo(CommodityKind.NATURALGAS);
+    }
+
+    @Test
+    void toVhd_unsupportedUnit_returnsEmptyList() {
+        var readings = List.of(reading(T0, 1.0, "Wh", "VALIDATED", "Consumption"));
+
+        assertThat(build(EnergyType.ELECTRICITY, readings).toVhd()).isEmpty();
+    }
+
+    @Test
+    void toVhd_setsReceiverFromConnectorConfigAndSenderFromDataSourceInformation() {
+        var readings = List.of(reading(T0, 1.0, "kWh", "VALIDATED", "Consumption"));
+        var doc = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst()
+                .getValidatedHistoricalDataMarketDocument();
+
+        assertThat(doc.getReceiverMarketParticipantMRID().getValue()).isEqualTo(ELIGIBLE_PARTY_ID);
+        assertThat(doc.getReceiverMarketParticipantMRID().getCodingScheme())
+                .isEqualTo(CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME);
+        assertThat(doc.getSenderMarketParticipantMRID().getValue()).isEqualTo("eta-plus");
+        assertThat(doc.getSenderMarketParticipantMRID().getCodingScheme())
+                .isEqualTo(CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME);
+    }
+
+    private IntermediateValidatedHistoricalDataEnvelope build(
+            EnergyType energyType,
+            List<EtaPlusMeteredData.MeterReading> readings
+    ) {
+        DePermissionRequest pr = new DePermissionRequestBuilder()
+                .permissionId("pid")
+                .connectionId("cid")
+                .meteringPointId(METERING_POINT_ID)
+                .start(LocalDate.of(2026, 4, 30))
+                .end(LocalDate.of(2026, 5, 1))
+                .granularity(Granularity.PT15M)
+                .energyType(energyType)
+                .status(PermissionProcessStatus.ACCEPTED)
+                .created(T0)
+                .dataNeedId("dnid")
+                .build();
+        var payload = new EtaPlusMeteredData(METERING_POINT_ID, pr.start(), pr.end(), readings);
+        return new IntermediateValidatedHistoricalDataEnvelope(
+                cimConfig, deConfiguration, new IdentifiableValidatedHistoricalData(pr, payload));
+    }
+
+    private static EtaPlusMeteredData.MeterReading reading(
+            ZonedDateTime ts, double value, String unit, String quality, String direction) {
+        return new EtaPlusMeteredData.MeterReading(ts, value, unit, quality, direction);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/DeValidatedHistoricalDataMarketDocumentProviderTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/DeValidatedHistoricalDataMarketDocumentProviderTest.java
@@ -1,0 +1,62 @@
+package energy.eddie.regionconnector.de.eta.providers.v1_04;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
+import energy.eddie.regionconnector.de.eta.providers.ValidatedHistoricalDataStream;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DeValidatedHistoricalDataMarketDocumentProviderTest {
+
+    private static final ZonedDateTime T0 = ZonedDateTime.of(2026, 4, 30, 22, 0, 0, 0, ZoneOffset.UTC);
+
+    @Test
+    void getValidatedHistoricalDataMarketDocumentsStream_emitsOneEnvelopePerInputPayload() {
+        var stream = mock(ValidatedHistoricalDataStream.class);
+        when(stream.validatedHistoricalData()).thenReturn(Flux.just(samplePayload()));
+
+        var provider = new DeValidatedHistoricalDataMarketDocumentProvider(
+                stream,
+                new PlainCommonInformationModelConfiguration(
+                        CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME, "fallback"),
+                new DeEtaPlusConfiguration(
+                        "ep-id", "http://api.url", "client-id", "client-secret",
+                        "/meters/historical", "/v1/permissions/{id}", 30,
+                        3, 2, true, false, null, null)
+        );
+
+        StepVerifier.create(provider.getValidatedHistoricalDataMarketDocumentsStream())
+                .expectNextCount(1)
+                .verifyComplete();
+    }
+
+    private static IdentifiableValidatedHistoricalData samplePayload() {
+        DePermissionRequest pr = new DePermissionRequestBuilder()
+                .permissionId("pid").connectionId("cid").meteringPointId("mp")
+                .start(LocalDate.of(2026, 4, 30)).end(LocalDate.of(2026, 5, 1))
+                .granularity(Granularity.PT15M).energyType(EnergyType.ELECTRICITY)
+                .status(PermissionProcessStatus.ACCEPTED).created(T0).dataNeedId("dnid")
+                .build();
+        var reading = new EtaPlusMeteredData.MeterReading(T0, 1.0, "kWh", "VALIDATED", "Consumption");
+        var payload = new EtaPlusMeteredData("mp", pr.start(), pr.end(), List.of(reading));
+        return new IdentifiableValidatedHistoricalData(pr, payload);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocumentTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocumentTest.java
@@ -5,6 +5,10 @@ import energy.eddie.api.agnostic.data.needs.EnergyType;
 import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
 import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
 import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.cim.serde.SerdeInitializationException;
+import energy.eddie.cim.serde.SerializationException;
+import energy.eddie.cim.serde.XmlMessageSerde;
+import energy.eddie.cim.testing.XmlValidator;
 import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
 import energy.eddie.cim.v1_04.StandardBusinessTypeList;
 import energy.eddie.cim.v1_04.vhd.CommodityKind;
@@ -19,18 +23,20 @@ import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
 import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IntermediateValidatedHistoricalDataMarketDocumentTest {
 
     private static final ZonedDateTime T0 = ZonedDateTime.of(2026, 4, 30, 22, 0, 0, 0, ZoneOffset.UTC);
     private static final String METERING_POINT_ID = "DE0123456789012345678901234567890";
-    private static final String ELIGIBLE_PARTY_ID = "test-eligible-party-id";
+    private static final String ELIGIBLE_PARTY_ID = "test-ep-id";
 
     private final CommonInformationModelConfiguration cimConfig = new PlainCommonInformationModelConfiguration(
             CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME,
@@ -43,6 +49,9 @@ class IntermediateValidatedHistoricalDataMarketDocumentTest {
             3, 2, true, false,
             null, null
     );
+    private final XmlMessageSerde serde = new XmlMessageSerde();
+
+    IntermediateValidatedHistoricalDataMarketDocumentTest() throws SerdeInitializationException {}
 
     @Test
     void toVhd_emptyReadings_returnsEmptyList() {
@@ -131,6 +140,20 @@ class IntermediateValidatedHistoricalDataMarketDocumentTest {
                 .containsExactly(1.0, 2.0, 3.0);
         assertThat(period.getTimeInterval().getStart()).isEqualTo(T0.toString());
         assertThat(period.getTimeInterval().getEnd()).isEqualTo(T0.plusHours(2).toString());
+    }
+
+    @Test
+    void toVhd_producesXsdValidV104MarketDocument() throws SerializationException {
+        var readings = List.of(
+                reading(T0, 12.345, "kWh", "VALIDATED", "Consumption"),
+                reading(T0.plusHours(1), 13.5, "kWh", "VALIDATED", "Consumption")
+        );
+
+        var envelope = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst();
+        var xml = serde.serialize(envelope);
+
+        assertTrue(XmlValidator.validateV104ValidatedHistoricalDataMarketDocument(xml),
+                "Produced XML failed XSD validation:\n" + new String(xml, StandardCharsets.UTF_8));
     }
 
     @Test

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocumentTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocumentTest.java
@@ -1,0 +1,172 @@
+package energy.eddie.regionconnector.de.eta.providers.v1_04;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
+import energy.eddie.cim.v1_04.StandardBusinessTypeList;
+import energy.eddie.cim.v1_04.vhd.CommodityKind;
+import energy.eddie.cim.v1_04.StandardDirectionTypeList;
+import energy.eddie.cim.v1_04.StandardEnergyProductTypeList;
+import energy.eddie.cim.v1_04.StandardQualityTypeList;
+import energy.eddie.cim.v1_04.StandardUnitOfMeasureTypeList;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableValidatedHistoricalData;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IntermediateValidatedHistoricalDataMarketDocumentTest {
+
+    private static final ZonedDateTime T0 = ZonedDateTime.of(2026, 4, 30, 22, 0, 0, 0, ZoneOffset.UTC);
+    private static final String METERING_POINT_ID = "DE0123456789012345678901234567890";
+    private static final String ELIGIBLE_PARTY_ID = "test-eligible-party-id";
+
+    private final CommonInformationModelConfiguration cimConfig = new PlainCommonInformationModelConfiguration(
+            CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME,
+            "unused-fallback"
+    );
+    private final DeEtaPlusConfiguration deConfiguration = new DeEtaPlusConfiguration(
+            ELIGIBLE_PARTY_ID,
+            "http://api.url", "client-id", "client-secret",
+            "/meters/historical", "/v1/permissions/{id}", 30,
+            3, 2, true, false,
+            null, null
+    );
+
+    @Test
+    void toVhd_emptyReadings_returnsEmptyList() {
+        var result = build(EnergyType.ELECTRICITY, List.of()).toVhd();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void toVhd_electricityConsumption_setsBusinessTypeConsumptionAndProductActiveEnergy() {
+        var readings = List.of(
+                reading(T0, 12.345, "kWh", "VALIDATED", "Consumption"),
+                reading(T0.plusHours(1), 13.5, "kWh", "VALIDATED", "Consumption")
+        );
+
+        var envelope = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst();
+        var ts = envelope.getMarketDocument().getTimeSeries().getFirst();
+
+        assertThat(ts.getBusinessType()).isEqualTo(StandardBusinessTypeList.CONSUMPTION.value());
+        assertThat(ts.getFlowDirectionDirection()).isEqualTo(StandardDirectionTypeList.DOWN.value());
+        assertThat(ts.getProduct()).isEqualTo(StandardEnergyProductTypeList.ACTIVE_ENERGY.value());
+        assertThat(ts.getEnergyMeasurementUnitName()).isEqualTo(StandardUnitOfMeasureTypeList.KILOWATT_HOUR.value());
+        assertThat(ts.getMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity())
+                .isEqualTo(CommodityKind.ELECTRICITYPRIMARYMETERED);
+        assertThat(ts.getMarketEvaluationPointMRID().getValue()).isEqualTo(METERING_POINT_ID);
+        var period = ts.getPeriods().getFirst();
+        assertThat(period.getPoints()).hasSize(2);
+        assertThat(period.getPoints().get(0).getEnergyQuantityQuality())
+                .isEqualTo(StandardQualityTypeList.AS_PROVIDED.value());
+    }
+
+    @Test
+    void toVhd_electricityGeneration_setsBusinessTypeProductionAndDirectionUp() {
+        var readings = List.of(reading(T0, 4.812, "kWh", "VALIDATED", "Generation"));
+
+        var ts = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst()
+                .getMarketDocument().getTimeSeries().getFirst();
+
+        assertThat(ts.getBusinessType()).isEqualTo(StandardBusinessTypeList.PRODUCTION.value());
+        assertThat(ts.getFlowDirectionDirection()).isEqualTo(StandardDirectionTypeList.UP.value());
+    }
+
+    @Test
+    void toVhd_naturalGas_omitsProductAndUsesCubicMetreUnit() {
+        var readings = List.of(reading(T0, 14.728, "m³", "VALIDATED", "Consumption"));
+
+        var ts = build(EnergyType.NATURAL_GAS, readings).toVhd().getFirst()
+                .getMarketDocument().getTimeSeries().getFirst();
+
+        assertThat(ts.getProduct()).isNull();
+        assertThat(ts.getEnergyMeasurementUnitName()).isEqualTo(StandardUnitOfMeasureTypeList.CUBIC_METRE.value());
+        assertThat(ts.getMarketEvaluationPointMeterReadingsReadingsReadingTypeCommodity())
+                .isEqualTo(CommodityKind.NATURALGAS);
+    }
+
+    @Test
+    void toVhd_unsupportedUnit_returnsEmptyList() {
+        var readings = List.of(reading(T0, 1.0, "Wh", "VALIDATED", "Consumption"));
+
+        assertThat(build(EnergyType.ELECTRICITY, readings).toVhd()).isEmpty();
+    }
+
+    @Test
+    void toVhd_unknownStatus_omitsQualityOnPoint() {
+        var readings = List.of(reading(T0, 1.0, "kWh", "ESTIMATED", "Consumption"));
+
+        var point = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst()
+                .getMarketDocument().getTimeSeries().getFirst()
+                .getPeriods().getFirst().getPoints().getFirst();
+
+        assertThat(point.getEnergyQuantityQuality()).isNull();
+    }
+
+    @Test
+    void toVhd_readingsOutOfOrder_sortsByTimestampAndAssignsPositionsInOrder() {
+        var readings = List.of(
+                reading(T0.plusHours(2), 3.0, "kWh", "VALIDATED", "Consumption"),
+                reading(T0, 1.0, "kWh", "VALIDATED", "Consumption"),
+                reading(T0.plusHours(1), 2.0, "kWh", "VALIDATED", "Consumption")
+        );
+
+        var period = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst()
+                .getMarketDocument().getTimeSeries().getFirst()
+                .getPeriods().getFirst();
+
+        assertThat(period.getPoints()).extracting(p -> p.getEnergyQuantityQuantity().doubleValue())
+                .containsExactly(1.0, 2.0, 3.0);
+        assertThat(period.getTimeInterval().getStart()).isEqualTo(T0.toString());
+        assertThat(period.getTimeInterval().getEnd()).isEqualTo(T0.plusHours(2).toString());
+    }
+
+    @Test
+    void toVhd_setsReceiverFromConnectorConfigAndSenderFromDataSourceInformation() {
+        var readings = List.of(reading(T0, 1.0, "kWh", "VALIDATED", "Consumption"));
+        var doc = build(EnergyType.ELECTRICITY, readings).toVhd().getFirst().getMarketDocument();
+
+        assertThat(doc.getReceiverMarketParticipantMRID().getValue()).isEqualTo(ELIGIBLE_PARTY_ID);
+        assertThat(doc.getReceiverMarketParticipantMRID().getCodingScheme()).isEqualTo("NDE");
+        assertThat(doc.getSenderMarketParticipantMRID().getValue()).isEqualTo("eta-plus");
+        assertThat(doc.getSenderMarketParticipantMRID().getCodingScheme()).isEqualTo("NDE");
+    }
+
+    private IntermediateValidatedHistoricalDataMarketDocument build(
+            EnergyType energyType,
+            List<EtaPlusMeteredData.MeterReading> readings
+    ) {
+        DePermissionRequest pr = new DePermissionRequestBuilder()
+                .permissionId("pid")
+                .connectionId("cid")
+                .meteringPointId(METERING_POINT_ID)
+                .start(LocalDate.of(2026, 4, 30))
+                .end(LocalDate.of(2026, 5, 1))
+                .granularity(Granularity.PT15M)
+                .energyType(energyType)
+                .status(PermissionProcessStatus.ACCEPTED)
+                .created(T0)
+                .dataNeedId("dnid")
+                .build();
+        var payload = new EtaPlusMeteredData(METERING_POINT_ID, pr.start(), pr.end(), readings);
+        return new IntermediateValidatedHistoricalDataMarketDocument(
+                cimConfig, deConfiguration, new IdentifiableValidatedHistoricalData(pr, payload));
+    }
+
+    private static EtaPlusMeteredData.MeterReading reading(
+            ZonedDateTime ts, double value, String unit, String quality, String direction) {
+        return new EtaPlusMeteredData.MeterReading(ts, value, unit, quality, direction);
+    }
+}


### PR DESCRIPTION
This PR implements the mapping of validated historical data into CIM-compliant market documents within the DE-ETA region connector.

A dedicated ValidatedHistoricalDataMarketDocumentProvider has been introduced to transform validated historical data streams into CIM v1.04 market documents. The provider consumes validated historical data emitted by the region connector and wraps it into validated historical data envelopes, ensuring correct association with the corresponding permission requests.

To maintain backward compatibility, a ValidatedHistoricalDataEnvelopeProvider for CIM v0.82 has also been implemented. This ensures that consumers relying on older CIM versions continue to receive validated historical data in a supported format.

The implementation follows the same architectural pattern as the existing raw data providers and integrates seamlessly with EDDIE’s event-driven data flow. Permission revocation scenarios are handled implicitly through upstream error handling when requesting data from the MDA API.


### Result

- Validated historical data is mapped and emitted as CIM-compliant market documents
- CIM v1.04 is supported via ValidatedHistoricalDataMarketDocumentProvider
- Backward compatibility with CIM v0.82 is ensured through envelope providers
- Implementation aligns with existing provider patterns and EDDIE best practices