### PR TITLE
NOISSUE CIM: Shade Jackson dependencies to avoid Spring Boot 3.x conflicts with older Jackson 2 versions

### DIFF
--- a/cim/CHANGELOG.md
+++ b/cim/CHANGELOG.md
@@ -76,3 +76,7 @@ For more information, see [Common Information Model Client Libraries](https://ar
 ## 3.5.1 - 2026-02-26
 
 - Improve Javadoc in the `CommonInformationModelVersions` class.
+
+## 3.5.2 - 2026-03-10
+
+- Shade Jackson dependencies to prevent conflicts with Spring Boot 3.x

--- a/cim/build.gradle.kts
+++ b/cim/build.gradle.kts
@@ -18,11 +18,12 @@ plugins {
     jacoco
     signing
     `java-library`
+    alias(libs.plugins.gradleup.shadow)
 }
 
 group = "energy.eddie"
 
-version = "3.5.1"
+version = "3.5.2"
 
 repositories {
     mavenCentral()
@@ -141,6 +142,12 @@ tasks.compileJava {
     dependsOn(generateCIMSchemaClasses)
 }
 
+tasks.shadowJar {
+    archiveClassifier.set("")
+    // Shade Jackson dependencies to prevent spring boot 3.x conflicts with newer jackson versions
+    relocate("tools", "energy.eddie.cim.shaded.tools.jackson")
+}
+
 val mavenCentralUsername = System.getenv("MAVEN_CENTRAL_USERNAME")
 val mavenCentralPassword = System.getenv("MAVEN_CENTRAL_PASSWORD")
 publishing {
@@ -156,7 +163,9 @@ publishing {
     }
     publications {
         create<MavenPublication>("cim") {
-            from(components["java"])
+            artifact(tasks.shadowJar)
+            artifact(tasks.named("javadocJar"))
+            artifact(tasks.named("sourcesJar"))
             groupId = group.toString()
             artifactId = project.name
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ jakarta-transaction = "2.0.1"
 jakarta-persistence-api = "3.2.0"
 sonar = "7.2.0.6526"
 commons-codec = "1.15"
-jackson = "3.0.3"
+jackson = "3.1.0"
 jackson2-short = "2.20"
 h2database = "2.3.232"
 postgresql = "42.7.3"
@@ -64,6 +64,7 @@ mvel2 = "2.5.2.Final"
 opentelemetry-instrumentation-bom = "2.18.1"
 
 undercouch-download = "5.6.0"
+gradleup-shadow = "9.3.2"
 
 [libraries]
 # Static analysis
@@ -210,6 +211,8 @@ opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testi
 
 [plugins]
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone" }
+# used by CIM
+gradleup-shadow = { id = "com.gradleup.shadow", version.ref = "gradleup-shadow" }
 # used by example-app
 jte-gradle = { id = "gg.jte.gradle", version.ref = "jte" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }


### PR DESCRIPTION
Work in progress, since there are more complications with shading jackson than I thought.