### PR TITLE
NOISSUE Improve pnpm build consistency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
+import com.github.gradle.node.pnpm.task.PnpmInstallTask
 import com.github.gradle.node.pnpm.task.PnpmTask
 import com.github.jk1.license.filter.DependencyFilter
 import com.github.jk1.license.filter.LicenseBundleNormalizer
@@ -34,6 +35,10 @@ node {
 licenseReport {
     renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html", "EDDIE Framework"))
     filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
+}
+
+tasks.withType<PnpmInstallTask> {
+    pnpmCommand.set(listOf("install", "--frozen-lockfile"))
 }
 
 tasks.register<PnpmTask>("pnpmBuild") {


### PR DESCRIPTION
Includes:
1. `--frozen-lockfile` argument for `pnpm install` to force exact minor/patch versions for packages
2. ~~Type cast through double assertion (`as unknown as Plugin`) preventing [this](https://github.com/eddie-energy/eddie/actions/runs/22065282537/job/63755388021?pr=2272#step:4:915) recently surfaced build error~~

```
src/main.ts(131,9): error TS2345: Argument of type 'Plugin' is not assignable to parameter of type 'Plugin<any[], any[]>'.
  Type 'ObjectPlugin<any[]>' is not assignable to type 'Plugin<any[], any[]>'.
    Type 'ObjectPlugin<any[]>' is not assignable to type 'FunctionPlugin<any[]>'.
      Type 'ObjectPlugin<any[]>' is not assignable to type '(app: App<any>, ...options: any[]) => any'.
        Type 'ObjectPlugin<any[]>' provides no match for the signature '(app: App<any>, ...options: any[]): any'.
```

Update: Using `--frozen-lockfile` alone already seems to prevent the type error. Please ping me if you manage to reproduce it with this commit.