### PR TITLE
feat(cim): Add the energy sharing reference data market document schema to CIM library

### DIFF
--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/inbound/ack/cim/MinMaxEnvelopeAckFormatterStrategy.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/inbound/ack/cim/MinMaxEnvelopeAckFormatterStrategy.java
@@ -5,10 +5,9 @@ package energy.eddie.aiida.adapters.datasource.inbound.ack.cim;
 
 import energy.eddie.aiida.adapters.datasource.inbound.ack.BaseAckFormatterStrategy;
 import energy.eddie.aiida.models.record.InboundRecord;
-import energy.eddie.cim.v1_12.ack.AcknowledgementEnvelope;
-import energy.eddie.cim.v1_12.ack.AcknowledgementMarketDocument;
-import energy.eddie.cim.v1_12.ack.MessageDocumentHeader;
-import energy.eddie.cim.v1_12.ack.PartyIDString;
+import energy.eddie.cim.v1_12.StandardMessageTypeList;
+import energy.eddie.cim.v1_12.StandardReasonCodeTypeList;
+import energy.eddie.cim.v1_12.ack.*;
 import tools.jackson.databind.ObjectMapper;
 
 import java.time.ZonedDateTime;
@@ -35,7 +34,7 @@ public class MinMaxEnvelopeAckFormatterStrategy extends BaseAckFormatterStrategy
 
         var marketDocument = toMarketDocument(now, minMaxEnvelope.getMarketDocument())
                 .withReceivedMarketDocumentCreatedDateTime(minMaxHeader.getCreationDateTime())
-                .withReceivedMarketDocumentType(minMaxMetaInformation.getDocumentType());
+                .withReceivedMarketDocumentType(StandardMessageTypeList.ACKNOWLEDGEMENT_DOCUMENT.value());
 
         return new AcknowledgementEnvelope()
                 .withMessageDocumentHeader(header)
@@ -50,13 +49,17 @@ public class MinMaxEnvelopeAckFormatterStrategy extends BaseAckFormatterStrategy
         return new AcknowledgementMarketDocument()
                 .withMRID(UUID.randomUUID().toString())
                 .withCreatedDateTime(now)
-                .withSenderMarketParticipantMRID(toPartyIdString(marketDocument.getSenderMarketParticipantMRID()))
-                .withSenderMarketParticipantMarketRoleType(marketDocument.getSenderMarketParticipantMarketRoleType())
-                .withReceiverMarketParticipantMRID(toPartyIdString(marketDocument.getReceiverMarketParticipantMRID()))
-                .withReceiverMarketParticipantMarketRoleType(marketDocument.getReceiverMarketParticipantMarketRoleType())
+                .withSenderMarketParticipantMRID(toPartyIdString(marketDocument.getReceiverMarketParticipantMRID()))
+                .withSenderMarketParticipantMarketRoleType(marketDocument.getReceiverMarketParticipantMarketRoleType())
+                .withReceiverMarketParticipantMRID(toPartyIdString(marketDocument.getSenderMarketParticipantMRID()))
+                .withReceiverMarketParticipantMarketRoleType(marketDocument.getSenderMarketParticipantMarketRoleType())
                 .withReceivedMarketDocumentMRID(marketDocument.getMRID())
                 .withReceivedMarketDocumentRevisionNumber(marketDocument.getRevisionNumber())
