### PR TITLE
GH-2236 Refine Data Source Health States

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,12 +96,13 @@ local.properties
 build
 
 ### IntelliJ
-.idea
+.idea/*
 !.idea/prettier.xml
 !.idea/vcs.xml
 !.idea/externalDependencies.xml
-#### Copyright Notice
-!.idea/copyright/**
+!.idea/fileTemplates
+!.idea/codeStyles
+!.idea/copyright
 
 ### jte template generated files ###
 **/jte-classes

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/MqttDataSourceAdapter.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/MqttDataSourceAdapter.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.aiida.adapters.datasource;
@@ -55,7 +55,9 @@ public abstract class MqttDataSourceAdapter<T extends MqttDataSource> extends Da
 
             MqttConnectionOptions connectOptions = createConnectOptions();
 
-            logger.info("Connecting to broker {} with username {}", dataSource().internalHost(), connectOptions.getUserName());
+            logger.info("Connecting to broker {} with username {}",
+                        dataSource().internalHost(),
+                        connectOptions.getUserName());
 
             asyncClient.connect(connectOptions);
         } catch (MqttException ex) {
@@ -151,14 +153,18 @@ public abstract class MqttDataSourceAdapter<T extends MqttDataSource> extends Da
 
     @Override
     public Health health() {
+        final String healthKey = "MqttDataSource";
+
         if (asyncClient == null) {
-            return Health.down().withDetail("MqttDataSource", "Client is null.").build();
+            return Health.down().withDetail(healthKey, "Client is null.").build();
         }
 
-        return (asyncClient.isConnected()
-                ? Health.up()
-                : Health.down().withDetail("MqttDataSource",
-                                           "Client not connected with server " + asyncClient.getServerURI())).build();
+        if (!asyncClient.isConnected()) {
+            return Health.down().withDetail(healthKey,
+                                            "Client not connected with server " + asyncClient.getServerURI()).build();
+        }
+
+        return super.health();
     }
 
     public void setKeepAliveInterval(Integer keepAliveInterval) {

--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/fr/MicroTeleinfoV3Adapter.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/fr/MicroTeleinfoV3Adapter.java
@@ -127,8 +127,8 @@ public class MicroTeleinfoV3Adapter extends MqttDataSourceAdapter<MicroTeleinfoV
                         .map(entry ->
                                      new MicroTeleinfoV3AdapterStandardModeMeasurement(
                                              entry.getKey(),
-                                             String.valueOf(entry.getValue().sanitizedValue(entry.getKey())))
-                        ).map(SmartMeterAdapterMeasurement::toAiidaRecordValue)
+                                             String.valueOf(entry.getValue().sanitizedValue(entry.getKey()))))
+                        .map(SmartMeterAdapterMeasurement::toAiidaRecordValue)
                         .toList();
                 case UNKNOWN -> throw new MicroTeleinfoV3ModeNotSupportedException(message.getPayload(),
                                                                                    List.of(MicroTeleinfoV3Mode.UNKNOWN));
