### PR TITLE
feat(sim): Produce raw data messages from simulation connector

### DIFF
--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/providers/DocumentStreams.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/providers/DocumentStreams.java
@@ -6,26 +6,39 @@ package energy.eddie.regionconnector.simulation.providers;
 import energy.eddie.api.agnostic.MessageStream;
 import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
 import energy.eddie.cim.agnostic.ConnectionStatusMessage;
+import energy.eddie.cim.agnostic.RawDataMessage;
 import energy.eddie.cim.v0_82.pmd.PermissionEnvelope;
 import energy.eddie.cim.v0_82.vhd.ValidatedHistoricalDataEnvelope;
+import energy.eddie.regionconnector.simulation.SimulationDataSourceInformation;
 import energy.eddie.regionconnector.simulation.dtos.SimulatedMeterReading;
 import energy.eddie.regionconnector.simulation.permission.request.IntermediateValidatedHistoricalDataMarketDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @Component
 public class DocumentStreams implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(DocumentStreams.class);
     private final Sinks.Many<SimulatedMeterReading> vhdSink = Sinks.many().multicast().onBackpressureBuffer();
-    private final Sinks.Many<ConnectionStatusMessage> csmSink = Sinks.many().multicast()
-                                                                     .onBackpressureBuffer();
+    private final Sinks.Many<ConnectionStatusMessage> csmSink = Sinks.many().multicast().onBackpressureBuffer();
     private final Sinks.Many<PermissionEnvelope> pmdSink = Sinks.many().multicast().onBackpressureBuffer();
     private final CommonInformationModelConfiguration cimConfig;
+    private final ObjectMapper objectMapper;
 
-    public DocumentStreams(@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") CommonInformationModelConfiguration cimConfig) {this.cimConfig = cimConfig;}
+    public DocumentStreams(
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") CommonInformationModelConfiguration cimConfig,
+            @Qualifier("jacksonJsonMapper") ObjectMapper objectMapper
+    ) {
+        this.cimConfig = cimConfig;
+        this.objectMapper = objectMapper;
+    }
 
     public synchronized void publish(SimulatedMeterReading document) {
         LOGGER.info("Publishing validated historical data market document");
@@ -62,6 +75,18 @@ public class DocumentStreams implements AutoCloseable {
     @MessageStream(PermissionEnvelope.class)
     public Flux<PermissionEnvelope> getPermissionMarketDocumentStream() {
         return pmdSink.asFlux();
+    }
+
+    @MessageStream(RawDataMessage.class)
+    public Flux<RawDataMessage> getRawDataMessageStream() {
+        return getSimulatedMeterReadingStream()
+                .map(data -> new RawDataMessage(
+                        data.permissionId(),
+                        data.connectionId(),
+                        data.dataNeedId(),
+                        new SimulationDataSourceInformation(),
+                        ZonedDateTime.now(ZoneOffset.UTC),
+                        objectMapper.writeValueAsString(data)));
     }
 
     public Flux<SimulatedMeterReading> getSimulatedMeterReadingStream() {

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/SimulationEngineTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/SimulationEngineTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.test.StepVerifier;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.Period;
 import java.time.ZoneOffset;
@@ -77,7 +78,7 @@ class SimulationEngineTest {
                 )
         );
         var metadata = new ScenarioMetadata("cid", "pid", "dnid");
-        var streams = new DocumentStreams(cimConfig);
+        var streams = new DocumentStreams(cimConfig, new ObjectMapper());
         var engine = new SimulationEngine(streams, dataNeedsService);
 
         // When
@@ -100,6 +101,43 @@ class SimulationEngineTest {
                     .verifyComplete();
         StepVerifier.create(streams.getPermissionMarketDocumentStream())
                     .expectNextCount(5)
+                    .verifyComplete();
+    }
+
+    void testRun_withValidatedHistoricalData_emitsRawData() {
+        // Given
+        when(dataNeedsService.findById("dnid")).thenReturn(
+                Optional.of(new ValidatedHistoricalDataDataNeed(
+                        new RelativeDuration(Period.ZERO,
+                                             Period.ZERO,
+                                             null),
+                        EnergyType.ELECTRICITY,
+                        Granularity.PT5M,
+                        Granularity.P1Y)));
+        var scenario = new Scenario(
+                "Test Scenario",
+                List.of(new ValidatedHistoricalDataStep(new SimulatedValidatedHistoricalData(
+                                "mid",
+                                ZonedDateTime.now(ZoneOffset.UTC),
+                                Granularity.PT15M.name(),
+                                List.of(
+                                        new Measurement(10.0,
+                                                        Measurement.MeasurementType.MEASURED)
+                                ))
+                        )
+                )
+        );
+        var metadata = new ScenarioMetadata("cid", "pid", "dnid");
+        var streams = new DocumentStreams(cimConfig, new ObjectMapper());
+        var engine = new SimulationEngine(streams, dataNeedsService);
+
+        // When
+        engine.run(scenario, metadata);
+
+        // Then
+        StepVerifier.create(streams.getRawDataMessageStream())
+                    .expectNextCount(1)
+                    .then(streams::close)
                     .verifyComplete();
     }
 
@@ -126,7 +164,7 @@ class SimulationEngineTest {
                 )
         );
         var metadata = new ScenarioMetadata("cid", "pid", "dnid");
-        var streams = new DocumentStreams(cimConfig);
+        var streams = new DocumentStreams(cimConfig, new ObjectMapper());
         var engine = new SimulationEngine(streams, dataNeedsService);
 
         // When

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/steps/TestSimulationContext.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/steps/TestSimulationContext.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.regionconnector.simulation.engine.steps;
@@ -7,11 +7,12 @@ import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
 import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
 import energy.eddie.regionconnector.simulation.engine.SimulationContext;
 import energy.eddie.regionconnector.simulation.providers.DocumentStreams;
+import tools.jackson.databind.ObjectMapper;
 
 public class TestSimulationContext {
     public static SimulationContext create() {
         return new SimulationContext(
-                new DocumentStreams(new PlainCommonInformationModelConfiguration(CodingSchemeTypeList.FINLAND_NATIONAL_CODING_SCHEME, "EP-ID")),
+                new DocumentStreams(new PlainCommonInformationModelConfiguration(CodingSchemeTypeList.FINLAND_NATIONAL_CODING_SCHEME, "EP-ID"), new ObjectMapper()),
                 "pid",
                 "cid",
                 "dnid"


### PR DESCRIPTION
Helps us explain raw data vs CIM data in the [EDDIE tutorial](https://github.com/eddie-energy/tutorial) and other documentation.

Thanks @fweingartshofer for the initial patch. I only adjusted the test to also cover the raw data messages.