### PR TITLE
GH-2187 Remove non-existent eta npm dependencies from lock file

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,15 +271,6 @@ importers:
         specifier: ^4.5.2
         version: 4.5.14(@types/node@22.19.11)
 
-  region-connectors/region-connector-de-eta:
-    dependencies:
-      lit:
-        specifier: ^2.7.5
-        version: 2.8.0
-      vite:
-        specifier: ^4.5.2
-        version: 4.5.14(@types/node@22.18.0)
-
   region-connectors/region-connector-dk-energinet:
     dependencies:
       lit:


### PR DESCRIPTION
Introduced in #2291. Potentially breaks builds. Frontend will only be added in #2292.