### PR TITLE
fix: Update OpenApi setup to respect `eddie.public.url` and `eddie.management.url`

### DIFF
--- a/core/src/main/java/energy/eddie/OpenApiDocs.java
+++ b/core/src/main/java/energy/eddie/OpenApiDocs.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie;
@@ -26,14 +26,12 @@ import static energy.eddie.spring.RegionConnectorRegistrationBeanPostProcessor.E
  * documentation for the European MasterData.
  */
 public class OpenApiDocs {
-    private static final String HOST = "localhost";
-
     @Bean
     @Primary
     public SwaggerUiConfigProperties swaggerUiConfig(
             SwaggerUiConfigProperties config,
-            @Value("${server.port}") int serverPort,
-            @Value("${eddie.management.server.port}") int managementPort,
+            @Value("${eddie.public.url}") String publicURL,
+            @Value("${eddie.management.url}") String managementURL,
             @Qualifier(ENABLED_REGION_CONNECTOR_BEAN_NAME) List<String> enabledRegionConnectors,
             @Qualifier(SWAGGER_ENABLED_OUTBOUND_CONNECTOR_BEAN_NAME) List<String> enabledOutboundConnectors
     ) {
@@ -42,10 +40,7 @@ public class OpenApiDocs {
                 .map(name -> {
                     // CVE-2024-22243 can be ignored, as we are not parsing an externally provided URL
                     String docUrl = UriComponentsBuilder
-                            .newInstance()
-                            .scheme("http")
-                            .host(HOST)
-                            .port(serverPort)
+                            .fromUriString(publicURL)
                             .pathSegment(ALL_REGION_CONNECTORS_BASE_URL_PATH)
                             .pathSegment(name)
                             .path(SWAGGER_DOC_PATH)
@@ -61,10 +56,7 @@ public class OpenApiDocs {
                 .map(name -> {
                     // CVE-2024-22243 can be ignored, as we are not parsing an externally provided URL
                     String docUrl = UriComponentsBuilder
-                            .newInstance()
-                            .scheme("http")
-                            .host(HOST)
-                            .port(managementPort)
+                            .fromUriString(managementURL)
                             .pathSegment("outbound-connectors")
                             .pathSegment(name)
                             .path(SWAGGER_DOC_PATH)
@@ -75,18 +67,15 @@ public class OpenApiDocs {
                                                                             name.toUpperCase(Locale.ENGLISH));
                 })
                 .collect(Collectors.toSet());
-        swaggerUrls.add(getEuropeanMasterDataSwaggerUrl(serverPort));
+        swaggerUrls.add(getEuropeanMasterDataSwaggerUrl(publicURL));
         swaggerUrls.addAll(outboundSwaggerUrls);
         config.setUrls(swaggerUrls);
         return config;
     }
 
-    private static AbstractSwaggerUiConfigProperties.SwaggerUrl getEuropeanMasterDataSwaggerUrl(int serverPort) {
+    private static AbstractSwaggerUiConfigProperties.SwaggerUrl getEuropeanMasterDataSwaggerUrl(String host) {
         var url = UriComponentsBuilder
-                .newInstance()
-                .scheme("http")
-                .host(HOST)
-                .port(serverPort)
+                .fromUriString(host)
                 .pathSegment("european-masterdata")
                 .path(SWAGGER_DOC_PATH)
                 .toUriString();

--- a/core/src/main/java/org/springdoc/webmvc/ui/SwaggerController.java
+++ b/core/src/main/java/org/springdoc/webmvc/ui/SwaggerController.java
@@ -1,16 +1,26 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package org.springdoc.webmvc.ui;
 
+import io.swagger.v3.oas.models.servers.Server;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigParameters;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springdoc.core.providers.SpringWebProvider;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
 
 
 /**
@@ -21,13 +31,61 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
  */
 @Configuration
 public class SwaggerController extends SwaggerWelcomeWebMvc {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerController.class);
+    private final int managementPort;
+    private final String publicUrl;
+    private final String managementUrl;
+
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     public SwaggerController(
             SwaggerUiConfigProperties swaggerUiConfig,
             SpringDocConfigProperties springDocConfigProperties,
-            ObjectProvider<SpringWebProvider> springWebProvider
+            ObjectProvider<SpringWebProvider> springWebProvider,
+            @Value("${eddie.management.server.port}") int managementPort,
+            @Value("${eddie.public.url}") String publicUrl,
+            @Value("${eddie.management.url}") String managementUrl
     ) {
         super(swaggerUiConfig, springDocConfigProperties, springWebProvider);
+        this.managementPort = managementPort;
+        this.publicUrl = publicUrl;
+        this.managementUrl = managementUrl;
+    }
+
+    @Bean
+    public OpenApiCustomizer dynamicServerUrlCustomizer(
+    ) {
+        return openApi -> {
+            ServletRequestAttributes attributes =
+                    (ServletRequestAttributes)
+                            RequestContextHolder.getRequestAttributes();
+
+            if (attributes == null) {
+                return;
+            }
+
+            HttpServletRequest request = attributes.getRequest();
+            LOGGER.trace(
+                    "Got request with servlet path {}, context path {}, path info {}, translated path {}, server port {}, local port {}",
+                    request.getServletPath(),
+                    request.getContextPath(),
+                    request.getPathInfo(),
+                    request.getPathTranslated(),
+                    request.getServerPort(),
+                    request.getLocalPort());
+
+            String baseUri = findBasePath(request.getLocalPort());
+
+            String serverUrl = UriComponentsBuilder.fromUriString(baseUri)
+                                                   .path(request.getServletPath())
+                                                   .build()
+                                                   .toUriString();
+            LOGGER.trace("Resolved server URL: {}", serverUrl);
+
+            Server server = new Server();
+            server.setUrl(serverUrl);
+
+            openApi.setServers(List.of(server));
+        };
     }
 
     @Override
@@ -36,8 +94,28 @@ public class SwaggerController extends SwaggerWelcomeWebMvc {
             HttpServletRequest request
     ) {
         super.init(swaggerUiConfigParameters);
-        // default is request.getContextPath()
-        swaggerUiConfigParameters.setContextPath(request.getServletPath());
-        buildConfigUrl(swaggerUiConfigParameters, ServletUriComponentsBuilder.fromCurrentContextPath());
+
+        // Determine the base URL based on the incoming request port
+        var swaggerBaseUrl = findBasePath(request.getServerPort());
+
+        LOGGER.trace(
+                "Configuring Swagger UI based on incoming port. Resolved Swagger base URL: '{}', " +
+                "Request port: {}, Context path: '{}'",
+                swaggerBaseUrl, request.getServerPort(), request.getServletPath()
+        );
+
+        // Dynamically build the server configuration
+        swaggerUiConfigParameters.setUrl(swaggerBaseUrl);
+        swaggerUiConfigParameters.setContextPath(UriComponentsBuilder.fromUriString(swaggerBaseUrl)
+                                                                     .path(request.getServletPath())
+                                                                     .build()
+                                                                     .getPath());
+        buildConfigUrl(swaggerUiConfigParameters, UriComponentsBuilder.fromUriString(swaggerBaseUrl));
+    }
+
+    private String findBasePath(int serverPort) {
+        return serverPort == managementPort
+                ? managementUrl
+                : publicUrl;
     }
 }

--- a/core/src/test/java/energy/eddie/OpenApiDocsTest.java
+++ b/core/src/test/java/energy/eddie/OpenApiDocsTest.java
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie;
+
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.properties.AbstractSwaggerUiConfigProperties;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenApiDocsTest {
+
+    @Test
+    void testSwaggerUiConfig_withEmptyConnectors() {
+        // Given
+        String publicURL = "https://public.example.com";
+        String managementURL = "https://management.example.com";
+        SwaggerUiConfigProperties config = new SwaggerUiConfigProperties();
+        OpenApiDocs openApiDocs = new OpenApiDocs();
+
+        // When
+        SwaggerUiConfigProperties result = openApiDocs.swaggerUiConfig(
+                config,
+                publicURL,
+                managementURL,
+                List.of(),
+                List.of()
+        );
+
+        // Then
+        Set<AbstractSwaggerUiConfigProperties.SwaggerUrl> urls = result.getUrls();
+        assertThat(urls)
+                .hasSize(1)
+                .anyMatch(url -> url.getName().equals("european-masterdata"));
+    }
+
+    @Test
+    void testSwaggerUiConfig_withRegionConnectors() {
+        // Given
+        String publicURL = "https://public.example.com";
+        String managementURL = "https://management.example.com";
+        SwaggerUiConfigProperties config = new SwaggerUiConfigProperties();
+        OpenApiDocs openApiDocs = new OpenApiDocs();
+
+        // When
+        SwaggerUiConfigProperties result = openApiDocs.swaggerUiConfig(
+                config,
+                publicURL,
+                managementURL,
+                List.of("region1", "region2"),
+                List.of()
+        );
+
+        // Then
+        Set<AbstractSwaggerUiConfigProperties.SwaggerUrl> urls = result.getUrls();
+        assertThat(urls)
+                .hasSize(3) // Includes European Master Data + 2 region connectors
+                .anyMatch(url -> url.getName().equals("region-connector-region1"))
+                .anyMatch(url -> url.getName().equals("region-connector-region2"))
+                .anyMatch(url -> url.getName().equals("european-masterdata"));
+    }
+
+    @Test
+    void testSwaggerUiConfig_withOutboundConnectors() {
+        // Given
+        String publicURL = "https://public.example.com";
+        String managementURL = "https://management.example.com";
+        SwaggerUiConfigProperties config = new SwaggerUiConfigProperties();
+        OpenApiDocs openApiDocs = new OpenApiDocs();
+
+        // When
+        SwaggerUiConfigProperties result = openApiDocs.swaggerUiConfig(
+                config,
+                publicURL,
+                managementURL,
+                List.of(),
+                List.of("connector1", "connector2")
+        );
+
+        // Then
+        Set<AbstractSwaggerUiConfigProperties.SwaggerUrl> urls = result.getUrls();
+        assertThat(urls)
+                .hasSize(3) // Includes European Master Data + 2 outbound connectors
+                .anyMatch(url -> url.getName().equals("outbound-connector-connector1"))
+                .anyMatch(url -> url.getName().equals("outbound-connector-connector2"))
+                .anyMatch(url -> url.getName().equals("european-masterdata"));
+    }
+
+    @Test
+    void testSwaggerUiConfig_withBothConnectors() {
+        // Given
+        String publicURL = "https://public.example.com";
+        String managementURL = "https://management.example.com";
+        SwaggerUiConfigProperties config = new SwaggerUiConfigProperties();
+        OpenApiDocs openApiDocs = new OpenApiDocs();
+
+        // When
+        SwaggerUiConfigProperties result = openApiDocs.swaggerUiConfig(
+                config,
+                publicURL,
+                managementURL,
+                List.of("region1"),
+                List.of("connector1")
+        );
+
+        // Then
+        Set<AbstractSwaggerUiConfigProperties.SwaggerUrl> urls = result.getUrls();
+        assertThat(urls)
+                .hasSize(3) // Includes all 3 APIs
+                .anyMatch(url -> url.getName().equals("region-connector-region1"))
+                .anyMatch(url -> url.getName().equals("outbound-connector-connector1"))
+                .anyMatch(url -> url.getName().equals("european-masterdata"));
+    }
+}

--- a/core/src/test/java/org/springdoc/webmvc/ui/SwaggerControllerTest.java
+++ b/core/src/test/java/org/springdoc/webmvc/ui/SwaggerControllerTest.java
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package org.springdoc.webmvc.ui;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SwaggerControllerTest {
+
+    @Test
+    void dynamicServerUrlCustomizer_shouldSetServerUrl_basedOnPublicUrl() {
+        // Given
+        int managementPort = 9090;
+        String publicUrl = "http://localhost:8080";
+        String managementUrl = "http://localhost:9090";
+        SwaggerController swaggerController = new SwaggerController(
+                null, null, null, managementPort, publicUrl, managementUrl);
+        OpenApiCustomizer customizer = swaggerController.dynamicServerUrlCustomizer();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setLocalPort(8080);
+        request.setServletPath("/api");
+
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        OpenAPI openApi = new OpenAPI();
+
+        // When
+        customizer.customise(openApi);
+
+        // Then
+        List<Server> servers = openApi.getServers();
+        assertEquals(1, servers.size());
+        assertEquals(publicUrl + "/api", servers.getFirst().getUrl());
+    }
+
+    @Test
+    void dynamicServerUrlCustomizer_shouldSetServerUrl_basedOnManagementUrl() {
+        // Given
+        int managementPort = 9090;
+        String publicUrl = "http://localhost:8080";
+        String managementUrl = "http://localhost:9090";
+        SwaggerController swaggerController = new SwaggerController(
+                null, null, null, managementPort, publicUrl, managementUrl);
+        OpenApiCustomizer customizer = swaggerController.dynamicServerUrlCustomizer();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setLocalPort(managementPort);
+        request.setServletPath("/management");
+
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        OpenAPI openApi = new OpenAPI();
+
+        // When
+        customizer.customise(openApi);
+
+        // Then
+        List<Server> servers = openApi.getServers();
+        assertEquals(1, servers.size());
+        assertEquals(managementUrl + "/management", servers.getFirst().getUrl());
+    }
+
+    @Test
+    void dynamicServerUrlCustomizer_shouldDoNothing_ifNoRequestAttributes() {
+        // Given
+        int managementPort = 9090;
+        String publicUrl = "http://localhost:8080";
+        String managementUrl = "http://localhost:9090";
+        SwaggerController swaggerController = new SwaggerController(
+                null, null, null, managementPort, publicUrl, managementUrl);
+        OpenApiCustomizer customizer = swaggerController.dynamicServerUrlCustomizer();
+        OpenAPI openApi = new OpenAPI();
+
+        // When
+        RequestContextHolder.resetRequestAttributes();
+        customizer.customise(openApi);
+
+        // Then
+        List<Server> servers = openApi.getServers();
+        assertNull(servers);
+    }
+}

--- a/core/src/test/resources/application-common-controller-advice.properties
+++ b/core/src/test/resources/application-common-controller-advice.properties
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+# SPDX-License-Identifier: Apache-2.0
+
 region-connector.dk.energinet.enabled=true
 region-connector.dk.energinet.customer.client.basepath=https://api.eloverblik.dk/customerapi
 
@@ -9,6 +12,8 @@ cim.eligible-party.fallback.id=REPLACE_ME
 spring.flyway.enabled=false
 eddie.management.server.port=0
 eddie.management.server.urlprefix=management
+eddie.public.url=http://localhost:8080
+eddie.management.url=http://localhost:9090
 
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
 spring.datasource.driverClassName=org.h2.Driver


### PR DESCRIPTION
- Fixes the swagger ui when eddie is running in a docker container and is exposed via different ports outside than are configured for eddie itself
- Fixes the swagger ui when hosting eddie behind a proxy such as caddy with different context paths

## Tests
### Simple Docker test

Tested to verify that it still works for only changing the port:

```yaml [env/docker-compose.yml]
services:
  # Other configs from https://github.com/eddie-energy/eddie/blob/b7a7b9e5481351ecaf52aac30f650e60131f8afc/env/docker-compose.yml
  eddie:
    image: ghcr.io/eddie-energy/eddie:latest
    build:
      dockerfile: src/main/docker/Dockerfile
      context: ../core
    env_file:
      - .env
      - path: .env.local
        required: false
    environment:
      EDDIE_PUBLIC_URL: http://localhost:8081
      EDDIE_MANAGEMENT_URL: http://localhost:9091
      OUTBOUND_CONNECTOR_REST_ENABLED: true
    ports:
      - "8081:8080"
      - "9091:9090"
    volumes:
      - ./keys:/opt/core/keys # mount a folder to store key files
      - ./ponton:/ponton # mount a folder to store ponton files
      - ./data-needs.json:/opt/core/config/data-needs.json
    depends_on:
      - kafka
      - db
```

### Test with reverse proxy (Caddy)

This one is a more sophisticated test, where the public and management port are behind a reverse proxy with different path prefixes to differentiate between those two

```yaml [env/docker-compose.yml]
services:
  # Other configs from https://github.com/eddie-energy/eddie/blob/b7a7b9e5481351ecaf52aac30f650e60131f8afc/env/docker-compose.yml
  eddie:
    image: ghcr.io/eddie-energy/eddie:latest
    build:
      dockerfile: src/main/docker/Dockerfile
      context: ../core
    env_file:
      - .env
      - path: .env.local
        required: false
    environment:
      EDDIE_PUBLIC_URL: http://localhost:9000/public
      EDDIE_MANAGEMENT_URL: http://localhost:9000/management
      OUTBOUND_CONNECTOR_REST_ENABLED: true
    ports:
      - "8081:8080"
      - "9091:9090"
    volumes:
      - ./keys:/opt/core/keys # mount a folder to store key files
      - ./ponton:/ponton # mount a folder to store ponton files
      - ./data-needs.json:/opt/core/config/data-needs.json
    depends_on:
      - kafka
      - db
```

Caddyfile:

```caddyfile [Caddyfile]
:8080 {
    handle_path /public/*  {
    	reverse_proxy eddie:8080
    }

    handle_path /management/*  {
    	reverse_proxy eddie:9090
    }
}
```