### PR TITLE
GH-2346 AIIDA deployment fails on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 # These are Windows script files and should use crlf
 *.bat           text eol=crlf
 
+# Password replacements fail in Docker Desktop on Windows if CRLF is active, so set it to LF manually
+*.sh            text eol=lf

--- a/aiida/docker/emqx/replace-password-with-env.sh
+++ b/aiida/docker/emqx/replace-password-with-env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# SPDX-FileCopyrightText: 2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+# SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/aiida/docker/postgres/replace-password-with-env.sh
+++ b/aiida/docker/postgres/replace-password-with-env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# SPDX-FileCopyrightText: 2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+# SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 # SPDX-License-Identifier: Apache-2.0
 
 set -e


### PR DESCRIPTION
- Change line ending for password replacement scripts in order for it to work in Docker Desktop for Windows