@@ -145,10 +145,17 @@ public class MicroTeleinfoV3Adapter extends MqttDataSourceAdapter<MicroTeleinfoV
 
     @Override
     public Health health() {
-        var health = super.health();
-        if (health != null && health.getStatus().equals(Status.DOWN)) {
-            return health;
+        var baseHealth = super.health();
+
+        if (baseHealth == null) {
+            return healthState;
         }
+
+        if (baseHealth.getStatus().equals(Status.DOWN) ||
+            baseHealth.getStatus().getCode().equals("WARNING")) {
+            return baseHealth;
+        }
+
         return healthState;
     }
 

--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/shelly/ShellyAdapter.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/shelly/ShellyAdapter.java
@@ -82,11 +82,18 @@ public class ShellyAdapter extends MqttDataSourceAdapter<ShellyDataSource> {
 
     @Override
     public Health health() {
-        var health = super.health();
-        if (healthState.getStatus().equals(Status.UNKNOWN)
-            || (health != null && health.getStatus().equals(Status.DOWN))) {
-            return health;
+        var baseHealth = super.health();
+
+        if (baseHealth == null) {
+            return healthState;
         }
+
+        if (healthState.getStatus().equals(Status.UNKNOWN) ||
+            baseHealth.getStatus().equals(Status.DOWN) ||
+            baseHealth.getStatus().getCode().equals("WARNING")) {
+            return baseHealth;
+        }
+
         return healthState;
     }
 

--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/simulation/SimulationAdapter.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/simulation/SimulationAdapter.java
@@ -11,7 +11,6 @@ import energy.eddie.api.agnostic.aiida.ObisCode;
 import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.health.contributor.Health;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
@@ -93,11 +92,6 @@ public class SimulationAdapter extends DataSourceAdapter<SimulationDataSource> {
 
         // ignore if this fails
         recordSink.tryEmitComplete();
-    }
-
-    @Override
-    public Health health() {
-        return Health.up().build();
     }
 
     private void emitRandomAiidaRecords() {

--- a/aiida/src/main/java/energy/eddie/aiida/errors/record/LatestAiidaRecordNotFoundException.java
+++ b/aiida/src/main/java/energy/eddie/aiida/errors/record/LatestAiidaRecordNotFoundException.java
@@ -3,12 +3,8 @@
 
 package energy.eddie.aiida.errors.record;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import java.util.UUID;
 
-@ResponseStatus(HttpStatus.NOT_FOUND)
 public class LatestAiidaRecordNotFoundException extends Exception {
     public LatestAiidaRecordNotFoundException(UUID dataSourceId) {
         super("Latest Aiida Record not found for data source with ID: %s".formatted(dataSourceId));

--- a/aiida/src/main/java/energy/eddie/aiida/repositories/AiidaRecordRepository.java
+++ b/aiida/src/main/java/energy/eddie/aiida/repositories/AiidaRecordRepository.java
@@ -4,6 +4,7 @@
 package energy.eddie.aiida.repositories;
 
 import energy.eddie.aiida.models.record.AiidaRecord;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,11 +12,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface AiidaRecordRepository extends JpaRepository<AiidaRecord, Long> {
     Optional<AiidaRecord> findFirstByDataSourceIdOrderByIdDesc(UUID dataSourceId);
+    List<AiidaRecord> findByDataSourceIdOrderByTimestampDesc(UUID dataSourceId, Pageable pageable);
 
     @Transactional
     @Modifying

--- a/aiida/src/main/java/energy/eddie/aiida/services/LatestRecordService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/LatestRecordService.java
@@ -19,8 +19,10 @@ import energy.eddie.aiida.repositories.AiidaRecordRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -51,6 +53,27 @@ public class LatestRecordService {
                     dataSourceId);
 
         return recordToLatestDto(aiidaRecord);
+    }
+
+    public List<LatestDataSourceRecordDto> latestDataSourceRecords(
+            UUID dataSourceId,
+            int amount
+    ) throws LatestAiidaRecordNotFoundException {
+        var aiidaRecords = aiidaRecordRepository.findByDataSourceIdOrderByTimestampDesc(dataSourceId,
+                                                                                        Pageable.ofSize(amount));
+        if (aiidaRecords.isEmpty()) {
+            throw new LatestAiidaRecordNotFoundException(dataSourceId);
+        }
+
+        LOGGER.info("Found data source record from timestamp: {} until {} for data source: {}",
+                    aiidaRecords.getFirst().timestamp(),
+                    aiidaRecords.getLast().timestamp(),
+                    dataSourceId);
+
+        return aiidaRecords
+                .stream()
+                .map(this::recordToLatestDto)
+                .toList();
     }
 
     public LatestOutboundPermissionRecordDto latestOutboundPermissionRecord(UUID permissionId) throws LatestPermissionRecordNotFoundException {

--- a/aiida/src/main/java/energy/eddie/aiida/web/LatestRecordController.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/LatestRecordController.java
@@ -13,6 +13,7 @@ import energy.eddie.aiida.errors.record.InboundRecordNotFoundException;
 import energy.eddie.aiida.errors.record.LatestAiidaRecordNotFoundException;
 import energy.eddie.aiida.services.LatestRecordService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -21,11 +22,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -56,6 +55,29 @@ public class LatestRecordController {
         LOGGER.info("Fetching latest data source record for datasource with ID: {}", dataSourceId);
 
         return latestRecordService.latestDataSourceRecord(dataSourceId);
+    }
+
+    @Operation(summary = "Gets the latest data source records for a given datasource ID",
+            operationId = "latestDataSourceRecords",
+            tags = {"dataSourceRecord"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "No latest data source records found",
+                    content = @Content(schema = @Schema(implementation = LatestDataSourceRecordDto.class))),
+            @ApiResponse(responseCode = "404", description = "Datasource not found",
+                    content = @Content(schema = @Schema(implementation = String.class)))
+    })
+    @GetMapping(value = "data-source/{id}/latestRecords")
+    public List<LatestDataSourceRecordDto> latestDataSourceRecords(
+            @PathVariable("id") UUID dataSourceId,
+            @Parameter(
+                    description = "Maximum number of latest records to return"
+            )
+            @RequestParam("amount") int amount
+    )
+            throws LatestAiidaRecordNotFoundException {
+        LOGGER.info("Fetching latest {} data source records for datasource with ID: {}", amount, dataSourceId);
+
+        return latestRecordService.latestDataSourceRecords(dataSourceId, amount);
     }
 
     @GetMapping(value = "permission/{id}/outbound/latest")

--- a/aiida/src/main/resources/application.yml
+++ b/aiida/src/main/resources/application.yml
@@ -22,10 +22,14 @@ spring:
           jwk-set-uri: ${aiida.keycloak.url.internal}/realms/${aiida.keycloak.realm}/protocol/openid-connect/certs
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health
   endpoint:
     health:
-      show-components: when_authorized
-      show-details: when_authorized
+      show-details: always
+      show-components: always
 
 aiida:
   cleanup:

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/DataSourceAdapterTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/DataSourceAdapterTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.aiida.adapters;
@@ -16,6 +16,7 @@ import energy.eddie.aiida.adapters.datasource.sga.SmartGatewaysAdapter;
 import energy.eddie.aiida.adapters.datasource.shelly.ShellyAdapter;
 import energy.eddie.aiida.adapters.datasource.simulation.SimulationAdapter;
 import energy.eddie.aiida.config.MqttConfiguration;
+import energy.eddie.aiida.models.datasource.DataSource;
 import energy.eddie.aiida.models.datasource.interval.modbus.ModbusDataSource;
 import energy.eddie.aiida.models.datasource.interval.simulation.SimulationDataSource;
 import energy.eddie.aiida.models.datasource.mqtt.at.OesterreichsEnergieDataSource;
@@ -24,6 +25,7 @@ import energy.eddie.aiida.models.datasource.mqtt.inbound.InboundDataSource;
 import energy.eddie.aiida.models.datasource.mqtt.it.SinapsiAlfaDataSource;
 import energy.eddie.aiida.models.datasource.mqtt.sga.SmartGatewaysDataSource;
 import energy.eddie.aiida.models.datasource.mqtt.shelly.ShellyDataSource;
+import energy.eddie.aiida.models.record.AiidaRecord;
 import energy.eddie.aiida.services.ModbusDeviceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,10 +33,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+import reactor.core.publisher.Flux;
 import tools.jackson.databind.ObjectMapper;
 
+import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -149,13 +157,61 @@ class DataSourceAdapterTest {
              MockedConstruction<ModbusTcpClient> mockedClient = mockConstruction(ModbusTcpClient.class)) {
 
             mockedStatic.when(() -> ModbusDeviceService.loadConfig(any()))
-                    .thenReturn(ModbusDeviceTestHelper.setupModbusDevice());
+                        .thenReturn(ModbusDeviceTestHelper.setupModbusDevice());
 
             var dataSource = mock(ModbusDataSource.class);
 
             var adapter = DataSourceAdapter.create(dataSource, mapper, mqttConfiguration);
 
             assertInstanceOf(ModbusTcpDataSourceAdapter.class, adapter);
+        }
+    }
+
+    @Test
+    void testHealth() {
+        //noinspection resource
+        var adapter = new HealthTestDataSourceAdapter(mock(DataSource.class));
+
+        assertEquals(Status.UNKNOWN, Objects.requireNonNull(adapter.health()).getStatus());
+
+        var record1 = mock(AiidaRecord.class);
+        var record2 = mock(AiidaRecord.class);
+        var record3 = mock(AiidaRecord.class);
+        var now = Instant.now();
+
+        when(record1.timestamp()).thenReturn(now.minusSeconds(181));
+        when(record2.timestamp()).thenReturn(now.minusSeconds(120));
+        when(record3.timestamp()).thenReturn(now.minusSeconds(10));
+
+        adapter.addTestHealthValidationMessage(record1);
+        assertEquals(Status.DOWN, Objects.requireNonNull(adapter.health()).getStatus());
+
+        adapter.addTestHealthValidationMessage(record2);
+        assertEquals(Health.status("WARNING").build().getStatus(),
+                     Objects.requireNonNull(adapter.health()).getStatus());
+
+        adapter.addTestHealthValidationMessage(record3);
+        assertEquals(Status.UP, Objects.requireNonNull(adapter.health()).getStatus());
+    }
+
+    private static class HealthTestDataSourceAdapter extends DataSourceAdapter<DataSource> {
+
+        protected HealthTestDataSourceAdapter(DataSource dataSource) {
+            super(dataSource);
+        }
+
+        @Override
+        public Flux<AiidaRecord> start() {
+            return Flux.empty();
+        }
+
+        @Override
+        public void close() {
+            // Not needed for test setup
+        }
+
+        public void addTestHealthValidationMessage(AiidaRecord r) {
+            healthValidationMessages.addFirst(r);
         }
     }
 }

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/MqttDataSourceAdapterTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/MqttDataSourceAdapterTest.java
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.aiida.adapters;
+
+import energy.eddie.aiida.adapters.datasource.MqttDataSourceAdapter;
+import energy.eddie.aiida.config.MqttConfiguration;
+import energy.eddie.aiida.models.datasource.mqtt.MqttDataSource;
+import energy.eddie.aiida.utils.MqttFactory;
+import energy.eddie.api.agnostic.aiida.AiidaAsset;
+import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.health.contributor.Status;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class MqttDataSourceAdapterTest {
+
+    private static final MqttConfiguration MQTT_CONFIGURATION = mock(MqttConfiguration.class);
+    private static final MqttDataSource DATA_SOURCE = mock(MqttDataSource.class);
+    private static final String DATA_SOURCE_INTERNAL_HOST = "tcp://localhost:1883";
+    private static final String DATA_SOURCE_TOPIC = "aiida/test";
+
+    @BeforeEach
+    void setup() {
+        when(DATA_SOURCE.internalHost()).thenReturn(DATA_SOURCE_INTERNAL_HOST);
+        when(DATA_SOURCE.topic()).thenReturn(DATA_SOURCE_TOPIC);
+        when(DATA_SOURCE.asset()).thenReturn(AiidaAsset.SUBMETER);
+        when(MQTT_CONFIGURATION.password()).thenReturn("password");
+    }
+
+    @SuppressWarnings("ReactiveStreamsUnusedPublisher")
+    @Test
+    void testHealth() {
+        var adapter = new HealthTestMqttDataSourceAdapter(DATA_SOURCE, MQTT_CONFIGURATION);
+
+        try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
+            var mockClient = mock(MqttAsyncClient.class);
+            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
+                           .thenReturn(mockClient);
+            when(mockClient.isConnected()).thenReturn(true);
+
+            adapter.start();
+            assertEquals(Status.UNKNOWN, Objects.requireNonNull(adapter.health()).getStatus()); // No messages found yet
+
+            adapter.close();
+            when(mockClient.isConnected()).thenReturn(false);
+            assertEquals(Status.DOWN, Objects.requireNonNull(adapter.health()).getStatus());
+        }
+    }
+
+    private static class HealthTestMqttDataSourceAdapter extends MqttDataSourceAdapter<MqttDataSource> {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(HealthTestMqttDataSourceAdapter.class);
+
+        protected HealthTestMqttDataSourceAdapter(MqttDataSource dataSource, MqttConfiguration mqttConfiguration) {
+            super(dataSource, LOGGER, mqttConfiguration);
+        }
+
+        @Override
+        public void messageArrived(String s, MqttMessage mqttMessage) {
+            // Implementation not needed for test setup
+        }
+    }
+}
+
+

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/at/OesterreichsEnergieAdapterTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/at/OesterreichsEnergieAdapterTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import org.springframework.boot.health.contributor.Status;
 import reactor.test.StepVerifier;
 import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.json.JsonMapper;
@@ -29,7 +28,6 @@ import java.util.UUID;
 
 import static energy.eddie.api.agnostic.aiida.ObisCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -64,24 +62,6 @@ class OesterreichsEnergieAdapterTest {
     @AfterEach
     void tearDown() {
         LOG_CAPTOR.clearLogs();
-    }
-
-    @SuppressWarnings("ReactiveStreamsUnusedPublisher")
-    @Test
-    void testHealth() {
-        try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
-            var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
-            when(mockClient.isConnected()).thenReturn(true);
-
-            adapter.start();
-            assertEquals(Status.UP, adapter.health().getStatus());
-
-            adapter.close();
-            when(mockClient.isConnected()).thenReturn(false);
-            assertEquals(Status.DOWN, adapter.health().getStatus());
-        }
     }
 
     @Test

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/cim/CimAdapterTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/cim/CimAdapterTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import org.springframework.boot.health.contributor.Status;
 import reactor.test.StepVerifier;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -27,7 +26,6 @@ import java.time.Duration;
 
 import static energy.eddie.api.agnostic.aiida.ObisCode.POSITIVE_ACTIVE_ENERGY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -61,24 +59,6 @@ class CimAdapterTest {
     @AfterEach
     void tearDown() {
         LOG_CAPTOR.clearLogs();
-    }
-
-    @SuppressWarnings("ReactiveStreamsUnusedPublisher")
-    @Test
-    void testHealth() {
-        try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
-            var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
-            when(mockClient.isConnected()).thenReturn(true);
-
-            adapter.start();
-            assertEquals(Status.UP, adapter.health().getStatus());
-
-            adapter.close();
-            when(mockClient.isConnected()).thenReturn(false);
-            assertEquals(Status.DOWN, adapter.health().getStatus());
-        }
     }
 
     @Test

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/inbound/InboundAdapterTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/inbound/InboundAdapterTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import org.springframework.boot.health.contributor.Status;
 import reactor.test.StepVerifier;
 
 import java.nio.charset.StandardCharsets;
@@ -26,7 +25,6 @@ import java.time.Duration;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -66,24 +64,6 @@ class InboundAdapterTest {
     @AfterEach
     void tearDown() {
         LOG_CAPTOR.clearLogs();
-    }
-
-    @SuppressWarnings("ReactiveStreamsUnusedPublisher")
-    @Test
-    void testHealth() {
-        try (MockedStatic<MqttFactory> mockMqttFactory = mockStatic(MqttFactory.class)) {
-            var mockClient = mock(MqttAsyncClient.class);
-            mockMqttFactory.when(() -> MqttFactory.getMqttAsyncClient(anyString(), anyString(), any()))
-                           .thenReturn(mockClient);
-            when(mockClient.isConnected()).thenReturn(true);
-
-            adapter.start();
-            assertEquals(Status.UP, adapter.health().getStatus());
-
-            adapter.close();
-            when(mockClient.isConnected()).thenReturn(false);
-            assertEquals(Status.DOWN, adapter.health().getStatus());
-        }
     }
 
     @Test

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/shelly/ShellyAdapterTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/shelly/ShellyAdapterTest.java
@@ -74,7 +74,7 @@ class ShellyAdapterTest {
             when(mockClient.isConnected()).thenReturn(true);
 
             adapter.start();
-            assertEquals(Status.UP, adapter.health().getStatus());
+            assertEquals(Status.UNKNOWN, adapter.health().getStatus());
 
             adapter.messageArrived(TOPIC, new MqttMessage("true".getBytes(StandardCharsets.UTF_8)));
             assertEquals(Status.UP, adapter.health().getStatus());

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/simulation/SimulationDataSourceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/simulation/SimulationDataSourceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.health.contributor.Status;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
@@ -77,11 +76,5 @@ class SimulationDataSourceTest {
         simulator.close();
 
         stepVerifier.verify(Duration.ofSeconds(1));
-    }
-
-    @Test
-    void testHealth() {
-        simulator = new SimulationAdapter(DATA_SOURCE);
-        assertEquals(Status.UP, simulator.health().getStatus());
     }
 }

--- a/aiida/src/test/java/energy/eddie/aiida/repositories/AiidaRecordRepositoryIntegrationTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/repositories/AiidaRecordRepositoryIntegrationTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -80,6 +81,75 @@ class AiidaRecordRepositoryIntegrationTest {
 
         dataSource = new SimulationDataSource(dto, UUID.randomUUID());
         dataSource = dataSourceRepository.saveAndFlush(dataSource);
+    }
+
+    @Test
+    void findByDataSourceIdOrderByTimestampDesc_validRecordsAdded_recordsReturned() {
+        Instant now = Instant.now();
+        AiidaRecord stringRecord1 = new AiidaRecord(now.minusSeconds(5), dataSource, List.of(
+                new AiidaRecordValue("0-0:C.1.0",
+                        METER_SERIAL,
+                        "Hello Test1",
+                        UnitOfMeasurement.NONE,
+                        "Hello Test1",
+                        UnitOfMeasurement.NONE)));
+
+        AiidaRecord stringRecord2 = new AiidaRecord(now.minusSeconds(10), dataSource, List.of(
+                new AiidaRecordValue("0-0:C.1.0",
+                        METER_SERIAL,
+                        "Hello Test2",
+                        UnitOfMeasurement.NONE,
+                        "Hello Test2",
+                        UnitOfMeasurement.NONE)));
+
+        AiidaRecord stringRecord3 = new AiidaRecord(now, dataSource, List.of(
+                new AiidaRecordValue("0-0:C.1.0",
+                        METER_SERIAL,
+                        "Hello Test3",
+                        UnitOfMeasurement.NONE,
+                        "Hello Test3",
+                        UnitOfMeasurement.NONE)));
+
+        repository.save(stringRecord1);
+        repository.save(stringRecord2);
+        repository.save(stringRecord3);
+
+        var latest = repository.findByDataSourceIdOrderByTimestampDesc(dataSource.id(), Pageable.ofSize(1));
+        var latestTwo = repository.findByDataSourceIdOrderByTimestampDesc(dataSource.id(), Pageable.ofSize(2));
+        var latestThree = repository.findByDataSourceIdOrderByTimestampDesc(dataSource.id(), Pageable.ofSize(3));
+
+        assertEquals(1, latest.size());
+        AiidaRecord firstOne = latest.getFirst();
+        assertEquals(METER_SERIAL, firstOne.aiidaRecordValues().getFirst().dataTag());
+        assertEquals(now.toEpochMilli(), firstOne.timestamp().toEpochMilli());
+        assertEquals("Hello Test3", firstOne.aiidaRecordValues().getFirst().value());
+
+        assertEquals(2, latestTwo.size());
+        AiidaRecord firstTwo = latestTwo.getFirst();
+        assertEquals(METER_SERIAL, firstTwo.aiidaRecordValues().getFirst().dataTag());
+        assertEquals(now.toEpochMilli(), firstTwo.timestamp().toEpochMilli());
+        assertEquals("Hello Test3", firstTwo.aiidaRecordValues().getFirst().value());
+
+        AiidaRecord secondTwo = latestTwo.get(1);
+        assertEquals(METER_SERIAL, secondTwo.aiidaRecordValues().getFirst().dataTag());
+        assertEquals(now.minusSeconds(5).toEpochMilli(), secondTwo.timestamp().toEpochMilli());
+        assertEquals("Hello Test1", secondTwo.aiidaRecordValues().getFirst().value());
+
+        assertEquals(3, latestThree.size());
+        AiidaRecord firstThree = latestTwo.getFirst();
+        assertEquals(METER_SERIAL, firstThree.aiidaRecordValues().getFirst().dataTag());
+        assertEquals(now.toEpochMilli(), firstThree.timestamp().toEpochMilli());
+        assertEquals("Hello Test3", firstThree.aiidaRecordValues().getFirst().value());
+
+        AiidaRecord secondThree = latestThree.get(1);
+        assertEquals(METER_SERIAL, secondThree.aiidaRecordValues().getFirst().dataTag());
+        assertEquals(now.minusSeconds(5).toEpochMilli(), secondThree.timestamp().toEpochMilli());
+        assertEquals("Hello Test1", secondThree.aiidaRecordValues().getFirst().value());
+
+        AiidaRecord thirdThree = latestThree.get(2);
+        assertEquals(METER_SERIAL, thirdThree.aiidaRecordValues().getFirst().dataTag());
+        assertEquals(now.minusSeconds(10).toEpochMilli(), thirdThree.timestamp().toEpochMilli());
+        assertEquals("Hello Test2", thirdThree.aiidaRecordValues().getFirst().value());
     }
 
     @Test

--- a/aiida/src/test/java/energy/eddie/aiida/services/LatestRecordServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/LatestRecordServiceTest.java
@@ -3,6 +3,7 @@
 
 package energy.eddie.aiida.services;
 
+import energy.eddie.aiida.dtos.record.LatestDataSourceRecordDto;
 import energy.eddie.aiida.errors.datasource.InvalidDataSourceTypeException;
 import energy.eddie.aiida.errors.permission.LatestPermissionRecordNotFoundException;
 import energy.eddie.aiida.errors.permission.PermissionNotFoundException;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
 import java.util.List;
@@ -96,6 +98,76 @@ class LatestRecordServiceTest {
 
         assertTrue(exception.getMessage().contains(DATA_SOURCE_ID.toString()));
         verify(repository, times(1)).findFirstByDataSourceIdOrderByIdDesc(DATA_SOURCE_ID);
+    }
+
+    @Test
+    void latestAiidaRecords_shouldReturnLatestRecords_whenFound() throws LatestAiidaRecordNotFoundException {
+        int nRecords = 5;
+
+        var timestamps = new Instant[]{
+                TIMESTAMP,
+                Instant.parse("2026-01-15T10:29:00Z"),
+                Instant.parse("2026-01-15T10:28:00Z"),
+                Instant.parse("2026-01-15T10:27:00Z"),
+                Instant.parse("2026-01-15T10:26:00Z")
+        };
+
+        var aiidaRecords = new AiidaRecord[nRecords];
+        var expectedDtos = new LatestDataSourceRecordDto[nRecords];
+
+        for (int i = 0; i < nRecords; i++) {
+            var aiidaRecord = mock(AiidaRecord.class);
+            var dataSource = mock(DataSource.class);
+
+            var value = new AiidaRecordValue(
+                    "my-raw-tag",
+                    ObisCode.POSITIVE_ACTIVE_ENERGY,
+                    "0.0255",
+                    UnitOfMeasurement.KILO_WATT,
+                    "25.5",
+                    UnitOfMeasurement.WATT
+            );
+
+            when(aiidaRecord.timestamp()).thenReturn(timestamps[i]);
+            when(aiidaRecord.dataSource()).thenReturn(dataSource);
+            when(aiidaRecord.aiidaRecordValues()).thenReturn(List.of(value));
+
+            when(dataSource.id()).thenReturn(DATA_SOURCE_ID);
+            when(dataSource.asset()).thenReturn(AiidaAsset.SUBMETER);
+            when(dataSource.name()).thenReturn("datasource%d".formatted(i + 1));
+
+            aiidaRecords[i] = aiidaRecord;
+            var expectedDto = new LatestDataSourceRecordDto(timestamps[i],
+                                                            "datasource%d".formatted(i + 1),
+                                                            AiidaAsset.SUBMETER,
+                                                            DATA_SOURCE_ID,
+                                                            List.of(value.toDto()));
+            expectedDtos[i] = expectedDto;
+        }
+
+        when(repository.findByDataSourceIdOrderByTimestampDesc(DATA_SOURCE_ID, Pageable.ofSize(nRecords)))
+                .thenReturn(List.of(aiidaRecords));
+
+        var resultList = aiidaRecordService.latestDataSourceRecords(DATA_SOURCE_ID, nRecords);
+
+        verify(repository, times(1)).findByDataSourceIdOrderByTimestampDesc(DATA_SOURCE_ID, Pageable.ofSize(nRecords));
+
+        for (int i = 0; i < nRecords; i++) {
+            assertEquals(expectedDtos[i], resultList.get(i));
+        }
+    }
+
+    @Test
+    void latestAiidaRecords_shouldThrow_whenRecordNotFound() {
+        when(repository.findByDataSourceIdOrderByTimestampDesc(DATA_SOURCE_ID, Pageable.ofSize(3)))
+                .thenReturn(List.of());
+
+        var exception = assertThrows(LatestAiidaRecordNotFoundException.class, () ->
+                aiidaRecordService.latestDataSourceRecords(DATA_SOURCE_ID, 3)
+        );
+
+        assertTrue(exception.getMessage().contains(DATA_SOURCE_ID.toString()));
+        verify(repository, times(1)).findByDataSourceIdOrderByTimestampDesc(DATA_SOURCE_ID, Pageable.ofSize(3));
     }
 
     @Test

--- a/aiida/ui/src/api.ts
+++ b/aiida/ui/src/api.ts
@@ -48,12 +48,12 @@ async function fetch(path: string, init?: RequestInit): Promise<any> {
       throw error
     })
 
-  if (!response.ok) {
+  if (!response.ok && !isHealthEndpoint) {
     const message =
       (await parseErrorResponse(response)) ??
       FALLBACK_ERROR_MESSAGES[response.status as keyof typeof FALLBACK_ERROR_MESSAGES] ??
       'errors.unexpectedError'
-    if (!((isImagesEndpoint && response.status == 404) || isHealthEndpoint)) {
+    if (!(isImagesEndpoint && response.status == 404)) {
       danger(message, response.status == 404 ? 5000 : 0, true)
     }
     throw new Error(message)

--- a/aiida/ui/src/assets/locales/de.json
+++ b/aiida/ui/src/assets/locales/de.json
@@ -42,7 +42,13 @@
       "downloadLatestMessageButton": "Neueste Nachricht herunterladen",
       "healthStatus": "Status",
       "healthStatusUp": "Aktiv",
-      "healthStatusDown": "Störung"
+      "healthStatusWarning": "Warnung",
+      "healthStatusDown": "Störung",
+      "healthStatusUnknown": "Unbekannt",
+      "healthStatusUpTooltip": "Eine oder mehrere Nachrichten wurden in den vergangenen 90 Sekunden empfangen.",
+      "healthStatusWarningTooltip": "Die neueste Nachricht wurde zwischen den vergangenen 90 und 180 Sekunden empfangen.",
+      "healthStatusDownTooltip": "Die neueste Nachricht wurde vor mehr als 180 Sekunden empfangen.",
+      "healthStatusUnknownTooltip": "Es konnten keine Nachrichten gefunden werden, um den Status der Datenquelle zu identifizieren."
     },
     "modal": {
       "name": "Name",

--- a/aiida/ui/src/assets/locales/en.json
+++ b/aiida/ui/src/assets/locales/en.json
@@ -41,7 +41,13 @@
       "downloadLatestMessageButton": "Download Latest Message",
       "healthStatus": "Status",
       "healthStatusUp": "Up",
-      "healthStatusDown": "Down"
+      "healthStatusWarning": "Warning",
+      "healthStatusDown": "Down",
+      "healthStatusUnknown": "Unknown",
+      "healthStatusUpTooltip": "One or more messages were received within the past 90 seconds.",
+      "healthStatusWarningTooltip": "The latest message was received between the past 90 and 180 seconds.",
+      "healthStatusDownTooltip": "The latest message was received longer than 180 seconds ago.",
+      "healthStatusUnknownTooltip": "No messages could be found to determine the status of the Data Source."
     },
     "modal": {
       "name": "Name",

--- a/aiida/ui/src/assets/locales/fr.json
+++ b/aiida/ui/src/assets/locales/fr.json
@@ -42,7 +42,13 @@
       "downloadLatestMessageButton": "Télécharger le dernier message",
       "healthStatus": "État",
       "healthStatusUp": "Actif",
-      "healthStatusDown": "Inactif"
+      "healthStatusWarning": "Avertissement",
+      "healthStatusDown": "Inactif",
+      "healthStatusUnknown": "Inconnu",
+      "healthStatusUpTooltip": "Un ou plusieurs messages ont été reçus au cours des 90 dernières secondes.",
+      "healthStatusWarningTooltip": "Le dernier message a été reçu il y a entre 90 et 180 secondes.",
+      "healthStatusDownTooltip": "Le dernier message a été reçu il y a plus de 180 secondes.",
+      "healthStatusUnknownTooltip": "Aucun message n'a pu être trouvé pour déterminer l'état de la source de données."
     },
     "modal": {
       "name": "Nom",

--- a/aiida/ui/src/assets/main.css
+++ b/aiida/ui/src/assets/main.css
@@ -30,13 +30,13 @@
   --eddie-secondary: #eff2f7;
   --eddie-blue: #15a7e0;
   --eddie-green: #92c143;
-  --eddie-yellow: #fed119;
   --eddie-red-dark: #9e0b0f;
-  --eddie-red-light: #ff3b30;
   --eddie-red-medium: #b3261e;
+  --eddie-red-light: #ff3b30;
+  --eddie-red-background: #ffeaeb;
   --eddie-primary-900: #017aa0e6;
-  --eddie-primary-100: #017aa01a;
   --eddie-primary-400: #017aa066;
+  --eddie-primary-100: #017aa01a;
   --max-content-width: 1620px;
   --content-padding: 1rem;
   --border-radius: 0.5rem;

--- a/aiida/ui/src/components/DataSourceCard.vue
+++ b/aiida/ui/src/components/DataSourceCard.vue
@@ -10,11 +10,12 @@ import DataSourceIcon from '@/components/DataSourceIcon.vue'
 import StatusDotIcon from '@/assets/icons/StatusDotIcon.svg'
 import ChevronDownIcon from '@/assets/icons/ChevronDownIcon.svg'
 import { computed, ref } from 'vue'
-import type { AiidaDataSource } from '@/types'
+import type { AiidaDataSource, StatusTypes } from '@/types'
 import { dataSourceHealthStatuses, dataSourceImages } from '@/stores/dataSources'
 import MessageDownloadButton from '@/components/MessageDownloadButton.vue'
 import { useI18n } from 'vue-i18n'
 import StatusTag from '@/components/StatusTag.vue'
+import Tooltip from '@/components/Tooltip.vue'
 
 const { t } = useI18n()
 const COUNTRY_NAMES = new Intl.DisplayNames(['en'], { type: 'region' })
@@ -42,8 +43,40 @@ const {
   icon,
 } = dataSource
 
+type HealthStatusConfig = {
+  type: StatusTypes
+  label: string
+  tooltip: string
+}
+
 const image = computed(() => dataSourceImages.value[dataSource.id])
 const healthStatus = computed(() => dataSourceHealthStatuses.value[dataSource.id])
+const healthTexts: Record<string, HealthStatusConfig> = {
+  UP: {
+    type: 'healthy',
+    label: t('datasources.card.healthStatusUp'),
+    tooltip: t('datasources.card.healthStatusUpTooltip'),
+  },
+  WARNING: {
+    type: 'partially-healthy',
+    label: t('datasources.card.healthStatusWarning'),
+    tooltip: t('datasources.card.healthStatusWarningTooltip'),
+  },
+  UNKNOWN: {
+    type: 'unknown',
+    label: t('datasources.card.healthStatusUnknown'),
+    tooltip: t('datasources.card.healthStatusUnknownTooltip'),
+  },
+  DOWN: {
+    type: 'unhealthy',
+    label: t('datasources.card.healthStatusDown'),
+    tooltip: t('datasources.card.healthStatusDownTooltip'),
+  },
+}
+
+const healthStatusConfig = computed<HealthStatusConfig>(
+  () => healthTexts[healthStatus?.value?.status || 'DOWN'],
+)
 </script>
 
 <template>
@@ -67,16 +100,11 @@ const healthStatus = computed(() => dataSourceHealthStatuses.value[dataSource.id
 
       <div>
         <dt>{{ t('datasources.card.healthStatus') }}</dt>
-        <StatusTag
-          :status-type="healthStatus?.status !== 'UP' ? 'unhealthy' : 'healthy'"
-          minimal-on-mobile
-        >
-          {{
-            healthStatus?.status === 'UP'
-              ? t('datasources.card.healthStatusUp')
-              : t('datasources.card.healthStatusDown')
-          }}
-        </StatusTag>
+        <Tooltip :enabled="enabled" :text="healthStatusConfig.tooltip">
+          <StatusTag :status-type="healthStatusConfig.type" minimal-on-mobile>
+            {{ healthStatusConfig.label }}
+          </StatusTag>
+        </Tooltip>
       </div>
 
       <template v-if="countryCode">

--- a/aiida/ui/src/components/StatusTag.vue
+++ b/aiida/ui/src/components/StatusTag.vue
@@ -5,9 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 <script setup lang="ts">
 import StatusDotIcon from '@/assets/icons/StatusDotIcon.svg'
+import type { StatusTypes } from '@/types'
 
 const { statusType = 'healthy', minimalOnMobile } = defineProps<{
-  statusType?: 'healthy' | 'unhealthy'
+  statusType?: StatusTypes
   minimalOnMobile?: boolean
 }>()
 </script>
@@ -23,22 +24,29 @@ const { statusType = 'healthy', minimalOnMobile } = defineProps<{
 
 <style scoped>
 .status-tag {
+  --status-color: var(--eddie-green);
+
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-xs) var(--spacing-md);
   background-color: #fafff2;
-  border: 1px solid var(--eddie-green);
-  color: var(--eddie-green);
+  border: 1px solid var(--status-color);
+  color: var(--status-color);
   width: fit-content;
   height: fit-content;
   border-radius: 1rem;
   text-wrap: nowrap;
 
-  &.unhealthy {
-    color: var(--eddie-red-medium);
-    background-color: #ffeaeb;
-    border-color: var(--eddie-red-medium);
+  &.unhealthy,
+  &.partially-healthy {
+    --status-color: var(--eddie-red-medium);
+    background-color: var(--eddie-red-background);
+  }
+
+  &.unknown {
+    --status-color: var(--eddie-grey-medium);
+    background-color: var(--eddie-grey-light);
   }
 
   &.minimal {

--- a/aiida/ui/src/components/Tooltip.vue
+++ b/aiida/ui/src/components/Tooltip.vue
@@ -1,0 +1,84 @@
+<!-- SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<script setup lang="ts">
+import { nextTick, ref } from 'vue'
+
+const tooltipRef = ref<HTMLElement | null>(null)
+
+async function show() {
+  isVisible.value = true
+  await nextTick()
+
+  const el = tooltipRef.value
+  if (!el) return
+
+  const rect = el.getBoundingClientRect()
+
+  if (rect.left < 0) {
+    el.style.left = '0'
+    el.style.transform = 'translateX(0)'
+  }
+
+  if (rect.right > window.innerWidth) {
+    el.style.left = '100%'
+    el.style.transform = 'translateX(-100%)'
+  }
+}
+
+defineProps<{
+  text: string
+  enabled: boolean
+}>()
+
+const isVisible = ref(false)
+
+function hide() {
+  isVisible.value = false
+}
+</script>
+
+<template>
+  <div class="tooltip-wrapper" @mouseenter="show" @mouseleave="hide">
+    <slot />
+
+    <transition name="fade">
+      <div v-if="isVisible && enabled" ref="tooltipRef" class="tooltip">
+        {{ text }}
+      </div>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+  cursor: default;
+  overflow: visible;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: 125%;
+
+  left: 50%;
+  transform: translateX(-50%);
+
+  background-color: var(--eddie-grey-medium);
+  color: var(--light);
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+
+  white-space: normal;
+  min-width: max-content;
+  max-width: min(16.25rem, 90vw);
+  width: max-content;
+
+  box-sizing: border-box;
+
+  text-align: center;
+  z-index: 1000;
+}
+</style>

--- a/aiida/ui/src/types.d.ts
+++ b/aiida/ui/src/types.d.ts
@@ -85,8 +85,11 @@ export type AiidaPermissionRequestsDTO = {
 
 export type AiidaDataSourceHealthStatus = {
   status: string
-  details: string
+  details?: {
+    [key: string]: string
+  }
 }
 
 export type PermissionTypes = 'Active' | 'Pending' | 'Complete'
 export type ToastTypes = 'info' | 'success' | 'warning' | 'danger'
+export type StatusTypes = 'healthy' | 'partially-healthy' | 'unhealthy' | 'unknown'

--- a/outbound-connectors/outbound-metric/build.gradle.kts
+++ b/outbound-connectors/outbound-metric/build.gradle.kts
@@ -90,7 +90,7 @@ jsonSchema2Pojo {
 sourceSets {
     main {
         java {
-            srcDir("${layout.buildDirectory}/generated-sources")
+            srcDir(layout.buildDirectory.dir("generated-sources"))
         }
     }
 }


### PR DESCRIPTION
- Update DataSourceAdapter's health check to represent flowing data i.e. its incoming messages
- Introduce new states UNKNOWN and WARNING
- Consolidate duplicated health tests
- Provide new latestDataSourceRecords endpoint for multiple LatestRecords
- Integration and unit tests for health and record repository