-                .withReceivedMarketDocumentProcessProcessType(marketDocument.getProcessProcessType());
+                .withReceivedMarketDocumentProcessProcessType(marketDocument.getProcessProcessType())
+                .withReasons(
+                        new Reason()
+                                .withCode(StandardReasonCodeTypeList.MESSAGE_FULLY_ACCEPTED.value())
+                );
     }
 
     private PartyIDString toPartyIdString(energy.eddie.cim.v1_12.recmmoe.PartyIDString partyIdString) {

--- a/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/inbound/ack/opaque/OpaqueAckFormatterStrategy.java
+++ b/aiida/src/main/java/energy/eddie/aiida/adapters/datasource/inbound/ack/opaque/OpaqueAckFormatterStrategy.java
@@ -6,12 +6,16 @@ package energy.eddie.aiida.adapters.datasource.inbound.ack.opaque;
 import energy.eddie.aiida.adapters.datasource.inbound.ack.BaseAckFormatterStrategy;
 import energy.eddie.aiida.models.record.InboundRecord;
 import energy.eddie.cim.agnostic.OpaqueEnvelope;
-import energy.eddie.cim.v1_12.ack.AcknowledgementEnvelope;
-import energy.eddie.cim.v1_12.ack.AcknowledgementMarketDocument;
-import energy.eddie.cim.v1_12.ack.MessageDocumentHeader;
+import energy.eddie.cim.v1_12.LocalCodingSchemeType;
+import energy.eddie.cim.v1_12.StandardDocumentTypeList;
+import energy.eddie.cim.v1_12.StandardReasonCodeTypeList;
+import energy.eddie.cim.v1_12.StandardRoleTypeList;
+import energy.eddie.cim.v1_12.ack.*;
 import tools.jackson.databind.ObjectMapper;
 
+import java.nio.ByteBuffer;
 import java.time.ZonedDateTime;
+import java.util.Base64;
 import java.util.UUID;
 
 public class OpaqueAckFormatterStrategy extends BaseAckFormatterStrategy {
@@ -38,7 +42,28 @@ public class OpaqueAckFormatterStrategy extends BaseAckFormatterStrategy {
         return new AcknowledgementMarketDocument()
                 .withMRID(UUID.randomUUID().toString())
                 .withCreatedDateTime(now)
+                .withSenderMarketParticipantMRID(new PartyIDString()
+                                                         .withCodingScheme(LocalCodingSchemeType.AIIDA.value())
+                                                         .withValue(truncateUUID(aiidaId))
+                )
+                .withSenderMarketParticipantMarketRoleType(StandardRoleTypeList.CONSUMER.value())
+                .withReceiverMarketParticipantMRID(
+                        new PartyIDString()
+                                .withCodingScheme(LocalCodingSchemeType.AIIDA.value())
+                                .withValue("") // Unknown, since the received document does not contain that information
+                )
                 .withReceivedMarketDocumentCreatedDateTime(opaqueEnvelope.timestamp())
-                .withReceivedMarketDocumentMRID(opaqueEnvelope.messageId());
+                .withReceivedMarketDocumentMRID(opaqueEnvelope.messageId())
+                .withReceivedMarketDocumentType(StandardDocumentTypeList.ACKNOWLEDGEMENT_DOCUMENT.value())
+                .withReasons(
+                        new Reason()
+                                .withCode(StandardReasonCodeTypeList.MESSAGE_FULLY_ACCEPTED.value())
+                );
+    }
+
+    private static String truncateUUID(UUID uuid) {
+        ByteBuffer bb = ByteBuffer.wrap(new byte[8]);
+        bb.putLong(uuid.getMostSignificantBits());
+        return Base64.getUrlEncoder().encodeToString(bb.array());
     }
 }

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/inbound/ack/cim/MinMaxEnvelopeAckFormatterStrategyTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/inbound/ack/cim/MinMaxEnvelopeAckFormatterStrategyTest.java
@@ -9,6 +9,8 @@ import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.models.permission.dataneed.AiidaLocalDataNeed;
 import energy.eddie.aiida.models.record.InboundRecord;
 import energy.eddie.api.agnostic.aiida.AiidaAsset;
+import energy.eddie.cim.serde.XmlMessageSerde;
+import energy.eddie.cim.testing.XmlValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,6 +79,7 @@ class MinMaxEnvelopeAckFormatterStrategyTest {
             );
 
             when(inboundRecord.payload()).thenReturn(payload);
+            var serde = new XmlMessageSerde();
 
             // When
             var envelope = strategy.convert(objectMapper, inboundRecord);
@@ -86,6 +89,8 @@ class MinMaxEnvelopeAckFormatterStrategyTest {
             var metaInfo = header.getMetaInformation();
             var asset = metaInfo.getAsset();
             var marketDocument = envelope.getMarketDocument();
+            var bytes = serde.serialize(envelope);
+            assertTrue(XmlValidator.validateV112AcknowledgementMarketDocument(bytes));
 
             assertAll(
                     () -> assertNotNull(header.getCreationDateTime()),
@@ -110,19 +115,19 @@ class MinMaxEnvelopeAckFormatterStrategyTest {
                     () -> assertNotNull(marketDocument.getMRID()),
                     () -> assertEquals("5dc71d7e-e8cd-4403-a3a8-d3c095c97a12",
                                        marketDocument.getReceivedMarketDocumentMRID()),
-                    () -> assertEquals("min-max-envelope", marketDocument.getReceivedMarketDocumentType()),
-                    () -> assertEquals("MIN_MAX_ENVELOPE",
+                    () -> assertEquals("A17", marketDocument.getReceivedMarketDocumentType()),
+                    () -> assertEquals("A37",
                                        marketDocument.getReceivedMarketDocumentProcessProcessType()),
                     () -> assertEquals(ZonedDateTime.parse("2026-02-16T10:11:58Z"),
                                        marketDocument.getReceivedMarketDocumentCreatedDateTime()),
-                    () -> assertEquals("AT003000", marketDocument.getSenderMarketParticipantMRID().getValue()),
+                    () -> assertEquals("fc-id", marketDocument.getSenderMarketParticipantMRID().getValue()),
                     () -> assertEquals("NAT", marketDocument.getSenderMarketParticipantMRID().getCodingScheme()),
-                    () -> assertEquals("CONNECTING_SYSTEM_OPERATOR",
+                    () -> assertEquals("A13",
                                        marketDocument.getSenderMarketParticipantMarketRoleType()),
-                    () -> assertEquals("88e0fc2c-4ea7-4850-a736-8b9742757518",
+                    () -> assertEquals("AT003000",
                                        marketDocument.getReceiverMarketParticipantMRID().getValue()),
                     () -> assertEquals("NAT", marketDocument.getReceiverMarketParticipantMRID().getCodingScheme()),
-                    () -> assertEquals("FINAL_CUSTOMER", marketDocument.getReceiverMarketParticipantMarketRoleType())
+                    () -> assertEquals("A56", marketDocument.getReceiverMarketParticipantMarketRoleType())
             );
         }
     }

--- a/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/inbound/ack/opaque/OpaqueAckFormatterStrategyTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/adapters/datasource/inbound/ack/opaque/OpaqueAckFormatterStrategyTest.java
@@ -9,6 +9,10 @@ import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.models.permission.dataneed.AiidaLocalDataNeed;
 import energy.eddie.aiida.models.record.InboundRecord;
 import energy.eddie.api.agnostic.aiida.AiidaAsset;
+import energy.eddie.cim.serde.SerdeInitializationException;
+import energy.eddie.cim.serde.SerializationException;
+import energy.eddie.cim.serde.XmlMessageSerde;
+import energy.eddie.cim.testing.XmlValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -84,8 +88,9 @@ class OpaqueAckFormatterStrategyTest {
     }
 
     @Test
-    void convert_convertsInboundRecordToAcknowledgementEnvelope() {
+    void convert_convertsInboundRecordToAcknowledgementEnvelope() throws SerdeInitializationException, SerializationException {
         when(inboundRecord.payload()).thenReturn(PAYLOAD);
+        var serde = new XmlMessageSerde();
 
         // When
         var envelope = strategy.convert(objectMapper, inboundRecord);
@@ -95,6 +100,8 @@ class OpaqueAckFormatterStrategyTest {
         var metaInfo = header.getMetaInformation();
         var asset = metaInfo.getAsset();
         var marketDocument = envelope.getMarketDocument();
+        var xml = serde.serialize(envelope);
+        assertTrue(XmlValidator.validateV112AcknowledgementMarketDocument(xml));
 
         assertAll(
                 () -> assertNotNull(header.getCreationDateTime()),

--- a/aiida/src/test/resources/cim/v1_12/min-max-envelope.json
+++ b/aiida/src/test/resources/cim/v1_12/min-max-envelope.json
@@ -6,7 +6,7 @@
       "requestPermissionId": "00213495-bdbf-4497-8695-5d811e45aa64",
       "dataNeedId": "5dc71d7e-e8cd-4403-a3a8-d3c095c97a12",
       "documentType": "min-max-envelope",
-      "finalCustomerId": "88e0fc2c-4ea7-4850-a736-8b9742757518",
+      "finalCustomerId": "fc-id",
       "dataSourceId": "0743c9d8-3e5f-4575-999b-34f6f83b2075",
       "regionConnector": "aiida",
       "regionCountry": "AT",
@@ -28,14 +28,14 @@
       "codingScheme": "NAT"
     },
     "sender_MarketParticipant.name": "Netz Oberösterreich GmbH",
-    "sender_MarketParticipant.marketRole.type": "CONNECTING_SYSTEM_OPERATOR",
+    "sender_MarketParticipant.marketRole.type": "A56",
     "receiver_MarketParticipant.mRID": {
-      "value": "88e0fc2c-4ea7-4850-a736-8b9742757518",
+      "value": "fc-id",
       "codingScheme": "NAT"
     },
     "receiver_MarketParticipant.name": "Max Mustermann",
-    "receiver_MarketParticipant.marketRole.type": "FINAL_CUSTOMER",
-    "process.processType": "MIN_MAX_ENVELOPE",
+    "receiver_MarketParticipant.marketRole.type": "A13",
+    "process.processType": "A37",
     "period.timeInterval": {
       "start": "2026-06-01T00:00:00Z",
       "end": "2026-06-02T23:59:59Z"

--- a/cim/CHANGELOG.md
+++ b/cim/CHANGELOG.md
@@ -88,4 +88,9 @@ For more information, see [Common Information Model Client Libraries](https://ar
 ## 3.8.0 - 2026-04-07
 
 - Add EnergySharingReferenceDataDocument.
-  This document can be used to announce the current participation factor of an accounting for a specific collective energy sharing unit (CESU).
+  This document can be used to announce the current participation factor of an accounting point for a specific collective energy sharing unit (CESU).
+- Fix missing (de)serialization for the following CIM documents:
+  - Real Time Data Market Document v1.12
+  - Acknowledgement Document v1.12
+  - Reference Energy Curve Min-Max Operation Document v1.12
+- Fix typo in RealTimeData Document namespace, where the namespace is missing a colon (:) in the namespace declaration

--- a/cim/CHANGELOG.md
+++ b/cim/CHANGELOG.md
@@ -84,3 +84,8 @@ For more information, see [Common Information Model Client Libraries](https://ar
 ## 3.7.0 - 2026-03-24
 
 - Add agnostic message classes
+
+## 3.8.0 - 2026-04-07
+
+- Add EnergySharingReferenceDataDocument.
+  This document can be used to announce the current participation factor of an accounting for a specific collective energy sharing unit (CESU).

--- a/cim/build.gradle.kts
+++ b/cim/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 group = "energy.eddie"
 
-version = "3.7.0"
+version = "3.8.0"
 
 repositories {
     mavenCentral()
@@ -99,7 +99,8 @@ val generateCIMSchemaClasses by tasks.registering {
         // V1.12
         cimSchemaFiles.resolve("v1_12/rtd/RealTimeData Document_v1.12_annotated.xsd"),
         cimSchemaFiles.resolve("v1_12/recmmoe/ReferenceEnergyCurveMinMaxOperatingEnvelope Document_v1.12_annotated.xsd"),
-        cimSchemaFiles.resolve("v1_12/ack/Acknowledgement Document_v1.12_annotated.xsd")
+        cimSchemaFiles.resolve("v1_12/ack/Acknowledgement Document_v1.12_annotated.xsd"),
+        cimSchemaFiles.resolve("v1_12/esr/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12.xsd")
     )
 
     // Define the task inputs and outputs, so Gradle can track changes and only run the task when needed

--- a/cim/build.gradle.kts
+++ b/cim/build.gradle.kts
@@ -271,6 +271,7 @@ fun generateJavaClassesFromCimXsds(originalDirectory: File, entryPointFiles: Set
                 "-mark-generated", "-npa", "-encoding", "UTF-8",
                 "-extension", "-Xfluent-api", "-Xannotate"
             )
+            isIgnoreExitValue = true
         }
         val res = execution.result.get()
         val stdOut = execution.standardOutput.asText
@@ -278,10 +279,12 @@ fun generateJavaClassesFromCimXsds(originalDirectory: File, entryPointFiles: Set
             logger.log(LogLevel.LIFECYCLE, stdOut.get())
         }
         if (res.exitValue != 0) {
+            logger.error("Error while generating classes for ${tmpSrcFile.name}")
             val stdError = execution.standardError.asText
             if (stdError.isPresent) {
-                logger.log(LogLevel.WARN, stdError.get())
+                logger.error(stdError.get())
             }
+            throw GradleException("Could not generate classes for $srcFile")
         }
     }
 }

--- a/cim/src/main/java/energy/eddie/cim/serde/XmlMessageSerde.java
+++ b/cim/src/main/java/energy/eddie/cim/serde/XmlMessageSerde.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.cim.serde;
@@ -37,7 +37,9 @@ public class XmlMessageSerde implements MessageSerde {
             RTREnvelope.class,
             // CIM v1.04
             VHDEnvelope.class,
-            RTDEnvelope.class
+            RTDEnvelope.class,
+            // CIM v1.12
+            energy.eddie.cim.v1_12.esr.Envelope.class
     );
     private final Marshaller marshaller;
     private final Unmarshaller unmarshaller;

--- a/cim/src/main/java/energy/eddie/cim/serde/XmlMessageSerde.java
+++ b/cim/src/main/java/energy/eddie/cim/serde/XmlMessageSerde.java
@@ -9,6 +9,9 @@ import energy.eddie.cim.v0_82.vhd.ValidatedHistoricalDataEnvelope;
 import energy.eddie.cim.v0_91_08.RTREnvelope;
 import energy.eddie.cim.v1_04.rtd.RTDEnvelope;
 import energy.eddie.cim.v1_04.vhd.VHDEnvelope;
+import energy.eddie.cim.v1_12.ack.AcknowledgementEnvelope;
+import energy.eddie.cim.v1_12.esr.ESRDMDEnvelope;
+import energy.eddie.cim.v1_12.recmmoe.RECMMOEEnvelope;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
@@ -39,7 +42,10 @@ public class XmlMessageSerde implements MessageSerde {
             VHDEnvelope.class,
             RTDEnvelope.class,
             // CIM v1.12
-            energy.eddie.cim.v1_12.esr.Envelope.class
+            energy.eddie.cim.v1_12.rtd.RTDEnvelope.class,
+            AcknowledgementEnvelope.class,
+            ESRDMDEnvelope.class,
+            RECMMOEEnvelope.class
     );
     private final Marshaller marshaller;
     private final Unmarshaller unmarshaller;

--- a/cim/src/main/java/energy/eddie/cim/testing/XmlValidator.java
+++ b/cim/src/main/java/energy/eddie/cim/testing/XmlValidator.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.cim.testing;
@@ -61,6 +61,12 @@ public class XmlValidator {
     public static boolean validateV104ValidatedHistoricalDataMarketDocument(byte[] xml) {
         var xsd = XmlValidator.class.getResource(
                 "/cim/xsd/v1_04/vhd/ValidatedHistoricalData Document_v1.04_annotated.xsd");
+        return validateXMLSchema(xsd, new String(xml, StandardCharsets.UTF_8));
+    }
+
+    public static boolean validateV112EnergySharingReferenceDataMarketDocument(byte[] xml) {
+        var xsd = XmlValidator.class.getResource(
+                "/cim/xsd/v1_12/esr/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12.xsd");
         return validateXMLSchema(xsd, new String(xml, StandardCharsets.UTF_8));
     }
 }

--- a/cim/src/main/java/energy/eddie/cim/testing/XmlValidator.java
+++ b/cim/src/main/java/energy/eddie/cim/testing/XmlValidator.java
@@ -9,8 +9,10 @@ import javax.xml.validation.SchemaFactory;
 import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
 
 public class XmlValidator {
+    private static final Logger LOGGER = Logger.getLogger(XmlValidator.class.getName());
 
     private XmlValidator() {
         // Utility Class
@@ -27,6 +29,7 @@ public class XmlValidator {
             var validator = schema.newValidator();
             validator.validate(new StreamSource(new StringReader(xml)));
         } catch (Exception e) {
+            LOGGER.info(xml);
             e.printStackTrace();
             return false;
         }
@@ -67,6 +70,18 @@ public class XmlValidator {
     public static boolean validateV112EnergySharingReferenceDataMarketDocument(byte[] xml) {
         var xsd = XmlValidator.class.getResource(
                 "/cim/xsd/v1_12/esr/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12.xsd");
+        return validateXMLSchema(xsd, new String(xml, StandardCharsets.UTF_8));
+    }
+
+    public static boolean validateV112NearRealTimeDataMarketDocument(byte[] xml) {
+        var xsd = XmlValidator.class.getResource(
+                "/cim/xsd/v1_12/rtd/RealTimeData Document_v1.12_annotated.xsd");
+        return validateXMLSchema(xsd, new String(xml, StandardCharsets.UTF_8));
+    }
+
+    public static boolean validateV112AcknowledgementMarketDocument(byte[] xml) {
+        var xsd = XmlValidator.class.getResource(
+                "/cim/xsd/v1_12/ack/Acknowledgement Document_v1.12_annotated.xsd");
         return validateXMLSchema(xsd, new String(xml, StandardCharsets.UTF_8));
     }
 }

--- a/cim/src/main/schemas/cim/xsd/v1_12/esr/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12.xsd
+++ b/cim/src/main/schemas/cim/xsd/v1_12/esr/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12.xsd
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<xs:schema xmlns:ecl="urn:entsoe.eu:wgedi:codelists:1.12" xmlns:sawsdl="http://www.w3.org/ns/sawsdl"
+           xmlns:dl="https://eddie.energy/CIM/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12_new.xsd"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           targetNamespace="https://eddie.energy/CIM/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12_new.xsd">
+    <xs:import schemaLocation="../urn-entsoe-eu-wgedi-codelists.xsd" namespace="urn:entsoe.eu:wgedi:codelists:1.12"/>
+    <xs:element name="Envelope" type="dl:Envelope"/>
+    <xs:simpleType name="DirectionKind_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#DirectionKind_String">
+        <xs:restriction base="ecl:DirectionTypeList"/>
+    </xs:simpleType>
+    <xs:complexType name="AccountingPoint" sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="mRID" type="xs:string">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="meterReadingResolution" type="xs:duration"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.meterReadingResolution">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="gridAgreementType" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.gridAgreementType">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="settlementMethod" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.settlementMethod">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="administrativeStatus" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.administrativeStatus">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="flexibilityContract" type="xs:boolean"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.flexibilityContract">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="EnergySharingParticipationFactor" type="xs:integer"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingpointExt.EnergySharingParticipationFactor">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="EnergySharingEnergyDirection" type="dl:DirectionKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingpointExt.EnergySharingEnergyDirection">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="MeterReadings" type="dl:MeterReading"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.MeterReadings">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Asset" sawsdl:modelReference="http://iec.ch/TC57/CIM100#Asset">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="type" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Asset.type">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="operatorId" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Asset.operatorId">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="meterId" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Asset.meterId">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="EnergyCommunity" sawsdl:modelReference="http://iec.ch/TC57/CIM100#EnergyCommunity">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="DateFrom" type="xs:dateTime"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#EnergyCommunity.DateFrom">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="mRID" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
+            </xs:element>
+            <xs:element minOccurs="1" maxOccurs="unbounded" name="AccountingPoint" type="dl:AccountingPoint"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#EnergyCommunity.AccountingPoint">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Envelope" sawsdl:modelReference="http://iec.ch/TC57/CIM100#Envelope">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="MessageDocumentHeader" type="dl:MessageDocumentHeader"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Envelope.MessageDocumentHeader">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="MarketDocument" type="dl:MarketDocument"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Envelope.MarketDocument">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="MessageKind_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#MessageKind_String">
+        <xs:restriction base="ecl:MessageTypeList"/>
+    </xs:simpleType>
+    <xs:simpleType name="ID_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ID_String">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="60"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ESMPVersion_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESMPVersion_String">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[1-9]([0-9]){0,2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ESMP_DateTime" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESMP_DateTime">
+        <xs:restriction base="xs:dateTime">
+            <xs:pattern
+                    value="((([0-9]{4})[\-](0[13578]|1[02])[\-](0[1-9]|[12][0-9]|3[01])|([0-9]{4})[\-]((0[469])|(11))[\-](0[1-9]|[12][0-9]|30))T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)|(([13579][26][02468][048]|[13579][01345789](0)[48]|[13579][01345789][2468][048]|[02468][048][02468][048]|[02468][1235679](0)[48]|[02468][1235679][2468][048]|[0-9][0-9][13579][26])[\-](02)[\-](0[1-9]|1[0-9]|2[0-9])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)|(([13579][26][02468][1235679]|[13579][01345789](0)[01235679]|[13579][01345789][2468][1235679]|[02468][048][02468][1235679]|[02468][1235679](0)[01235679]|[02468][1235679][2468][1235679]|[0-9][0-9][13579][01345789])[\-](02)[\-](0[1-9]|1[0-9]|2[0-8])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PayloadId_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#PayloadId_String">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="150"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="PartyID_String-base" sawsdl:modelReference="http://iec.ch/TC57/CIM100#PartyID_String">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="16"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="PartyID_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#PartyID_String">
+        <xs:simpleContent>
+            <xs:extension base="dl:PartyID_String-base">
+                <xs:attribute name="codingScheme" type="ecl:CodingSchemeTypeList" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="MarketRoleKind_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketRoleKind_String">
+        <xs:restriction base="ecl:RoleTypeList"/>
+    </xs:simpleType>
+    <xs:simpleType name="ProcessKind_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ProcessKind_String">
+        <xs:restriction base="ecl:ProcessTypeList"/>
+    </xs:simpleType>
+    <xs:simpleType name="ClassificationKind_String"
+                   sawsdl:modelReference="http://iec.ch/TC57/CIM100#ClassificationKind_String">
+        <xs:restriction base="ecl:ClassificationTypeList"/>
+    </xs:simpleType>
+    <xs:simpleType name="Status_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#Status_String">
+        <xs:restriction base="ecl:StatusTypeList"/>
+    </xs:simpleType>
+    <xs:complexType name="Action_Status" sawsdl:modelReference="http://iec.ch/TC57/CIM100#Action_Status">
+        <xs:sequence>
+            <xs:element minOccurs="1" maxOccurs="1" name="value" type="dl:Status_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Status.value">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="MarketDocument" sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketDocument">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="mRID" type="dl:ID_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="description" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.description">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="revisionNumber" type="dl:ESMPVersion_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.revisionNumber">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="lastModifiedDateTime" type="xs:dateTime"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.lastModifiedDateTime">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="type" type="dl:MessageKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.type">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="createdDateTime" type="dl:ESMP_DateTime"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.createdDateTime">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="docStatus" type="dl:Action_Status"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.docStatus">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="title" type="dl:PayloadId_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.title">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="status" type="dl:Action_Status"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.status">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="comment" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.comment">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="sender_MarketParticipant.mRID" type="dl:PartyID_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="sender_MarketParticipant.name" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.name">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="sender_MarketParticipant.marketRole.type"
+                        type="dl:MarketRoleKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketRole.type">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="receiver_MarketParticipant.mRID" type="dl:PartyID_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="receiver_MarketParticipant.name" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.name">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="receiver_MarketParticipant.marketRole.type"
+                        type="dl:MarketRoleKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketRole.type">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="process.processType" type="dl:ProcessKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Process.processType">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="process.classificationType"
+                        type="dl:ClassificationKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Process.classificationType">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="EnergyCommunity" type="dl:EnergyCommunity"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketDocument.EnergyCommunity">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="MessageDocumentHeader"
+                    sawsdl:modelReference="http://iec.ch/TC57/CIM100#MessageDocumentHeader">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="creationDateTime" type="dl:ESMP_DateTime"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MessageDocumentHeader.creationDateTime">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="MetaInformation" type="dl:MetaInformation"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MessageDocumentHeader.MetaInformation">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="MetaInformation" sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="connectionId" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.connectionId">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="requestPermissionId" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.requestPermissionId">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="dataNeedId" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.dataNeedId">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="documentType" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.documentType">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="finalCustomerId" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.finalCustomerId">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="dataSourceId" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.dataSourceId">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="defaultValues" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.defaultValues">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="regionConnector" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.regionConnector">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="regionCountry" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.regionCountry">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="Asset" type="dl:Asset"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MetaInformation.Asset">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ResourceID_String-base" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ResourceID_String">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="60"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="ResourceID_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ResourceID_String">
+        <xs:simpleContent>
+            <xs:extension base="dl:ResourceID_String-base">
+                <xs:attribute name="codingScheme" type="ecl:CodingSchemeTypeList" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="MeterReading" sawsdl:modelReference="http://iec.ch/TC57/CIM100#MeterReading">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="mRID" type="dl:ResourceID_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="name" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.name">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/cim/src/main/schemas/cim/xsd/v1_12/esr/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12.xsd
+++ b/cim/src/main/schemas/cim/xsd/v1_12/esr/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12.xsd
@@ -3,18 +3,39 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <xs:schema xmlns:ecl="urn:entsoe.eu:wgedi:codelists:1.12" xmlns:sawsdl="http://www.w3.org/ns/sawsdl"
-           xmlns:dl="https://eddie.energy/CIM/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12_new.xsd"
+           xmlns:dl="https://eddie.energy/CIM/CEEDS_EnergySharingReferenceDataMarketDocument_v1.12_annotated.xsd"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
            elementFormDefault="qualified"
-           targetNamespace="https://eddie.energy/CIM/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12_new.xsd">
+           targetNamespace="https://eddie.energy/CIM/CEEDS_EnergySharingReferenceDataMarketDocument_v1.12_annotated.xsd">
     <xs:import schemaLocation="../urn-entsoe-eu-wgedi-codelists.xsd" namespace="urn:entsoe.eu:wgedi:codelists:1.12"/>
-    <xs:element name="Envelope" type="dl:Envelope"/>
-    <xs:simpleType name="DirectionKind_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#DirectionKind_String">
-        <xs:restriction base="ecl:DirectionTypeList"/>
+    <xs:element name="ESRDMD_Envelope" type="dl:ESRDMD_Envelope"/>
+    <xs:simpleType name="MeasurementPointID_String-base"
+                   sawsdl:modelReference="http://iec.ch/TC57/CIM100#MeasurementPointID_String">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="60"/>
+        </xs:restriction>
     </xs:simpleType>
+    <xs:complexType name="MeasurementPointID_String"
+                    sawsdl:modelReference="http://iec.ch/TC57/CIM100#MeasurementPointID_String">
+        <xs:simpleContent>
+            <xs:extension base="dl:MeasurementPointID_String-base">
+                <xs:attribute name="codingScheme" type="ecl:CodingSchemeTypeList" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
     <xs:complexType name="AccountingPoint" sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint">
         <xs:sequence>
-            <xs:element minOccurs="0" maxOccurs="1" name="mRID" type="xs:string">
+            <xs:element minOccurs="0" maxOccurs="1" name="energySharingParticipationFactor" type="xs:integer"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingpointExt.energySharingParticipationFactor">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="mRID" type="dl:MeasurementPointID_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="settlementMethod" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.settlementMethod">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="energySharingEnergyDirection" type="xs:string"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingpointExt.energySharingEnergyDirection">
             </xs:element>
             <xs:element minOccurs="0" maxOccurs="1" name="meterReadingResolution" type="xs:duration"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.meterReadingResolution">
@@ -22,20 +43,11 @@
             <xs:element minOccurs="0" maxOccurs="1" name="gridAgreementType" type="xs:string"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.gridAgreementType">
             </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="settlementMethod" type="xs:string"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.settlementMethod">
-            </xs:element>
             <xs:element minOccurs="0" maxOccurs="1" name="administrativeStatus" type="xs:string"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.administrativeStatus">
             </xs:element>
             <xs:element minOccurs="0" maxOccurs="1" name="flexibilityContract" type="xs:boolean"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.flexibilityContract">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="EnergySharingParticipationFactor" type="xs:integer"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingpointExt.EnergySharingParticipationFactor">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="EnergySharingEnergyDirection" type="dl:DirectionKind_String"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingpointExt.EnergySharingEnergyDirection">
             </xs:element>
             <xs:element minOccurs="0" maxOccurs="unbounded" name="MeterReadings" type="dl:MeterReading"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#AccountingPoint.MeterReadings">
@@ -55,26 +67,31 @@
             </xs:element>
         </xs:sequence>
     </xs:complexType>
+    <xs:simpleType name="ESMP_DateTime" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESMP_DateTime">
+        <xs:restriction base="xs:dateTime">
+            <xs:pattern
+                    value="((([0-9]{4})[\-](0[13578]|1[02])[\-](0[1-9]|[12][0-9]|3[01])|([0-9]{4})[\-]((0[469])|(11))[\-](0[1-9]|[12][0-9]|30))T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)|(([13579][26][02468][048]|[13579][01345789](0)[48]|[13579][01345789][2468][048]|[02468][048][02468][048]|[02468][1235679](0)[48]|[02468][1235679][2468][048]|[0-9][0-9][13579][26])[\-](02)[\-](0[1-9]|1[0-9]|2[0-9])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)|(([13579][26][02468][1235679]|[13579][01345789](0)[01235679]|[13579][01345789][2468][1235679]|[02468][048][02468][1235679]|[02468][1235679](0)[01235679]|[02468][1235679][2468][1235679]|[0-9][0-9][13579][01345789])[\-](02)[\-](0[1-9]|1[0-9]|2[0-8])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)"/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:complexType name="EnergyCommunity" sawsdl:modelReference="http://iec.ch/TC57/CIM100#EnergyCommunity">
         <xs:sequence>
-            <xs:element minOccurs="0" maxOccurs="1" name="DateFrom" type="xs:dateTime"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#EnergyCommunity.DateFrom">
+            <xs:element minOccurs="0" maxOccurs="1" name="DateFrom" type="dl:ESMP_DateTime">
             </xs:element>
             <xs:element minOccurs="0" maxOccurs="1" name="mRID" type="xs:string"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
             </xs:element>
-            <xs:element minOccurs="1" maxOccurs="unbounded" name="AccountingPoint" type="dl:AccountingPoint"
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="AccountingPoint" type="dl:AccountingPoint"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#EnergyCommunity.AccountingPoint">
             </xs:element>
         </xs:sequence>
     </xs:complexType>
-    <xs:complexType name="Envelope" sawsdl:modelReference="http://iec.ch/TC57/CIM100#Envelope">
+    <xs:complexType name="ESRDMD_Envelope" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESRDMD_Envelope">
         <xs:sequence>
-            <xs:element minOccurs="0" maxOccurs="1" name="MessageDocumentHeader" type="dl:MessageDocumentHeader"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Envelope.MessageDocumentHeader">
+            <xs:element minOccurs="0" maxOccurs="1" name="MarketDocument" type="dl:ESRDMD_MarketDocument"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESRDMD_Envelope.MarketDocument">
             </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="MarketDocument" type="dl:MarketDocument"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Envelope.MarketDocument">
+            <xs:element minOccurs="0" maxOccurs="1" name="MessageDocumentHeader" type="dl:MessageDocumentHeader"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESRDMD_Envelope.MessageDocumentHeader">
             </xs:element>
         </xs:sequence>
     </xs:complexType>
@@ -89,17 +106,6 @@
     <xs:simpleType name="ESMPVersion_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESMPVersion_String">
         <xs:restriction base="xs:string">
             <xs:pattern value="[1-9]([0-9]){0,2}"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="ESMP_DateTime" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESMP_DateTime">
-        <xs:restriction base="xs:dateTime">
-            <xs:pattern
-                    value="((([0-9]{4})[\-](0[13578]|1[02])[\-](0[1-9]|[12][0-9]|3[01])|([0-9]{4})[\-]((0[469])|(11))[\-](0[1-9]|[12][0-9]|30))T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)|(([13579][26][02468][048]|[13579][01345789](0)[48]|[13579][01345789][2468][048]|[02468][048][02468][048]|[02468][1235679](0)[48]|[02468][1235679][2468][048]|[0-9][0-9][13579][26])[\-](02)[\-](0[1-9]|1[0-9]|2[0-9])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)|(([13579][26][02468][1235679]|[13579][01345789](0)[01235679]|[13579][01345789][2468][1235679]|[02468][048][02468][1235679]|[02468][1235679](0)[01235679]|[02468][1235679][2468][1235679]|[0-9][0-9][13579][01345789])[\-](02)[\-](0[1-9]|1[0-9]|2[0-8])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9])Z)"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="PayloadId_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#PayloadId_String">
-        <xs:restriction base="xs:string">
-            <xs:maxLength value="150"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="PartyID_String-base" sawsdl:modelReference="http://iec.ch/TC57/CIM100#PartyID_String">
@@ -117,25 +123,12 @@
     <xs:simpleType name="MarketRoleKind_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketRoleKind_String">
         <xs:restriction base="ecl:RoleTypeList"/>
     </xs:simpleType>
-    <xs:simpleType name="ProcessKind_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ProcessKind_String">
-        <xs:restriction base="ecl:ProcessTypeList"/>
-    </xs:simpleType>
-    <xs:simpleType name="ClassificationKind_String"
-                   sawsdl:modelReference="http://iec.ch/TC57/CIM100#ClassificationKind_String">
-        <xs:restriction base="ecl:ClassificationTypeList"/>
-    </xs:simpleType>
-    <xs:simpleType name="Status_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#Status_String">
-        <xs:restriction base="ecl:StatusTypeList"/>
-    </xs:simpleType>
-    <xs:complexType name="Action_Status" sawsdl:modelReference="http://iec.ch/TC57/CIM100#Action_Status">
+    <xs:complexType name="ESRDMD_MarketDocument"
+                    sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESRDMD_MarketDocument">
         <xs:sequence>
-            <xs:element minOccurs="1" maxOccurs="1" name="value" type="dl:Status_String"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Status.value">
+            <xs:element minOccurs="0" maxOccurs="1" name="type" type="dl:MessageKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.type">
             </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="MarketDocument" sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketDocument">
-        <xs:sequence>
             <xs:element minOccurs="0" maxOccurs="1" name="mRID" type="dl:ID_String"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
             </xs:element>
@@ -145,26 +138,8 @@
             <xs:element minOccurs="0" maxOccurs="1" name="revisionNumber" type="dl:ESMPVersion_String"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.revisionNumber">
             </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="lastModifiedDateTime" type="xs:dateTime"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.lastModifiedDateTime">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="type" type="dl:MessageKind_String"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.type">
-            </xs:element>
             <xs:element minOccurs="0" maxOccurs="1" name="createdDateTime" type="dl:ESMP_DateTime"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.createdDateTime">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="docStatus" type="dl:Action_Status"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.docStatus">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="title" type="dl:PayloadId_String"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.title">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="status" type="dl:Action_Status"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.status">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="comment" type="xs:string"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Document.comment">
             </xs:element>
             <xs:element minOccurs="0" maxOccurs="1" name="sender_MarketParticipant.mRID" type="dl:PartyID_String"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.mRID">
@@ -186,15 +161,11 @@
                         type="dl:MarketRoleKind_String"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketRole.type">
             </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="process.processType" type="dl:ProcessKind_String"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Process.processType">
-            </xs:element>
-            <xs:element minOccurs="0" maxOccurs="1" name="process.classificationType"
-                        type="dl:ClassificationKind_String"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Process.classificationType">
-            </xs:element>
             <xs:element minOccurs="0" maxOccurs="unbounded" name="EnergyCommunity" type="dl:EnergyCommunity"
-                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#MarketDocument.EnergyCommunity">
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESRDMD_MarketDocument.EnergyCommunity">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="Process" type="dl:Process"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#ESRDMD_MarketDocument.Process">
             </xs:element>
         </xs:sequence>
     </xs:complexType>
@@ -262,6 +233,23 @@
             </xs:element>
             <xs:element minOccurs="0" maxOccurs="1" name="name" type="xs:string"
                         sawsdl:modelReference="http://iec.ch/TC57/CIM100#IdentifiedObject.name">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ProcessKind_String" sawsdl:modelReference="http://iec.ch/TC57/CIM100#ProcessKind_String">
+        <xs:restriction base="ecl:ProcessTypeList"/>
+    </xs:simpleType>
+    <xs:simpleType name="ClassificationKind_String"
+                   sawsdl:modelReference="http://iec.ch/TC57/CIM100#ClassificationKind_String">
+        <xs:restriction base="ecl:ClassificationTypeList"/>
+    </xs:simpleType>
+    <xs:complexType name="Process" sawsdl:modelReference="http://iec.ch/TC57/CIM100#Process">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="processType" type="dl:ProcessKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Process.processType">
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="1" name="classificationType" type="dl:ClassificationKind_String"
+                        sawsdl:modelReference="http://iec.ch/TC57/CIM100#Process.classificationType">
             </xs:element>
         </xs:sequence>
     </xs:complexType>

--- a/cim/src/main/schemas/cim/xsd/v1_12/rtd/RealTimeData Document_v1.12_annotated.xsd
+++ b/cim/src/main/schemas/cim/xsd/v1_12/rtd/RealTimeData Document_v1.12_annotated.xsd
@@ -2,11 +2,11 @@
 <!-- SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-<xs:schema xmlns:dl="https//eddie.energy/CIM/RTD_v1.12"
+<xs:schema xmlns:dl="https://eddie.energy/CIM/RTD_v1.12"
            xmlns:ecl="urn:entsoe.eu:wgedi:codelists:1.12"
            xmlns:sawsdl="http://www.w3.org/ns/sawsdl" xmlns:cimp="http://www.iec.ch/cimprofile"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="qualified"
-           targetNamespace="https//eddie.energy/CIM/RTD_v1.12">
+           targetNamespace="https://eddie.energy/CIM/RTD_v1.12">
     <xs:import schemaLocation="../urn-entsoe-eu-wgedi-codelists.xsd" namespace="urn:entsoe.eu:wgedi:codelists:1.12"/>
     <xs:element name="RTD_Envelope" type="dl:RTD_Envelope"/>
     <xs:simpleType name="MeasurementPointID_String-base"

--- a/cim/src/main/schemas/cim/xsd/v1_12/urn-entsoe-eu-local-extension-types.xsd
+++ b/cim/src/main/schemas/cim/xsd/v1_12/urn-entsoe-eu-local-extension-types.xsd
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<!-- SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
             elementFormDefault="qualified" targetNamespace="urn:entsoe.eu:wgedi:codelists:1.12">
     <xsd:annotation>
@@ -95,6 +98,17 @@
                         <CodeDescription>
                             <Title>Canada</Title>
                             <Definition>Canada</Definition>
+                        </CodeDescription>
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <!-- TODO: Should be changed with GH-638 -->
+            <xsd:enumeration value="AIIDA">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        <CodeDescription>
+                            <Title>AIIDA</Title>
+                            <Definition>AIIDA</Definition>
                         </CodeDescription>
                     </xsd:documentation>
                 </xsd:annotation>

--- a/cim/src/test/java/energy/eddie/cim/serde/XmlMessageSerdeTest.java
+++ b/cim/src/test/java/energy/eddie/cim/serde/XmlMessageSerdeTest.java
@@ -13,19 +13,24 @@ import energy.eddie.cim.v0_82.pmd.ESMPDateTimeIntervalComplexType;
 import energy.eddie.cim.v0_82.pmd.ProcessTypeList;
 import energy.eddie.cim.v0_82.pmd.TimeSeriesComplexType;
 import energy.eddie.cim.v0_82.vhd.*;
-import energy.eddie.cim.v0_82.vhd.AccumulationKind;
-import energy.eddie.cim.v0_82.vhd.AggregateKind;
 import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
 import energy.eddie.cim.v0_82.vhd.MeasurementPointIDStringComplexType;
 import energy.eddie.cim.v0_91_08.RTREnvelope;
 import energy.eddie.cim.v1_04.*;
-import energy.eddie.cim.v1_04.vhd.*;
-import energy.eddie.cim.v1_04.vhd.PartyIDString;
-import energy.eddie.cim.v1_04.vhd.ResourceIDString;
+import energy.eddie.cim.v1_04.vhd.ESMPDateTimeInterval;
+import energy.eddie.cim.v1_04.vhd.TimeSeries;
+import energy.eddie.cim.v1_04.vhd.VHDEnvelope;
+import energy.eddie.cim.v1_04.vhd.VHDMarketDocument;
+import energy.eddie.cim.v1_12.ack.AcknowledgementMarketDocument;
+import energy.eddie.cim.v1_12.ack.Reason;
+import energy.eddie.cim.v1_12.ack.TimePeriod;
 import energy.eddie.cim.v1_12.esr.*;
+import energy.eddie.cim.v1_12.rtd.Quantity;
+import energy.eddie.cim.v1_12.rtd.RTDMarketDocument;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.datatype.DatatypeFactory;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
@@ -541,13 +546,13 @@ class XmlMessageSerdeTest {
                                 .withType(StandardMessageTypeList.MEASUREMENT_VALUE_DOCUMENT.value())
                                 .withRevisionNumber("1")
                                 .withSenderMarketParticipantMRID(
-                                        new PartyIDString()
+                                        new energy.eddie.cim.v1_04.vhd.PartyIDString()
                                                 .withCodingScheme(StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
                                                 .withValue("EDA")
                                 )
                                 .withReceiverMarketParticipantMarketRoleType(StandardRoleTypeList.CONSUMER.value())
                                 .withReceiverMarketParticipantMRID(
-                                        new PartyIDString()
+                                        new energy.eddie.cim.v1_04.vhd.PartyIDString()
                                                 .withCodingScheme(StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
                                                 .withValue("eligible-party")
                                 )
@@ -564,17 +569,17 @@ class XmlMessageSerdeTest {
                                                 .withFlowDirectionDirection(StandardDirectionTypeList.DOWN.value())
                                                 .withProduct(StandardEnergyProductTypeList.ACTIVE_ENERGY.value())
                                                 .withMarketEvaluationPointMRID(
-                                                        new MeasurementPointIDString()
+                                                        new energy.eddie.cim.v1_04.vhd.MeasurementPointIDString()
                                                                 .withCodingScheme(StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
                                                                 .withValue("ID")
                                                 )
                                                 .withMarketEvaluationPointMeterReadingsMRID(
-                                                        new ResourceIDString()
+                                                        new energy.eddie.cim.v1_04.vhd.ResourceIDString()
                                                                 .withCodingScheme(StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
                                                                 .withValue("ID")
                                                 )
                                                 .withMarketEvaluationPointMeterReadingsReadingsMRID(
-                                                        new ResourceIDString()
+                                                        new energy.eddie.cim.v1_04.vhd.ResourceIDString()
                                                                 .withCodingScheme(StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
                                                                 .withValue("ID")
                                                 )
@@ -592,7 +597,7 @@ class XmlMessageSerdeTest {
                                                 .withEnergyQualityMeasurementUnitName(StandardUnitOfMeasureTypeList.KILOWATT_HOUR.value())
                                                 .withDateAndOrTimeDateTime(dateTime)
                                                 .withRegisteredResourceMRID(
-                                                        new ResourceIDString()
+                                                        new energy.eddie.cim.v1_04.vhd.ResourceIDString()
                                                                 .withCodingScheme(StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
                                                                 .withValue("MRID")
                                                 )
@@ -624,10 +629,10 @@ class XmlMessageSerdeTest {
     void testSerialize_producesCIM_v1_12_CompliantEnergySharingReferenceDataMarketDocument() throws SerdeInitializationException, SerializationException {
         // Given
         var dateTime = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        var document = new Envelope()
+        var document = new ESRDMDEnvelope()
                 .withMessageDocumentHeader(new MessageDocumentHeader())
                 .withMarketDocument(
-                        new MarketDocument()
+                        new ESRDMDMarketDocument()
                                 .withMRID("MRID")
                                 .withCreatedDateTime(dateTime)
                                 .withSenderMarketParticipantMarketRoleType(StandardRoleTypeList.DISTRIBUTION_SYSTEM_OPERATOR_DSO.value())
@@ -647,7 +652,9 @@ class XmlMessageSerdeTest {
                                                 .withMRID("MRID")
                                                 .withAccountingPoints(
                                                         new AccountingPoint()
-                                                                .withMRID("MRID")
+                                                                .withMRID(new MeasurementPointIDString()
+                                                                                  .withCodingScheme(energy.eddie.cim.v1_12.StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
+                                                                                  .withValue("MRID"))
                                                                 .withMeterReadingResolution(DatatypeFactory.newDefaultInstance()
                                                                                                            .newDuration(
                                                                                                                    true,
@@ -668,6 +675,149 @@ class XmlMessageSerdeTest {
         // When
         var res = serde.serialize(document);
         var valid = XmlValidator.validateV112EnergySharingReferenceDataMarketDocument(res);
+
+        // Then
+        assertTrue(valid);
+    }
+
+
+    @Test
+    void testSerialize_producesCIMCompliantV1_12RTDEnvelope() throws SerdeInitializationException, SerializationException {
+        // Given
+        var dateTime = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var document = new energy.eddie.cim.v1_12.rtd.RTDEnvelope()
+                .withMessageDocumentHeader(
+                        new energy.eddie.cim.v1_12.rtd.MessageDocumentHeader()
+                                .withCreationDateTime(dateTime)
+                                .withMetaInformation(
+                                        new energy.eddie.cim.v1_12.rtd.MetaInformation()
+                                                .withConnectionId("1")
+                                                .withRequestPermissionId("pid")
+                                                .withDataNeedId("dnid")
+                                                .withDocumentType("near-real-time-market-document")
+                                                .withFinalCustomerId("fcid")
+                                                .withDataSourceId("dsid")
+                                                .withRegionConnector("aiida")
+                                                .withRegionCountry("AT")
+                                                .withAsset(
+                                                        new energy.eddie.cim.v1_12.rtd.Asset()
+                                                                .withType("CONNECTION-AGREEMENT-POINT")
+                                                )
+                                )
+                )
+                .withMarketDocument(
+                        new RTDMarketDocument()
+                                .withMRID("MRID")
+                                .withCreatedDateTime(dateTime)
+                                .withTimeSeries(
+                                        new energy.eddie.cim.v1_12.rtd.TimeSeries()
+                                                .withVersion("1")
+                                                .withDateAndOrTimeDateTime(dateTime)
+                                                .withQuantities(
+                                                        new Quantity()
+                                                                .withQuantity(BigDecimal.valueOf(0.117))
+                                                                .withType(energy.eddie.cim.v1_12.rtd.QuantityTypeKind.INSTANTANEOUS_ACTIVE_POWER_CONSUMPTION_KW)
+                                                                .withQuality(energy.eddie.cim.v1_12.StandardQualityTypeList.AS_PROVIDED.value())
+                                                )
+                                                .withRegisteredResourceMRID(
+                                                        new energy.eddie.cim.v1_12.rtd.ResourceIDString()
+                                                                .withCodingScheme(energy.eddie.cim.v1_12.StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
+                                                                .withValue("MRID")
+                                                )
+                                )
+                );
+        var serde = new XmlMessageSerde();
+
+        // When
+        var res = serde.serialize(document);
+        var valid = XmlValidator.validateV112NearRealTimeDataMarketDocument(res);
+
+        // Then
+        assertTrue(valid);
+    }
+
+
+    @Test
+    void testSerialize_producesCIMCompliantV1_12AcknowledgementEnvelope() throws SerdeInitializationException, SerializationException {
+        // Given
+        var dateTime = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var document = new energy.eddie.cim.v1_12.ack.AcknowledgementEnvelope()
+                .withMessageDocumentHeader(
+                        new energy.eddie.cim.v1_12.ack.MessageDocumentHeader()
+                                .withCreationDateTime(dateTime)
+                                .withMetaInformation(
+                                        new energy.eddie.cim.v1_12.ack.MetaInformation()
+                                                .withConnectionId("1")
+                                                .withRequestPermissionId("pid")
+                                                .withDataNeedId("dnid")
+                                                .withDocumentType("acknowledgement-market-document")
+                                                .withFinalCustomerId("fcid")
+                                                .withDataSourceId("dsid")
+                                                .withRegionConnector("aiida")
+                                                .withRegionCountry("AT")
+                                                .withAsset(
+                                                        new energy.eddie.cim.v1_12.ack.Asset()
+                                                                .withType("CONNECTION-AGREEMENT-POINT")
+                                                                .withOperatorId("AT003000")
+                                                                .withMeterId("003114735")
+                                                )
+                                )
+                )
+                .withMarketDocument(
+                        new AcknowledgementMarketDocument()
+                                .withMRID("MRID")
+                                .withCreatedDateTime(dateTime)
+                                .withSenderMarketParticipantMRID(
+                                        new energy.eddie.cim.v1_12.ack.PartyIDString()
+                                                .withCodingScheme(energy.eddie.cim.v1_12.StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
+                                                .withValue("AT00300"))
+                                .withSenderMarketParticipantMarketRoleType(energy.eddie.cim.v1_12.StandardRoleTypeList.FLEXIBILITY_SERVICE_PROVIDER.value())
+                                .withSenderMarketParticipantMarketRoleType(energy.eddie.cim.v1_12.StandardRoleTypeList.SYSTEM_OPERATOR.value())
+                                .withReceiverMarketParticipantMRID(
+                                        new energy.eddie.cim.v1_12.ack.PartyIDString()
+                                                .withCodingScheme(energy.eddie.cim.v1_12.StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
+                                                .withValue("id")
+                                )
+                                .withReceiverMarketParticipantMarketRoleType(StandardRoleTypeList.CONSUMER.value())
+                                .withReceivedMarketDocumentMRID("prev-id")
+                                .withReceivedMarketDocumentRevisionNumber("1")
+                                .withReceivedMarketDocumentProcessProcessType(energy.eddie.cim.v1_12.StandardProcessTypeList.AGREED_CAPACITY_ALLOCATION.value())
+                                .withReceivedMarketDocumentCreatedDateTime(dateTime)
+                                .withReasons(
+                                        new Reason()
+                                                .withCode(energy.eddie.cim.v1_12.StandardReasonCodeTypeList.MESSAGE_FULLY_ACCEPTED.value())
+                                                .withText("asdf")
+                                )
+                                .withRejectedTimeSeries(
+                                        new energy.eddie.cim.v1_12.ack.TimeSeries()
+                                                .withMRID("MRID")
+                                                .withVersion("1")
+                                                .withInErrorPeriods(
+                                                        new TimePeriod()
+                                                                .withTimeInterval(
+                                                                        new energy.eddie.cim.v1_12.ack.ESMPDateTimeInterval()
+                                                                                .withStart(dateTime.toString())
+                                                                                .withEnd(dateTime.toString())
+                                                                )
+                                                                .withReasons(
+                                                                        new Reason()
+                                                                                .withCode(energy.eddie.cim.v1_12.StandardReasonCodeTypeList.MESSAGE_FULLY_ACCEPTED.value())
+                                                                                .withText("Invalid time series data")
+                                                                )
+                                                )
+                                                .withReasons(
+                                                        new Reason()
+                                                                .withCode(energy.eddie.cim.v1_12.StandardReasonCodeTypeList.MESSAGE_FULLY_ACCEPTED.value())
+                                                                .withText("Invalid time series data")
+                                                )
+                                )
+                );
+        var serde = new XmlMessageSerde();
+
+        // When
+        var res = serde.serialize(document);
+        System.out.println(new String(res, StandardCharsets.UTF_8));
+        var valid = XmlValidator.validateV112AcknowledgementMarketDocument(res);
 
         // Then
         assertTrue(valid);

--- a/cim/src/test/java/energy/eddie/cim/serde/XmlMessageSerdeTest.java
+++ b/cim/src/test/java/energy/eddie/cim/serde/XmlMessageSerdeTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.cim.serde;
@@ -20,8 +20,12 @@ import energy.eddie.cim.v0_82.vhd.MeasurementPointIDStringComplexType;
 import energy.eddie.cim.v0_91_08.RTREnvelope;
 import energy.eddie.cim.v1_04.*;
 import energy.eddie.cim.v1_04.vhd.*;
+import energy.eddie.cim.v1_04.vhd.PartyIDString;
+import energy.eddie.cim.v1_04.vhd.ResourceIDString;
+import energy.eddie.cim.v1_12.esr.*;
 import org.junit.jupiter.api.Test;
 
+import javax.xml.datatype.DatatypeFactory;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
@@ -611,6 +615,59 @@ class XmlMessageSerdeTest {
         // When
         var res = serde.serialize(document);
         var valid = XmlValidator.validateV104ValidatedHistoricalDataMarketDocument(res);
+
+        // Then
+        assertTrue(valid);
+    }
+
+    @Test
+    void testSerialize_producesCIM_v1_12_CompliantEnergySharingReferenceDataMarketDocument() throws SerdeInitializationException, SerializationException {
+        // Given
+        var dateTime = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var document = new Envelope()
+                .withMessageDocumentHeader(new MessageDocumentHeader())
+                .withMarketDocument(
+                        new MarketDocument()
+                                .withMRID("MRID")
+                                .withCreatedDateTime(dateTime)
+                                .withSenderMarketParticipantMarketRoleType(StandardRoleTypeList.DISTRIBUTION_SYSTEM_OPERATOR_DSO.value())
+                                .withDescription("energy-sharing-reference-data-market-document")
+                                .withType(StandardMessageTypeList.NOTIFICATION_DATA_MARKET_DOCUMENT.value())
+                                .withRevisionNumber("1")
+                                .withReceiverMarketParticipantMarketRoleType(StandardRoleTypeList.ENERGY_SERVICE_COMPANY_ESCO.value())
+                                .withSenderMarketParticipantMRID(new energy.eddie.cim.v1_12.esr.PartyIDString()
+                                                                         .withCodingScheme(energy.eddie.cim.v1_12.StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
+                                                                         .withValue("AT00000000"))
+                                .withReceiverMarketParticipantMRID(new energy.eddie.cim.v1_12.esr.PartyIDString()
+                                                                           .withCodingScheme(energy.eddie.cim.v1_12.StandardCodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME.value())
+                                                                           .withValue("EP00000000"))
+                                .withEnergyCommunities(
+                                        new EnergyCommunity()
+                                                .withDateFrom(dateTime)
+                                                .withMRID("MRID")
+                                                .withAccountingPoints(
+                                                        new AccountingPoint()
+                                                                .withMRID("MRID")
+                                                                .withMeterReadingResolution(DatatypeFactory.newDefaultInstance()
+                                                                                                           .newDuration(
+                                                                                                                   true,
+                                                                                                                   0,
+                                                                                                                   0,
+                                                                                                                   0,
+                                                                                                                   0,
+                                                                                                                   15,
+                                                                                                                   0))
+                                                                .withGridAgreementType("agreement")
+                                                                .withEnergySharingParticipationFactor(BigInteger.TEN)
+                                                                .withEnergySharingEnergyDirection(energy.eddie.cim.v1_12.StandardDirectionTypeList.DOWN.value())
+                                                )
+                                )
+                );
+        var serde = new XmlMessageSerde();
+
+        // When
+        var res = serde.serialize(document);
+        var valid = XmlValidator.validateV112EnergySharingReferenceDataMarketDocument(res);
 
         // Then
         assertTrue(valid);

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -214,6 +214,10 @@ export default withMermaid(
                       link: "/2-integrating/messages/cim/acknowledgement-market-documents.md",
                     },
                     {
+                      text: "Energy Sharing Reference Data Market Documents",
+                      link: "/2-integrating/messages/cim/energy-sharing-reference-data-market-documents.md",
+                    },
+                    {
                       text: "Existing Mappings",
                       link: "/2-integrating/messages/cim/mappings.md",
                     },

--- a/docs/2-integrating/messages/cim/acknowledgement-market-documents.md
+++ b/docs/2-integrating/messages/cim/acknowledgement-market-documents.md
@@ -11,7 +11,6 @@ The XSD files for version v1.12 of this document can be found here: https://gith
 The following is an example of a acknowledgement envelope for version v1.12:
 
 ```xml
-
 <Acknowledgement_Envelope xmlns="https://eddie.energy/CIM/ACK_v1.12">
     <MessageDocumentHeader>
         <creationDateTime>2026-02-24T11:58:05Z</creationDateTime>
@@ -20,7 +19,7 @@ The following is an example of a acknowledgement envelope for version v1.12:
             <requestPermissionId>aae63ff1-4062-4599-8f4c-686df39138e7</requestPermissionId>
             <dataNeedId>5dc71d7e-e8cd-4403-a3a8-d3c095c97a84</dataNeedId>
             <documentType>acknowledgement-market-document</documentType>
-            <finalCustomerId>88e0fc2c-4ea7-4850-a736-8b9742757518</finalCustomerId>
+            <finalCustomerId>fc-id</finalCustomerId>
             <dataSourceId>0743c9d8-3e5f-4575-999b-34f6f83b2075</dataSourceId>
             <defaultValues xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
             <regionConnector>aiida</regionConnector>
@@ -36,16 +35,18 @@ The following is an example of a acknowledgement envelope for version v1.12:
         <mRID>1cb72828-e869-463c-a447-7062bcca24b4</mRID>
         <createdDateTime>2026-02-24T11:58:05Z</createdDateTime>
         <sender_MarketParticipant.mRID codingScheme="NAT">AT003000</sender_MarketParticipant.mRID>
-        <sender_MarketParticipant.marketRole.type>CONNECTING_SYSTEM_OPERATOR</sender_MarketParticipant.marketRole.type>
-        <receiver_MarketParticipant.mRID codingScheme="NAT">88e0fc2c-4ea7-4850-a736-8b9742757518
-        </receiver_MarketParticipant.mRID>
-        <receiver_MarketParticipant.marketRole.type>FINAL_CUSTOMER</receiver_MarketParticipant.marketRole.type>
+        <sender_MarketParticipant.marketRole.type>A56</sender_MarketParticipant.marketRole.type>
+        <receiver_MarketParticipant.mRID codingScheme="NAT">fc-id</receiver_MarketParticipant.mRID>
+        <receiver_MarketParticipant.marketRole.type>A13</receiver_MarketParticipant.marketRole.type>
         <received_MarketDocument.mRID>5a1cd7e9-345a-4c5a-94e3-987b3b8d2def</received_MarketDocument.mRID>
         <received_MarketDocument.revisionNumber>1</received_MarketDocument.revisionNumber>
-        <received_MarketDocument.type>min-max-envelope</received_MarketDocument.type>
-        <received_MarketDocument.process.processType>MIN_MAX_ENVELOPE</received_MarketDocument.process.processType>
+        <received_MarketDocument.type>A17</received_MarketDocument.type>
+        <received_MarketDocument.process.processType>A37</received_MarketDocument.process.processType>
         <received_MarketDocument.title xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
         <received_MarketDocument.createdDateTime>2026-02-24T11:57:05Z</received_MarketDocument.createdDateTime>
+        <Reason>
+            <code>A01</code>
+        </Reason>
         <Rejected_TimeSeries>
             <Rejected_TimeSeries>
                 <mRID>63c99336-d854-4ed2-be01-13dca22a2850</mRID>

--- a/docs/2-integrating/messages/cim/energy-sharing-reference-data-market-documents.md
+++ b/docs/2-integrating/messages/cim/energy-sharing-reference-data-market-documents.md
@@ -1,0 +1,22 @@
+# Energy Sharing Reference Data Market Documents
+
+Energy Sharing Reference Data Market Documents to announce to the eligible party the participation factor of an accounting point in a specific Collective Energy Sharing Unit (CESU).
+This document is emitted for permission requests with a [CESU Join Request Data Need](../../data-needs.md#cesujoinrequestdataneed).
+
+> [!Warning]
+> Only the XSD is provided since the CIM is an XML first format, and it cannot be guaranteed that the JSON variant is stable.
+
+The XSD files can be found [here for v1.12](https://github.com/eddie-energy/eddie/tree/main/cim/src/main/schemas/cim/xsd/v1_12/esr).
+The following is an example of an energy sharing reference data market document.
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns:Envelope xmlns:ns="https://eddie.energy/CIM/CEEDS_EnergySharingReferenceDataMarketDocument_annotated_v1.12_new.xsd">
+    <ns:MessageDocumentHeader>
+        <!-- Omitted for conciseness -->
+    </ns:MessageDocumentHeader>
+    <ns:MarketDocument>
+        <!-- Full example will be made available once the Austrian region connector implements the mapping in order to create a realistic example. See GH-2439 -->
+    </ns:MarketDocument>
+</ns:Envelope>
+```

--- a/docs/2-integrating/messages/cim/min-max-envelope.md
+++ b/docs/2-integrating/messages/cim/min-max-envelope.md
@@ -19,7 +19,7 @@ The following is an example of a min-max envelope document for version v1.12:
             <requestPermissionId>aae63ff1-4062-4599-8f4c-686df39138e7</requestPermissionId>
             <dataNeedId>5dc71d7e-e8cd-4403-a3a8-d3c095c97a12</dataNeedId>
             <documentType>min-max-envelope</documentType>
-            <finalCustomerId>88e0fc2c-4ea7-4850-a736-8b9742757518</finalCustomerId>
+            <finalCustomerId>fc-id</finalCustomerId>
             <dataSourceId>0743c9d8-3e5f-4575-999b-34f6f83b2075</dataSourceId>
             <defaultValues xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
             <regionConnector>aiida</regionConnector>
@@ -39,11 +39,10 @@ The following is an example of a min-max envelope document for version v1.12:
         <comment>This is a test min-max envelope.</comment>
         <sender_MarketParticipant.mRID codingScheme="NAT">AT003000</sender_MarketParticipant.mRID>
         <sender_MarketParticipant.name>Netz Oberösterreich GmbH</sender_MarketParticipant.name>
-        <sender_MarketParticipant.marketRole.type>CONNECTING_SYSTEM_OPERATOR</sender_MarketParticipant.marketRole.type>
-        <receiver_MarketParticipant.mRID codingScheme="NAT">88e0fc2c-4ea7-4850-a736-8b9742757518
-        </receiver_MarketParticipant.mRID>
+        <sender_MarketParticipant.marketRole.type>A56</sender_MarketParticipant.marketRole.type>
+        <receiver_MarketParticipant.mRID codingScheme="NAT">fc-id</receiver_MarketParticipant.mRID>
         <receiver_MarketParticipant.name>Max Mustermann</receiver_MarketParticipant.name>
-        <receiver_MarketParticipant.marketRole.type>FINAL_CUSTOMER</receiver_MarketParticipant.marketRole.type>
+        <receiver_MarketParticipant.marketRole.type>A13</receiver_MarketParticipant.marketRole.type>
         <process.processType>MIN_MAX_ENVELOPE</process.processType>
         <period.timeInterval>
             <start>2026-06-01T00:00:00Z</start>


### PR DESCRIPTION
This PR is the first of a number of PRs to support the energy sharing reference data market document in EDDIE.
The following PRs will add support for sending the document via all the outbound connectors and for supporting it in the eda region connector.