### PR TITLE
feat(de-eta-region-connector): implement accounting point data fetch and emission (GH-2193)

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/DeEtaBeanConfig.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/DeEtaBeanConfig.java
@@ -13,6 +13,7 @@ import energy.eddie.regionconnector.de.eta.data.needs.EtaDataNeedRuleSet;
 import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
 import energy.eddie.regionconnector.de.eta.persistence.DePermissionEventRepository;
 import energy.eddie.regionconnector.de.eta.persistence.DePermissionRequestRepository;
+import energy.eddie.regionconnector.de.eta.providers.AccountingPointDataStream;
 import energy.eddie.regionconnector.de.eta.providers.ValidatedHistoricalDataStream;
 import energy.eddie.regionconnector.de.eta.service.PollingService;
 import energy.eddie.regionconnector.shared.agnostic.JsonRawDataProvider;
@@ -94,11 +95,16 @@ public class DeEtaBeanConfig {
 
     @SuppressWarnings("ReactiveStreamsUnusedPublisher")
     @Bean
-    public JsonRawDataProvider rawDataProvider(ObjectMapper objectMapper, ValidatedHistoricalDataStream stream) {
+    public JsonRawDataProvider rawDataProvider(
+            ObjectMapper objectMapper,
+            ValidatedHistoricalDataStream vhdStream,
+            AccountingPointDataStream apStream
+    ) {
         return new JsonRawDataProvider(
                 EtaRegionConnectorMetadata.REGION_CONNECTOR_ID,
                 objectMapper,
-                stream.validatedHistoricalData()
+                vhdStream.validatedHistoricalData(),
+                apStream.accountingPointData()
         );
     }
 

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/auth/EtaAuthService.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/auth/EtaAuthService.java
@@ -5,12 +5,16 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +51,21 @@ public class EtaAuthService {
                    .subscribeOn(Schedulers.boundedElastic())
                    .onErrorResume(error -> {
                        LOGGER.error("Error during token exchange", error);
+                       return Mono.just(new AuthTokenResponse(null, false));
+                   });
+    }
+
+    /**
+     * Exchanges a stored refresh token for a fresh access token. Used by handlers
+     * that hit a 401 on a one-shot fetch and want to recover without forcing the
+     * customer to re-consent. The returned tokens are intended for in-flight use
+     * only — callers are responsible for deciding whether to persist them.
+     */
+    public Mono<AuthTokenResponse> refresh(String refreshToken) {
+        return Mono.fromCallable(() -> performTokenRefresh(refreshToken))
+                   .subscribeOn(Schedulers.boundedElastic())
+                   .onErrorResume(error -> {
+                       LOGGER.error("Error during token refresh", error);
                        return Mono.just(new AuthTokenResponse(null, false));
                    });
     }
@@ -109,6 +128,56 @@ public class EtaAuthService {
 
         return new AuthTokenResponse(
                 new AuthTokenResponse.TokenData(token, refreshTokenString),
+                true
+        );
+    }
+
+    private AuthTokenResponse performTokenRefresh(String refreshToken)
+            throws IOException, ParseException {
+
+        LOGGER.info("Refreshing access token");
+
+        RefreshTokenGrant grant = new RefreshTokenGrant(new RefreshToken(refreshToken));
+
+        URI tokenEndpoint = URI.create(configuration.auth().tokenUrl());
+        ClientID clientID = new ClientID(configuration.auth().clientId());
+        ClientSecretBasic clientAuth = new ClientSecretBasic(
+                clientID, new Secret(configuration.auth().clientSecret()));
+
+        TokenRequest request = new TokenRequest(tokenEndpoint, clientAuth, grant);
+        HTTPRequest httpRequest = request.toHTTPRequest();
+        httpRequest.setAccept("application/json");
+
+        if (configuration.sslTrustAll()) {
+            httpRequest.setSSLSocketFactory(createTrustAllSocketFactory());
+        }
+
+        HTTPResponse response = httpRequest.send();
+        TokenResponse tokenResponse = TokenResponse.parse(response);
+
+        if (!tokenResponse.indicatesSuccess()) {
+            TokenErrorResponse errorResponse = tokenResponse.toErrorResponse();
+            ErrorObject errorObject = errorResponse.getErrorObject();
+
+            if (errorObject != null && errorObject.getCode() != null) {
+                LOGGER.warn("Token refresh unsuccessful: {}", errorObject.getCode());
+            } else {
+                LOGGER.warn("Token refresh unsuccessful with unknown error");
+            }
+            return new AuthTokenResponse(null, false);
+        }
+
+        AccessTokenResponse successResponse = tokenResponse.toSuccessResponse();
+
+        String token = successResponse.getTokens().getAccessToken().getValue();
+        String newRefreshToken = successResponse.getTokens().getRefreshToken() != null
+                ? successResponse.getTokens().getRefreshToken().getValue()
+                : null;
+
+        LOGGER.info("Successfully refreshed access token");
+
+        return new AuthTokenResponse(
+                new AuthTokenResponse.TokenData(token, newRefreshToken),
                 true
         );
     }

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
@@ -4,10 +4,14 @@ import energy.eddie.regionconnector.de.eta.EtaRegionConnectorMetadata;
 import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.AuthenticationException;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.DeserializationException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusBadRequestException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusForbiddenException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusNotFoundException;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusServerException;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusTimeoutException;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusOperationExceptions.RateLimitException;
 import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusAccountingPointData;
 import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,6 +123,69 @@ public class EtaPlusApiClient {
                 effectiveEnd,
                 domainReadings
         );
+    }
+
+    /**
+     * Fetch accounting point master data for a permission request.
+     * Single-shot fetch — caller is responsible for retry / state transitions
+     * on failure. Error envelope bodies (4xx/5xx) are not parsed; status code
+     * drives the mapping.
+     *
+     * @param permissionRequest the permission request whose metering point we want
+     * @param accessToken       the customer's OAuth bearer
+     * @return a Mono emitting the accounting point data or an error
+     */
+    public Mono<EtaPlusAccountingPointData> fetchAccountingPointData(
+            DePermissionRequest permissionRequest,
+            String accessToken
+    ) {
+        LOGGER.atInfo()
+              .addArgument(permissionRequest::permissionId)
+              .addArgument(permissionRequest::meteringPointId)
+              .log("Fetching accounting point data for permission {} on metering point {}");
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(configuration.accountingPointEndpoint())
+                        .queryParam("meteringPointId", permissionRequest.meteringPointId())
+                        .build())
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(EtaPlusAccountingPointData.class)
+                .timeout(Duration.ofSeconds(configuration.responseTimeoutSeconds()))
+                .retryWhen(retrySpec(permissionRequest.permissionId()))
+                .onErrorMap(WebClientResponseException.BadRequest.class, ex ->
+                        new EtaPlusBadRequestException(
+                                "Bad request fetching accounting point data for permission " + permissionRequest.permissionId(),
+                                ex.getStatusCode().value(), ex))
+                .onErrorMap(WebClientResponseException.Unauthorized.class, ex ->
+                        new AuthenticationException(
+                                "Authentication failed fetching accounting point data for permission " + permissionRequest.permissionId(),
+                                ex.getStatusCode().value(), ex))
+                .onErrorMap(WebClientResponseException.Forbidden.class, ex ->
+                        new EtaPlusForbiddenException(
+                                "Forbidden fetching accounting point data for permission " + permissionRequest.permissionId(),
+                                ex.getStatusCode().value(), ex))
+                .onErrorMap(WebClientResponseException.NotFound.class, ex ->
+                        new EtaPlusNotFoundException(
+                                "Metering point not found for permission " + permissionRequest.permissionId(),
+                                ex.getStatusCode().value(), ex))
+                .onErrorMap(WebClientResponseException.TooManyRequests.class, ex ->
+                        new RateLimitException(
+                                "Rate limit exceeded fetching accounting point data for permission " + permissionRequest.permissionId()))
+                .onErrorMap(ex -> ex instanceof WebClientResponseException wce
+                                && wce.getStatusCode().is5xxServerError(),
+                        ex -> new EtaPlusServerException(
+                                "ETA Plus server error fetching accounting point data for permission " + permissionRequest.permissionId(),
+                                ((WebClientResponseException) ex).getStatusCode().value(), ex))
+                .onErrorMap(DecodingException.class, ex ->
+                        new DeserializationException(
+                                "Failed to deserialize accounting point data for permission " + permissionRequest.permissionId(),
+                                ex))
+                .onErrorMap(java.util.concurrent.TimeoutException.class, ex ->
+                        new EtaPlusTimeoutException(
+                                "Accounting point request timed out for permission " + permissionRequest.permissionId(),
+                                ex));
     }
 
     /**

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/config/DeEtaPlusConfiguration.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/config/DeEtaPlusConfiguration.java
@@ -19,6 +19,7 @@ public record DeEtaPlusConfiguration(
                 @NotBlank String apiClientId,
                 @NotBlank String apiClientSecret,
                 @DefaultValue("/meters/historical") String meteredDataEndpoint,
+                @DefaultValue("/meters/accounting-point") String accountingPointEndpoint,
                 @DefaultValue("/v1/permissions/{id}") String permissionCheckEndpoint,
                 @Positive @DefaultValue("30") int responseTimeoutSeconds,
                 @PositiveOrZero @DefaultValue("3") int retryMaxAttempts,

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/exceptions/EtaPlusClientExceptions.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/exceptions/EtaPlusClientExceptions.java
@@ -85,4 +85,57 @@ public final class EtaPlusClientExceptions {
             super(message, cause);
         }
     }
+
+    /**
+     * Thrown when the ETA Plus API responds with HTTP 400 (Bad Request).
+     * Indicates a malformed request from the connector and should be treated as
+     * terminal — a retry will not succeed.
+     */
+    public static class EtaPlusBadRequestException extends RuntimeException {
+        private final int statusCode;
+
+        public EtaPlusBadRequestException(String message, int statusCode, Throwable cause) {
+            super(message, cause);
+            this.statusCode = statusCode;
+        }
+
+        public int statusCode() {
+            return statusCode;
+        }
+    }
+
+    /**
+     * Thrown when the ETA Plus API responds with HTTP 403 (Forbidden) on a resource
+     * the bearer should normally authorise. Reserved for future per-resource ACL
+     * responses; treated as terminal at the handler layer.
+     */
+    public static class EtaPlusForbiddenException extends RuntimeException {
+        private final int statusCode;
+
+        public EtaPlusForbiddenException(String message, int statusCode, Throwable cause) {
+            super(message, cause);
+            this.statusCode = statusCode;
+        }
+
+        public int statusCode() {
+            return statusCode;
+        }
+    }
+
+    /**
+     * Thrown when the ETA Plus API responds with HTTP 404 (Not Found) for a
+     * requested resource. Treated as terminal — the resource does not exist.
+     */
+    public static class EtaPlusNotFoundException extends RuntimeException {
+        private final int statusCode;
+
+        public EtaPlusNotFoundException(String message, int statusCode, Throwable cause) {
+            super(message, cause);
+            this.statusCode = statusCode;
+        }
+
+        public int statusCode() {
+            return statusCode;
+        }
+    }
 }

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/handlers/AccountingPointDataHandler.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/handlers/AccountingPointDataHandler.java
@@ -128,37 +128,45 @@ public class AccountingPointDataHandler implements EventHandler<AcceptedEvent> {
     }
 
     private void handleError(String permissionId, Throwable error) {
-        PermissionProcessStatus status;
-        if (error instanceof EtaPlusForbiddenException) {
-            LOGGER.warn(
-                    "Forbidden fetching accounting point data for permission {} — verify backend scopes for this metering point",
-                    permissionId, error);
-            status = PermissionProcessStatus.UNFULFILLABLE;
-        } else if (error instanceof EtaPlusNotFoundException) {
-            LOGGER.warn("Metering point not found for permission {} — marking UNFULFILLABLE", permissionId, error);
-            status = PermissionProcessStatus.UNFULFILLABLE;
-        } else if (error instanceof EtaPlusBadRequestException) {
-            LOGGER.warn("Bad request fetching accounting point data for permission {} — programmer error",
-                    permissionId, error);
-            status = PermissionProcessStatus.UNFULFILLABLE;
-        } else if (error instanceof AuthenticationException) {
-            LOGGER.warn(
-                    "Authentication failed fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
-                    permissionId, error);
-            status = PermissionProcessStatus.UNABLE_TO_SEND;
-        } else if (error instanceof RateLimitException
-                || error instanceof EtaPlusServerException
-                || error instanceof EtaPlusTimeoutException
-                || error instanceof DeserializationException) {
-            LOGGER.warn("Transient error fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
-                    permissionId, error);
-            status = PermissionProcessStatus.UNABLE_TO_SEND;
-        } else {
-            LOGGER.warn("Unexpected error fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
-                    permissionId, error);
-            status = PermissionProcessStatus.UNABLE_TO_SEND;
-        }
+        PermissionProcessStatus status = switch (error) {
+            case EtaPlusForbiddenException e -> {
+                LOGGER.warn(
+                        "Forbidden fetching accounting point data for permission {} — verify backend scopes for this metering point",
+                        permissionId, e);
+                yield PermissionProcessStatus.UNFULFILLABLE;
+            }
+            case EtaPlusNotFoundException e -> {
+                LOGGER.warn("Metering point not found for permission {} — marking UNFULFILLABLE", permissionId, e);
+                yield PermissionProcessStatus.UNFULFILLABLE;
+            }
+            case EtaPlusBadRequestException e -> {
+                LOGGER.warn("Bad request fetching accounting point data for permission {} — programmer error",
+                        permissionId, e);
+                yield PermissionProcessStatus.UNFULFILLABLE;
+            }
+            case AuthenticationException e -> {
+                LOGGER.warn(
+                        "Authentication failed fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
+                        permissionId, e);
+                yield PermissionProcessStatus.UNABLE_TO_SEND;
+            }
+            case RateLimitException e -> markTransient(permissionId, e);
+            case EtaPlusServerException e -> markTransient(permissionId, e);
+            case EtaPlusTimeoutException e -> markTransient(permissionId, e);
+            case DeserializationException e -> markTransient(permissionId, e);
+            default -> {
+                LOGGER.warn("Unexpected error fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
+                        permissionId, error);
+                yield PermissionProcessStatus.UNABLE_TO_SEND;
+            }
+        };
         commitSafely(permissionId, status);
+    }
+
+    private PermissionProcessStatus markTransient(String permissionId, Throwable error) {
+        LOGGER.warn("Transient error fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
+                permissionId, error);
+        return PermissionProcessStatus.UNABLE_TO_SEND;
     }
 
     private void commitSafely(String permissionId, PermissionProcessStatus status) {

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/handlers/AccountingPointDataHandler.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/handlers/AccountingPointDataHandler.java
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.permission.handlers;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.dataneeds.needs.AccountingPointDataNeed;
+import energy.eddie.dataneeds.needs.DataNeed;
+import energy.eddie.dataneeds.services.DataNeedsService;
+import energy.eddie.regionconnector.de.eta.auth.EtaAuthService;
+import energy.eddie.regionconnector.de.eta.client.EtaPlusApiClient;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.AuthenticationException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.DeserializationException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusBadRequestException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusForbiddenException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusNotFoundException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusServerException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusTimeoutException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusOperationExceptions.RateLimitException;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.persistence.DePermissionRequestRepository;
+import energy.eddie.regionconnector.de.eta.permission.request.events.AcceptedEvent;
+import energy.eddie.regionconnector.de.eta.permission.request.events.SimpleEvent;
+import energy.eddie.regionconnector.de.eta.providers.AccountingPointDataStream;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusAccountingPointData;
+import energy.eddie.regionconnector.shared.event.sourcing.EventBus;
+import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
+import energy.eddie.regionconnector.shared.event.sourcing.handlers.EventHandler;
+import jakarta.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+/**
+ * Handles {@link AcceptedEvent}s for permission requests whose data need is
+ * {@link AccountingPointDataNeed}. Performs a single-shot fetch against the
+ * accounting-point endpoint, publishes the payload to {@link AccountingPointDataStream},
+ * and commits the corresponding terminal event.
+ *
+ * <p>On 401 the handler attempts one in-flight refresh of the customer's access token
+ * using the refresh token persisted on the {@link AcceptedEvent}; the refreshed token
+ * is held only for the duration of the retry and is not persisted.
+ */
+@Component
+public class AccountingPointDataHandler implements EventHandler<AcceptedEvent> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccountingPointDataHandler.class);
+
+    private final DePermissionRequestRepository repository;
+    private final DataNeedsService dataNeedsService;
+    private final EtaPlusApiClient apiClient;
+    private final EtaAuthService authService;
+    private final AccountingPointDataStream stream;
+    private final Outbox outbox;
+
+    public AccountingPointDataHandler(
+            EventBus eventBus,
+            DePermissionRequestRepository repository,
+            DataNeedsService dataNeedsService,
+            EtaPlusApiClient apiClient,
+            EtaAuthService authService,
+            AccountingPointDataStream stream,
+            Outbox outbox
+    ) {
+        this.repository = repository;
+        this.dataNeedsService = dataNeedsService;
+        this.apiClient = apiClient;
+        this.authService = authService;
+        this.stream = stream;
+        this.outbox = outbox;
+        eventBus.filteredFlux(AcceptedEvent.class).subscribe(this::accept);
+    }
+
+    @Override
+    public void accept(AcceptedEvent event) {
+        Optional<DePermissionRequest> optionalPr = repository.findByPermissionId(event.permissionId());
+        if (optionalPr.isEmpty()) {
+            LOGGER.warn("Permission request not found for id: {}", event.permissionId());
+            return;
+        }
+        DePermissionRequest pr = optionalPr.get();
+
+        DataNeed dataNeed = dataNeedsService.getById(pr.dataNeedId());
+        if (!(dataNeed instanceof AccountingPointDataNeed)) {
+            return;
+        }
+
+        String refreshToken = event.refreshToken().orElse(null);
+
+        apiClient.fetchAccountingPointData(pr, event.accessToken())
+                 .onErrorResume(AuthenticationException.class, ex -> recoverWithRefreshToken(pr, refreshToken, ex))
+                 .subscribe(
+                         data -> {
+                             stream.publish(pr, data);
+                             commitSafely(pr.permissionId(), PermissionProcessStatus.FULFILLED);
+                         },
+                         error -> handleError(pr.permissionId(), error)
+                 );
+    }
+
+    private Mono<EtaPlusAccountingPointData> recoverWithRefreshToken(
+            DePermissionRequest pr,
+            @Nullable String refreshToken,
+            AuthenticationException originalError
+    ) {
+        if (refreshToken == null) {
+            LOGGER.warn("401 fetching accounting point data for permission {} — no refresh token available",
+                    pr.permissionId());
+            return Mono.error(originalError);
+        }
+
+        return authService.refresh(refreshToken)
+                .flatMap(refreshResponse -> {
+                    if (!refreshResponse.success() || refreshResponse.getAccessToken() == null) {
+                        LOGGER.warn("Refresh of access token failed for permission {}", pr.permissionId());
+                        return Mono.<EtaPlusAccountingPointData>error(originalError);
+                    }
+                    return apiClient.fetchAccountingPointData(pr, refreshResponse.getAccessToken())
+                            .onErrorResume(AuthenticationException.class, retryError -> {
+                                LOGGER.warn(
+                                        "401 fetching accounting point data for permission {} after successful token refresh",
+                                        pr.permissionId(), retryError);
+                                return Mono.error(retryError);
+                            });
+                });
+    }
+
+    private void handleError(String permissionId, Throwable error) {
+        PermissionProcessStatus status;
+        if (error instanceof EtaPlusForbiddenException) {
+            LOGGER.warn(
+                    "Forbidden fetching accounting point data for permission {} — verify backend scopes for this metering point",
+                    permissionId, error);
+            status = PermissionProcessStatus.UNFULFILLABLE;
+        } else if (error instanceof EtaPlusNotFoundException) {
+            LOGGER.warn("Metering point not found for permission {} — marking UNFULFILLABLE", permissionId, error);
+            status = PermissionProcessStatus.UNFULFILLABLE;
+        } else if (error instanceof EtaPlusBadRequestException) {
+            LOGGER.warn("Bad request fetching accounting point data for permission {} — programmer error",
+                    permissionId, error);
+            status = PermissionProcessStatus.UNFULFILLABLE;
+        } else if (error instanceof AuthenticationException) {
+            LOGGER.warn(
+                    "Authentication failed fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
+                    permissionId, error);
+            status = PermissionProcessStatus.UNABLE_TO_SEND;
+        } else if (error instanceof RateLimitException
+                || error instanceof EtaPlusServerException
+                || error instanceof EtaPlusTimeoutException
+                || error instanceof DeserializationException) {
+            LOGGER.warn("Transient error fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
+                    permissionId, error);
+            status = PermissionProcessStatus.UNABLE_TO_SEND;
+        } else {
+            LOGGER.warn("Unexpected error fetching accounting point data for permission {} — marking UNABLE_TO_SEND",
+                    permissionId, error);
+            status = PermissionProcessStatus.UNABLE_TO_SEND;
+        }
+        commitSafely(permissionId, status);
+    }
+
+    private void commitSafely(String permissionId, PermissionProcessStatus status) {
+        try {
+            outbox.commit(new SimpleEvent(permissionId, status));
+        } catch (Exception ex) {
+            LOGGER.error("Failed to persist {} event for permission {}", status, permissionId, ex);
+        }
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/request/events/AccountingPointValidatedEvent.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/request/events/AccountingPointValidatedEvent.java
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.permission.request.events;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+
+import java.time.LocalDate;
+
+/**
+ * Validated permission event for accounting-point data needs.
+ * Carries the permission timeframe but no granularity, since accounting-point
+ * data is non-temporal master data.
+ */
+@Entity(name = "DeAccountingPointValidatedEvent")
+@SuppressWarnings({"NullAway", "unused"})
+public class AccountingPointValidatedEvent extends PersistablePermissionEvent {
+
+    @Column(name = "permission_start")
+    private final LocalDate start;
+
+    @Column(name = "permission_end")
+    private final LocalDate end;
+
+    public AccountingPointValidatedEvent(String permissionId, LocalDate start, LocalDate end) {
+        super(permissionId, PermissionProcessStatus.VALIDATED);
+        this.start = start;
+        this.end = end;
+    }
+
+    protected AccountingPointValidatedEvent() {
+        super();
+        this.start = null;
+        this.end = null;
+    }
+
+    public LocalDate start() {
+        return start;
+    }
+
+    public LocalDate end() {
+        return end;
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/request/events/StartPollingEvent.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/request/events/StartPollingEvent.java
@@ -1,0 +1,27 @@
+package energy.eddie.regionconnector.de.eta.permission.request.events;
+
+import energy.eddie.api.agnostic.process.model.events.InternalPermissionEvent;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import jakarta.persistence.Entity;
+
+/**
+ * Internal event used to trigger polling for future data.
+ * This event is emitted by the CommonFutureDataService to signal the AcceptedHandler
+ * to poll data for an active permission request.
+ *
+ * <p>Implements InternalPermissionEvent to indicate this event should not be
+ * propagated to the eligible party.
+ */
+@Entity(name = "DeStartPollingEvent")
+@SuppressWarnings("NullAway")
+public class StartPollingEvent extends PersistablePermissionEvent implements InternalPermissionEvent {
+
+    public StartPollingEvent(String permissionId) {
+        super(permissionId, PermissionProcessStatus.ACCEPTED);
+    }
+
+    protected StartPollingEvent() {
+        super();
+    }
+}
+

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/request/events/ValidatedEvent.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/request/events/ValidatedEvent.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 
+import javax.annotation.Nullable;
 import java.time.LocalDate;
 
 /**
@@ -19,9 +20,9 @@ import java.time.LocalDate;
 @SuppressWarnings({"NullAway", "unused"})
 public class ValidatedEvent extends PersistablePermissionEvent {
 
-    @Column(name = "permission_start")
+    @Column(name = "data_start")
     private LocalDate start;
-    @Column(name = "permission_end")
+    @Column(name = "data_end")
     private LocalDate end;
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "text")
@@ -31,7 +32,7 @@ public class ValidatedEvent extends PersistablePermissionEvent {
             String permissionId,
             LocalDate start,
             LocalDate end,
-            Granularity granularity
+            @Nullable Granularity granularity
     ) {
         super(permissionId, PermissionProcessStatus.VALIDATED);
         this.start = start;

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/AccountingPointDataStream.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/AccountingPointDataStream.java
@@ -1,0 +1,54 @@
+package energy.eddie.regionconnector.de.eta.providers;
+
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+@Component
+public class AccountingPointDataStream implements AutoCloseable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccountingPointDataStream.class);
+
+    private final Sinks.Many<IdentifiableAccountingPointData> sink = Sinks.many()
+            .multicast()
+            .onBackpressureBuffer();
+
+    private final Flux<IdentifiableAccountingPointData> flux;
+
+    public AccountingPointDataStream() {
+        this.flux = sink.asFlux().share();
+    }
+
+    /**
+     * Get the flux of accounting point data.
+     * 
+     * @return flux of identifiable accounting point data
+     */
+    public Flux<IdentifiableAccountingPointData> accountingPointData() {
+        return flux;
+    }
+
+    /**
+     * Publish a chunk of accounting point data.
+     * 
+     * @param permissionRequest the permission request associated with this data
+     * @param data the accounting point data from the MDA
+     */
+    public void publish(DePermissionRequest permissionRequest, EtaPlusAccountingPointData data) {
+        var identifiableData = new IdentifiableAccountingPointData(permissionRequest, data);
+
+        Sinks.EmitResult result = sink.tryEmitNext(identifiableData);
+
+        if (result.isFailure()) {
+            LOGGER.error("Failed to emit accounting point data for permission {}: {}", 
+                    permissionRequest.permissionId(), result);
+        }
+    }
+
+    @Override
+    public void close() {
+        sink.tryEmitComplete();
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusAccountingPointData.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusAccountingPointData.java
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.providers;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.annotation.Nullable;
+
+/**
+ * Deserialised payload of the accounting-point response from the ETA+ backend.
+ * The backend strips null leaves and whole-null sub-objects from the wire, so
+ * {@code deliveryAddress} or {@code contractParty} may arrive absent rather than
+ * as an explicit JSON {@code null}; both shapes deserialise to a Java {@code null}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EtaPlusAccountingPointData(
+        String meteringPointId,
+        @Nullable String customerId,
+        @Nullable String energyType,
+        @Nullable String direction,
+        @Nullable Address deliveryAddress,
+        @Nullable ContractParty contractParty
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Address(
+            @Nullable String streetName,
+            @Nullable String buildingNumber,
+            @Nullable String postalCode,
+            @Nullable String city,
+            @Nullable String country,
+            @Nullable String addressSuffix
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ContractParty(
+            @Nullable String firstName,
+            @Nullable String surName,
+            @Nullable String companyName,
+            @Nullable String email
+    ) {}
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/IdentifiableAccountingPointData.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/IdentifiableAccountingPointData.java
@@ -1,0 +1,10 @@
+package energy.eddie.regionconnector.de.eta.providers;
+
+import energy.eddie.api.agnostic.IdentifiablePayload;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+
+public record IdentifiableAccountingPointData(
+        DePermissionRequest permissionRequest,
+        EtaPlusAccountingPointData payload
+) implements IdentifiablePayload<DePermissionRequest, EtaPlusAccountingPointData> {
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestCreationService.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestCreationService.java
@@ -12,6 +12,7 @@ import energy.eddie.dataneeds.exceptions.UnsupportedDataNeedException;
 import energy.eddie.dataneeds.needs.DataNeed;
 import energy.eddie.regionconnector.de.eta.dtos.CreatedPermissionRequest;
 import energy.eddie.regionconnector.de.eta.dtos.PermissionRequestForCreation;
+import energy.eddie.regionconnector.de.eta.permission.request.events.AccountingPointValidatedEvent;
 import energy.eddie.regionconnector.de.eta.permission.request.events.CreatedEvent;
 import energy.eddie.regionconnector.de.eta.permission.request.events.MalformedEvent;
 import energy.eddie.regionconnector.de.eta.permission.request.events.ValidatedEvent;
@@ -79,10 +80,13 @@ public class PermissionRequestCreationService {
                 requestForCreation.meteringPointId()));
 
         switch (dataNeedCalculationService.calculate(dataNeedId)) {
-            case AccountingPointDataNeedResult ignored -> {
-                String message = "AccountingPointDataNeed not supported by DE-ETA connector";
-                outbox.commit(new MalformedEvent(permissionId, new AttributeError(DATA_NEED_ID, message)));
-                throw new UnsupportedDataNeedException(REGION_CONNECTOR_ID, dataNeedId, message);
+            case AccountingPointDataNeedResult(Timeframe permissionTimeframe) -> {
+                LOGGER.info("Validated accounting-point permission request {}", permissionId);
+                outbox.commit(new AccountingPointValidatedEvent(
+                        permissionId,
+                        permissionTimeframe.start(),
+                        permissionTimeframe.end()));
+                return new CreatedPermissionRequest(permissionId, buildRedirectUri(permissionId));
             }
             case DataNeedNotFoundResult ignored -> {
                 outbox.commit(new MalformedEvent(

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/DeEtaBeanConfigTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/DeEtaBeanConfigTest.java
@@ -10,6 +10,7 @@ import energy.eddie.dataneeds.services.DataNeedsService;
 import energy.eddie.regionconnector.de.eta.data.needs.EtaDataNeedRuleSet;
 import energy.eddie.regionconnector.de.eta.persistence.DePermissionEventRepository;
 import energy.eddie.regionconnector.de.eta.persistence.DePermissionRequestRepository;
+import energy.eddie.regionconnector.de.eta.providers.AccountingPointDataStream;
 import energy.eddie.regionconnector.de.eta.providers.ValidatedHistoricalDataStream;
 import energy.eddie.regionconnector.de.eta.service.PollingService;
 import energy.eddie.regionconnector.shared.cim.v0_82.TransmissionScheduleProvider;
@@ -35,11 +36,14 @@ class DeEtaBeanConfigTest {
     void testBeansAreCreated() {
         var vhdStream = mock(ValidatedHistoricalDataStream.class);
         when(vhdStream.validatedHistoricalData()).thenReturn(Flux.empty());
+        var apStream = mock(AccountingPointDataStream.class);
+        when(apStream.accountingPointData()).thenReturn(Flux.empty());
         contextRunner
                 .withBean(DePermissionEventRepository.class, () -> mock(DePermissionEventRepository.class))
                 .withBean(DePermissionRequestRepository.class, () -> mock(DePermissionRequestRepository.class))
                 .withBean(DataNeedsService.class, () -> mock(DataNeedsService.class))
                 .withBean(ValidatedHistoricalDataStream.class, () -> vhdStream)
+                .withBean(AccountingPointDataStream.class, () -> apStream)
                 .withBean(EtaDataNeedRuleSet.class, EtaDataNeedRuleSet::new)
                 .withBean(ObjectMapper.class, ObjectMapper::new)
                 .withBean(PollingService.class, () -> mock(PollingService.class))

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/auth/EtaAuthServiceTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/auth/EtaAuthServiceTest.java
@@ -29,7 +29,7 @@ class EtaAuthServiceTest {
 
         DeEtaPlusConfiguration configuration = new DeEtaPlusConfiguration(
                 "partner", "http://api.url", "client-id", "client-secret",
-                "/meters/historical", "/v1/permissions/{id}", 30,
+                "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
                 3, 2, true, false,
                 authConfig, null);
 
@@ -75,5 +75,64 @@ class EtaAuthServiceTest {
                     assertThat(res.success()).isFalse();
                     assertThat(res.getAccessToken()).isNull();
                 }).verifyComplete();
+    }
+
+    @Test
+    void refreshShouldExchangeRefreshTokenForNewAccessToken() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json;charset=UTF-8")
+                .setBody("{\"access_token\":\"new-acc\",\"token_type\":\"bearer\",\"refresh_token\":\"new-ref\",\"expires_in\":3600}"));
+
+        StepVerifier.create(service.refresh("old-refresh-token"))
+                .assertNext(res -> {
+                    assertThat(res.success()).isTrue();
+                    assertThat(res.getAccessToken()).isEqualTo("new-acc");
+                    assertThat(res.getRefreshToken()).isEqualTo("new-ref");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void refreshShouldReturnUnsuccessfulOnInvalidRefreshToken() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"error\":\"invalid_grant\"}"));
+
+        StepVerifier.create(service.refresh("expired-refresh-token"))
+                .assertNext(res -> {
+                    assertThat(res.success()).isFalse();
+                    assertThat(res.getAccessToken()).isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void refreshShouldReturnUnsuccessfulWhenIdpUnreachable() throws IOException {
+        mockWebServer.shutdown();
+
+        StepVerifier.create(service.refresh("any"))
+                .assertNext(res -> {
+                    assertThat(res.success()).isFalse();
+                    assertThat(res.getAccessToken()).isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void refreshShouldHandleMissingRefreshTokenInResponse() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json;charset=UTF-8")
+                .setBody("{\"access_token\":\"only-access\",\"token_type\":\"bearer\",\"expires_in\":3600}"));
+
+        StepVerifier.create(service.refresh("rt"))
+                .assertNext(res -> {
+                    assertThat(res.success()).isTrue();
+                    assertThat(res.getAccessToken()).isEqualTo("only-access");
+                    assertThat(res.getRefreshToken()).isNull();
+                })
+                .verifyComplete();
     }
 }

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClientTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClientTest.java
@@ -4,10 +4,14 @@ import energy.eddie.regionconnector.de.eta.EtaRegionConnectorMetadata;
 import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.AuthenticationException;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.DeserializationException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusBadRequestException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusForbiddenException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusNotFoundException;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusServerException;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusOperationExceptions.RateLimitException;
 import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
 import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusAccountingPointData;
 import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -53,6 +57,7 @@ class EtaPlusApiClientTest {
                 "client-id",
                 "client-secret",
                 "/meters/historical",
+                "/meters/accounting-point",
                 "/v1/permissions/{id}",
                 30,
                 3, 0,
@@ -447,5 +452,203 @@ class EtaPlusApiClientTest {
         assertThat(recorded).isNotNull();
         assertThat(recorded.getMethod()).isEqualTo("HEAD");
         assertThat(recorded.getPath()).isEqualTo("/v1/permissions/perm-abc-123");
+    }
+
+    // ------------------------------------------------------------------
+    // fetchAccountingPointData
+    // ------------------------------------------------------------------
+
+    private DePermissionRequest buildApRequest(String permissionId, String meteringPointId) {
+        return new DePermissionRequestBuilder()
+                .permissionId(permissionId)
+                .meteringPointId(meteringPointId)
+                .build();
+    }
+
+    @Test
+    void fetchAccountingPointData_validResponse_mapsToDto() {
+        String body = """
+                {
+                  "meteringPointId": "malo-1",
+                  "customerId": "42",
+                  "energyType": "ELECTRICITY",
+                  "direction": "Consumption",
+                  "deliveryAddress": {
+                    "streetName": "Hauptstraße",
+                    "city": "Berlin",
+                    "country": "DE"
+                  },
+                  "contractParty": {
+                    "firstName": "Max",
+                    "surName": "Mustermann"
+                  }
+                }
+                """;
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(body));
+
+        DePermissionRequest request = buildApRequest("perm-ap-1", "malo-1");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "test-token"))
+                .assertNext(data -> {
+                    assertThat(data.meteringPointId()).isEqualTo("malo-1");
+                    assertThat(data.customerId()).isEqualTo("42");
+                    assertThat(data.deliveryAddress().city()).isEqualTo("Berlin");
+                    assertThat(data.contractParty().surName()).isEqualTo("Mustermann");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void fetchAccountingPointData_sendsQueryParamAndBearer() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"meteringPointId\":\"malo-q\"}"));
+
+        DePermissionRequest request = buildApRequest("perm-ap-q", "malo-q");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "ap-bearer"))
+                .assertNext(data -> assertThat(data.meteringPointId()).isEqualTo("malo-q"))
+                .verifyComplete();
+
+        RecordedRequest recorded = takeLatestRequest();
+        assertThat(recorded).isNotNull();
+        assertThat(recorded.getPath()).startsWith("/meters/accounting-point?meteringPointId=malo-q");
+        assertThat(recorded.getHeader("Authorization")).isEqualTo("Bearer ap-bearer");
+    }
+
+    @Test
+    void fetchAccountingPointData_400_throwsBadRequestException_noRetry() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"Success\":false,\"Message\":\"meteringPointId is required.\"}"));
+
+        DePermissionRequest request = buildApRequest("perm-ap-400", "malo-400");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(EtaPlusBadRequestException.class);
+                    assertThat(((EtaPlusBadRequestException) error).statusCode()).isEqualTo(400);
+                    assertThat(error.getMessage()).contains("perm-ap-400");
+                })
+                .verify();
+    }
+
+    @Test
+    void fetchAccountingPointData_401_throwsAuthenticationException_noRetry() {
+        server.enqueue(new MockResponse().setResponseCode(401));
+
+        DePermissionRequest request = buildApRequest("perm-ap-401", "malo-401");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(AuthenticationException.class);
+                    assertThat(((AuthenticationException) error).statusCode()).isEqualTo(401);
+                    assertThat(error.getMessage()).contains("perm-ap-401");
+                })
+                .verify();
+    }
+
+    @Test
+    void fetchAccountingPointData_403_throwsForbiddenException_noRetry() {
+        server.enqueue(new MockResponse().setResponseCode(403));
+
+        DePermissionRequest request = buildApRequest("perm-ap-403", "malo-403");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(EtaPlusForbiddenException.class);
+                    assertThat(((EtaPlusForbiddenException) error).statusCode()).isEqualTo(403);
+                })
+                .verify();
+    }
+
+    @Test
+    void fetchAccountingPointData_404_throwsNotFoundException_noRetry() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"Success\":false,\"Message\":\"Device malo-404 not found.\"}"));
+
+        DePermissionRequest request = buildApRequest("perm-ap-404", "malo-404");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(EtaPlusNotFoundException.class);
+                    assertThat(((EtaPlusNotFoundException) error).statusCode()).isEqualTo(404);
+                })
+                .verify();
+    }
+
+    @Test
+    void fetchAccountingPointData_429_retriesAndThrowsRateLimitException() {
+        for (int i = 0; i < 4; i++) {
+            server.enqueue(new MockResponse().setResponseCode(429));
+        }
+        DePermissionRequest request = buildApRequest("perm-ap-429", "malo-429");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(RateLimitException.class);
+                    assertThat(error.getMessage()).contains("perm-ap-429");
+                })
+                .verify();
+
+        assertThat(server.getRequestCount()).isGreaterThan(1);
+    }
+
+    @Test
+    void fetchAccountingPointData_429ThenRecovers_returnsData() {
+        server.enqueue(new MockResponse().setResponseCode(429));
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"meteringPointId\":\"malo-recover\"}"));
+
+        DePermissionRequest request = buildApRequest("perm-ap-recover", "malo-recover");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "token"))
+                .assertNext(data -> assertThat(data.meteringPointId()).isEqualTo("malo-recover"))
+                .verifyComplete();
+    }
+
+    @Test
+    void fetchAccountingPointData_500_retriesAndThrowsServerException() {
+        for (int i = 0; i < 4; i++) {
+            server.enqueue(new MockResponse().setResponseCode(500));
+        }
+        DePermissionRequest request = buildApRequest("perm-ap-500", "malo-500");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(EtaPlusServerException.class);
+                    assertThat(((EtaPlusServerException) error).statusCode()).isEqualTo(500);
+                })
+                .verify();
+    }
+
+    @Test
+    void fetchAccountingPointData_malformedJson_throwsDeserializationException() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{not valid json"));
+
+        DePermissionRequest request = buildApRequest("perm-ap-bad", "malo-bad");
+
+        StepVerifier.create(apiClient.fetchAccountingPointData(request, "token"))
+                .expectErrorSatisfies(error -> assertThat(error).isInstanceOf(DeserializationException.class))
+                .verify();
+    }
+
+    @Test
+    void fetchAccountingPointData_assertDtoTypeForCompiler() {
+        EtaPlusAccountingPointData ignored = new EtaPlusAccountingPointData(
+                "malo", null, null, null, null, null);
+        assertThat(ignored.meteringPointId()).isEqualTo("malo");
     }
 }

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/config/DeEtaPlusConfigurationTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/config/DeEtaPlusConfigurationTest.java
@@ -39,6 +39,7 @@ class DeEtaPlusConfigurationTest {
                     DeEtaPlusConfiguration config = context.getBean(DeEtaPlusConfiguration.class);
                     assertThat(config.apiBaseUrl()).isEqualTo("https://int.eta-plus.com/api");
                     assertThat(config.meteredDataEndpoint()).isEqualTo("/meters/historical");
+                    assertThat(config.accountingPointEndpoint()).isEqualTo("/meters/accounting-point");
                     assertThat(config.permissionCheckEndpoint()).isEqualTo("/v1/permissions/{id}");
                     assertThat(config.responseTimeoutSeconds()).isEqualTo(30);
                     assertThat(config.retryMaxAttempts()).isEqualTo(3);

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/config/EtaPlusClientConfigTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/config/EtaPlusClientConfigTest.java
@@ -42,6 +42,7 @@ class EtaPlusClientConfigTest {
                 "my-client",
                 "my-secret",
                 "/meters/historical",
+                "/meters/accounting-point",
                 "/v1/permissions/{id}",
                 30,
                 3, 2,

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/permission/handlers/AccountingPointDataHandlerTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/permission/handlers/AccountingPointDataHandlerTest.java
@@ -1,0 +1,308 @@
+package energy.eddie.regionconnector.de.eta.permission.handlers;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.dataneeds.needs.AccountingPointDataNeed;
+import energy.eddie.dataneeds.needs.DataNeed;
+import energy.eddie.dataneeds.needs.ValidatedHistoricalDataDataNeed;
+import energy.eddie.dataneeds.services.DataNeedsService;
+import energy.eddie.regionconnector.de.eta.auth.AuthTokenResponse;
+import energy.eddie.regionconnector.de.eta.auth.EtaAuthService;
+import energy.eddie.regionconnector.de.eta.client.EtaPlusApiClient;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.AuthenticationException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.DeserializationException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusBadRequestException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusForbiddenException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusNotFoundException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusServerException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusClientExceptions.EtaPlusTimeoutException;
+import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusOperationExceptions.RateLimitException;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.persistence.DePermissionRequestRepository;
+import energy.eddie.regionconnector.de.eta.permission.request.events.AcceptedEvent;
+import energy.eddie.regionconnector.de.eta.permission.request.events.SimpleEvent;
+import energy.eddie.regionconnector.de.eta.providers.AccountingPointDataStream;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusAccountingPointData;
+import energy.eddie.regionconnector.shared.event.sourcing.EventBus;
+import energy.eddie.regionconnector.shared.event.sourcing.EventBusImpl;
+import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class AccountingPointDataHandlerTest {
+
+    private static final String PID = "perm-ap-1";
+    private static final String MPID = "malo-1";
+    private static final String DATA_NEED_ID = "dn-1";
+    private static final String ACCESS_TOKEN = "initial-access";
+    private static final String REFRESH_TOKEN = "initial-refresh";
+
+    private DePermissionRequestRepository repository;
+    private DataNeedsService dataNeedsService;
+    private EtaPlusApiClient apiClient;
+    private EtaAuthService authService;
+    private AccountingPointDataStream stream;
+    private Outbox outbox;
+    private EventBus eventBus;
+    private AccountingPointDataNeed apDataNeed;
+    private DePermissionRequest pr;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(DePermissionRequestRepository.class);
+        dataNeedsService = mock(DataNeedsService.class);
+        apiClient = mock(EtaPlusApiClient.class);
+        authService = mock(EtaAuthService.class);
+        stream = mock(AccountingPointDataStream.class);
+        outbox = mock(Outbox.class);
+        eventBus = new EventBusImpl();
+        apDataNeed = mock(AccountingPointDataNeed.class);
+
+        pr = new DePermissionRequestBuilder()
+                .permissionId(PID)
+                .meteringPointId(MPID)
+                .dataNeedId(DATA_NEED_ID)
+                .accessToken(ACCESS_TOKEN)
+                .refreshToken(REFRESH_TOKEN)
+                .build();
+
+        // Construct handler so it subscribes to the event bus
+        new AccountingPointDataHandler(
+                eventBus, repository, dataNeedsService, apiClient, authService, stream, outbox);
+    }
+
+    private void emit(AcceptedEvent event) {
+        eventBus.emit(event);
+    }
+
+    private EtaPlusAccountingPointData samplePayload() {
+        return new EtaPlusAccountingPointData(MPID, "42", "ELECTRICITY", "Consumption", null, null);
+    }
+
+    @Test
+    void nonApDataNeed_skipsFetch() {
+        when(repository.findByPermissionId(PID)).thenReturn(Optional.of(pr));
+        when(dataNeedsService.getById(DATA_NEED_ID)).thenReturn(mock(ValidatedHistoricalDataDataNeed.class));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        verifyNoInteractions(apiClient);
+        verifyNoInteractions(stream);
+        verifyNoInteractions(outbox);
+    }
+
+    @Test
+    void missingPermissionRequest_logsAndReturns() {
+        when(repository.findByPermissionId(PID)).thenReturn(Optional.empty());
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        verifyNoInteractions(apiClient);
+        verifyNoInteractions(stream);
+        verifyNoInteractions(outbox);
+    }
+
+    @Test
+    void apDataNeed_200_publishesAndCommitsFulfilled() {
+        when(repository.findByPermissionId(PID)).thenReturn(Optional.of(pr));
+        when(dataNeedsService.getById(DATA_NEED_ID)).thenReturn(apDataNeed);
+        EtaPlusAccountingPointData payload = samplePayload();
+        when(apiClient.fetchAccountingPointData(pr, ACCESS_TOKEN)).thenReturn(Mono.just(payload));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        verify(stream).publish(pr, payload);
+        assertCommitted(PermissionProcessStatus.FULFILLED);
+        verifyNoInteractions(authService);
+    }
+
+    @Test
+    void apDataNeed_403_marksUnfulfillable() {
+        primeFetchFailure(new EtaPlusForbiddenException("403", 403, new RuntimeException()));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertNoStreamPublish();
+        assertCommitted(PermissionProcessStatus.UNFULFILLABLE);
+    }
+
+    @Test
+    void apDataNeed_404_marksUnfulfillable() {
+        primeFetchFailure(new EtaPlusNotFoundException("404", 404, new RuntimeException()));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertNoStreamPublish();
+        assertCommitted(PermissionProcessStatus.UNFULFILLABLE);
+    }
+
+    @Test
+    void apDataNeed_400_marksUnfulfillable() {
+        primeFetchFailure(new EtaPlusBadRequestException("400", 400, new RuntimeException()));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertNoStreamPublish();
+        assertCommitted(PermissionProcessStatus.UNFULFILLABLE);
+    }
+
+    @Test
+    void apDataNeed_429_marksUnableToSend() {
+        primeFetchFailure(new RateLimitException("429"));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertNoStreamPublish();
+        assertCommitted(PermissionProcessStatus.UNABLE_TO_SEND);
+    }
+
+    @Test
+    void apDataNeed_5xx_marksUnableToSend() {
+        primeFetchFailure(new EtaPlusServerException("500", 500, new RuntimeException()));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertCommitted(PermissionProcessStatus.UNABLE_TO_SEND);
+    }
+
+    @Test
+    void apDataNeed_timeout_marksUnableToSend() {
+        primeFetchFailure(new EtaPlusTimeoutException("timeout", new RuntimeException()));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertCommitted(PermissionProcessStatus.UNABLE_TO_SEND);
+    }
+
+    @Test
+    void apDataNeed_deserializationError_marksUnableToSend() {
+        primeFetchFailure(new DeserializationException("bad", new RuntimeException()));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertCommitted(PermissionProcessStatus.UNABLE_TO_SEND);
+    }
+
+    @Test
+    void apDataNeed_unexpectedException_marksUnableToSend() {
+        primeFetchFailure(new RuntimeException("boom"));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertCommitted(PermissionProcessStatus.UNABLE_TO_SEND);
+    }
+
+    @Test
+    void apDataNeed_401_thenRefreshSucceeds_thenSecondFetchSucceeds_marksFulfilled() {
+        when(repository.findByPermissionId(PID)).thenReturn(Optional.of(pr));
+        when(dataNeedsService.getById(DATA_NEED_ID)).thenReturn(apDataNeed);
+        when(apiClient.fetchAccountingPointData(pr, ACCESS_TOKEN))
+                .thenReturn(Mono.error(new AuthenticationException("401", 401, new RuntimeException())));
+        when(authService.refresh(REFRESH_TOKEN))
+                .thenReturn(Mono.just(new AuthTokenResponse(
+                        new AuthTokenResponse.TokenData("new-access", "new-refresh"), true)));
+        EtaPlusAccountingPointData payload = samplePayload();
+        when(apiClient.fetchAccountingPointData(pr, "new-access")).thenReturn(Mono.just(payload));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        verify(stream).publish(pr, payload);
+        assertCommitted(PermissionProcessStatus.FULFILLED);
+        verify(apiClient, times(1)).fetchAccountingPointData(pr, ACCESS_TOKEN);
+        verify(apiClient, times(1)).fetchAccountingPointData(pr, "new-access");
+    }
+
+    @Test
+    void apDataNeed_401_refreshFails_marksUnableToSend() {
+        when(repository.findByPermissionId(PID)).thenReturn(Optional.of(pr));
+        when(dataNeedsService.getById(DATA_NEED_ID)).thenReturn(apDataNeed);
+        when(apiClient.fetchAccountingPointData(pr, ACCESS_TOKEN))
+                .thenReturn(Mono.error(new AuthenticationException("401", 401, new RuntimeException())));
+        when(authService.refresh(REFRESH_TOKEN))
+                .thenReturn(Mono.just(new AuthTokenResponse(null, false)));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        // Initial fetch with the original token, no retry with a different token
+        verify(apiClient, times(1)).fetchAccountingPointData(pr, ACCESS_TOKEN);
+        verify(apiClient, times(1)).fetchAccountingPointData(eq(pr), anyString());
+        assertNoStreamPublish();
+        assertCommitted(PermissionProcessStatus.UNABLE_TO_SEND);
+    }
+
+    @Test
+    void apDataNeed_401_refreshSucceeds_butSecondFetch401_marksUnableToSend() {
+        when(repository.findByPermissionId(PID)).thenReturn(Optional.of(pr));
+        when(dataNeedsService.getById(DATA_NEED_ID)).thenReturn(apDataNeed);
+        when(apiClient.fetchAccountingPointData(pr, ACCESS_TOKEN))
+                .thenReturn(Mono.error(new AuthenticationException("401", 401, new RuntimeException())));
+        when(authService.refresh(REFRESH_TOKEN))
+                .thenReturn(Mono.just(new AuthTokenResponse(
+                        new AuthTokenResponse.TokenData("new-access", "new-refresh"), true)));
+        when(apiClient.fetchAccountingPointData(pr, "new-access"))
+                .thenReturn(Mono.error(new AuthenticationException("401-again", 401, new RuntimeException())));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, REFRESH_TOKEN));
+
+        assertNoStreamPublish();
+        assertCommitted(PermissionProcessStatus.UNABLE_TO_SEND);
+        // Verify no third fetch attempt: only the two we set up
+        verify(apiClient, times(1)).fetchAccountingPointData(pr, ACCESS_TOKEN);
+        verify(apiClient, times(1)).fetchAccountingPointData(pr, "new-access");
+    }
+
+    @Test
+    void apDataNeed_401_noRefreshToken_marksUnableToSend() {
+        DePermissionRequest prWithoutRefresh = new DePermissionRequestBuilder()
+                .permissionId(PID)
+                .meteringPointId(MPID)
+                .dataNeedId(DATA_NEED_ID)
+                .accessToken(ACCESS_TOKEN)
+                .build();
+        when(repository.findByPermissionId(PID)).thenReturn(Optional.of(prWithoutRefresh));
+        when(dataNeedsService.getById(DATA_NEED_ID)).thenReturn(apDataNeed);
+        when(apiClient.fetchAccountingPointData(prWithoutRefresh, ACCESS_TOKEN))
+                .thenReturn(Mono.error(new AuthenticationException("401", 401, new RuntimeException())));
+
+        emit(new AcceptedEvent(PID, ACCESS_TOKEN, null));
+
+        verifyNoInteractions(authService);
+        assertNoStreamPublish();
+        assertCommitted(PermissionProcessStatus.UNABLE_TO_SEND);
+    }
+
+    // ----- helpers -----
+
+    private void primeFetchFailure(Throwable error) {
+        when(repository.findByPermissionId(PID)).thenReturn(Optional.of(pr));
+        when(dataNeedsService.getById(DATA_NEED_ID)).thenReturn(apDataNeed);
+        when(apiClient.fetchAccountingPointData(pr, ACCESS_TOKEN)).thenReturn(Mono.error(error));
+    }
+
+    private void assertNoStreamPublish() {
+        verify(stream, never()).publish(any(DePermissionRequest.class), any(EtaPlusAccountingPointData.class));
+    }
+
+    private void assertCommitted(PermissionProcessStatus expected) {
+        ArgumentCaptor<SimpleEvent> captor = ArgumentCaptor.forClass(SimpleEvent.class);
+        verify(outbox).commit(captor.capture());
+        SimpleEvent committed = captor.getValue();
+        assertThat(committed.permissionId()).isEqualTo(PID);
+        assertThat(committed.status()).isEqualTo(expected);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/permission/request/events/AcceptedEventTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/permission/request/events/AcceptedEventTest.java
@@ -1,0 +1,29 @@
+package energy.eddie.regionconnector.de.eta.permission.request.events;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AcceptedEventTest {
+
+    @Test
+    void constructor_setsPermissionIdStatusAndTokens() {
+        var event = new AcceptedEvent("test-permission-id", "access-token", "refresh-token");
+
+        assertThat(event.permissionId()).isEqualTo("test-permission-id");
+        assertThat(event.status()).isEqualTo(PermissionProcessStatus.ACCEPTED);
+        assertThat(event.accessToken()).isEqualTo("access-token");
+        assertThat(event.refreshToken()).contains("refresh-token");
+        assertThat(event.eventCreated()).isNotNull();
+    }
+
+    @Test
+    void constructor_allowsNullRefreshToken() {
+        var event = new AcceptedEvent("test-permission-id", "access-token", null);
+
+        assertThat(event.accessToken()).isEqualTo("access-token");
+        assertThat(event.refreshToken()).isEmpty();
+    }
+}
+

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/permission/request/events/AccountingPointValidatedEventTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/permission/request/events/AccountingPointValidatedEventTest.java
@@ -1,0 +1,33 @@
+package energy.eddie.regionconnector.de.eta.permission.request.events;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AccountingPointValidatedEventTest {
+
+    @Test
+    void constructor_setsAllFieldsAndStatus() {
+        LocalDate start = LocalDate.of(2026, 5, 1);
+        LocalDate end = LocalDate.of(2026, 6, 1);
+
+        AccountingPointValidatedEvent event = new AccountingPointValidatedEvent("pid", start, end);
+
+        assertThat(event.permissionId()).isEqualTo("pid");
+        assertThat(event.status()).isEqualTo(PermissionProcessStatus.VALIDATED);
+        assertThat(event.start()).isEqualTo(start);
+        assertThat(event.end()).isEqualTo(end);
+        assertThat(event.eventCreated()).isNotNull();
+    }
+
+    @Test
+    void protectedNoArgConstructor_initialisesNullsForJpa() {
+        AccountingPointValidatedEvent event = new AccountingPointValidatedEvent() {};
+
+        assertThat(event.start()).isNull();
+        assertThat(event.end()).isNull();
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/permission/request/events/StartPollingEventTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/permission/request/events/StartPollingEventTest.java
@@ -1,0 +1,31 @@
+package energy.eddie.regionconnector.de.eta.permission.request.events;
+
+import energy.eddie.api.agnostic.process.model.events.InternalPermissionEvent;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StartPollingEventTest {
+
+    @Test
+    void constructor_setsPermissionIdAndStatus() {
+        // When
+        var event = new StartPollingEvent("test-permission-id");
+
+        // Then
+        assertThat(event.permissionId()).isEqualTo("test-permission-id");
+        assertThat(event.status()).isEqualTo(PermissionProcessStatus.ACCEPTED);
+        assertThat(event.eventCreated()).isNotNull();
+    }
+
+    @Test
+    void startPollingEvent_implementsInternalPermissionEvent() {
+        // When
+        var event = new StartPollingEvent("test-permission-id");
+
+        // Then
+        assertThat(event).isInstanceOf(InternalPermissionEvent.class);
+    }
+}
+

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusAccountingPointDataTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusAccountingPointDataTest.java
@@ -1,0 +1,205 @@
+package energy.eddie.regionconnector.de.eta.providers;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EtaPlusAccountingPointDataTest {
+
+    private final JsonMapper mapper = new JsonMapper();
+
+    @Test
+    void deserialize_fullElectricityDocument_allFieldsPresent() {
+        String body = """
+                {
+                  "meteringPointId": "DE0001234567890123456789012345",
+                  "customerId": "42",
+                  "energyType": "ELECTRICITY",
+                  "direction": "Consumption",
+                  "deliveryAddress": {
+                    "streetName": "Hauptstraße",
+                    "buildingNumber": "12",
+                    "postalCode": "10115",
+                    "city": "Berlin",
+                    "country": "DE",
+                    "addressSuffix": "Hinterhof"
+                  },
+                  "contractParty": {
+                    "firstName": "Max",
+                    "surName": "Mustermann",
+                    "email": "max@example.de"
+                  }
+                }
+                """;
+
+        EtaPlusAccountingPointData data = mapper.readValue(body, EtaPlusAccountingPointData.class);
+
+        assertThat(data.meteringPointId()).isEqualTo("DE0001234567890123456789012345");
+        assertThat(data.customerId()).isEqualTo("42");
+        assertThat(data.energyType()).isEqualTo("ELECTRICITY");
+        assertThat(data.direction()).isEqualTo("Consumption");
+
+        EtaPlusAccountingPointData.Address addr = data.deliveryAddress();
+        assertThat(addr).isNotNull();
+        assertThat(addr.streetName()).isEqualTo("Hauptstraße");
+        assertThat(addr.buildingNumber()).isEqualTo("12");
+        assertThat(addr.postalCode()).isEqualTo("10115");
+        assertThat(addr.city()).isEqualTo("Berlin");
+        assertThat(addr.country()).isEqualTo("DE");
+        assertThat(addr.addressSuffix()).isEqualTo("Hinterhof");
+
+        EtaPlusAccountingPointData.ContractParty cp = data.contractParty();
+        assertThat(cp).isNotNull();
+        assertThat(cp.firstName()).isEqualTo("Max");
+        assertThat(cp.surName()).isEqualTo("Mustermann");
+        assertThat(cp.companyName()).isNull();
+        assertThat(cp.email()).isEqualTo("max@example.de");
+    }
+
+    @Test
+    void deserialize_minimalNaturalGasDocument_subObjectsAbsent() {
+        String body = """
+                {
+                  "meteringPointId": "DE9876543210987654321098765432",
+                  "energyType": "NATURAL_GAS",
+                  "direction": "Consumption"
+                }
+                """;
+
+        EtaPlusAccountingPointData data = mapper.readValue(body, EtaPlusAccountingPointData.class);
+
+        assertThat(data.meteringPointId()).isEqualTo("DE9876543210987654321098765432");
+        assertThat(data.customerId()).isNull();
+        assertThat(data.energyType()).isEqualTo("NATURAL_GAS");
+        assertThat(data.direction()).isEqualTo("Consumption");
+        assertThat(data.deliveryAddress()).isNull();
+        assertThat(data.contractParty()).isNull();
+    }
+
+    @Test
+    void deserialize_prosumerCompany_companyNameWithoutFirstNameSurname() {
+        String body = """
+                {
+                  "meteringPointId": "DE5555555555555555555555555555",
+                  "customerId": "4711",
+                  "energyType": "ELECTRICITY",
+                  "direction": "Generation",
+                  "deliveryAddress": {
+                    "streetName": "Marienplatz",
+                    "buildingNumber": "1",
+                    "postalCode": "80331",
+                    "city": "München",
+                    "country": "DE"
+                  },
+                  "contractParty": {
+                    "companyName": "Solar Beispiel GmbH",
+                    "email": "ap@solar-beispiel.de"
+                  }
+                }
+                """;
+
+        EtaPlusAccountingPointData data = mapper.readValue(body, EtaPlusAccountingPointData.class);
+
+        assertThat(data.deliveryAddress()).isNotNull();
+        assertThat(data.deliveryAddress().addressSuffix()).isNull();
+
+        EtaPlusAccountingPointData.ContractParty cp = data.contractParty();
+        assertThat(cp).isNotNull();
+        assertThat(cp.companyName()).isEqualTo("Solar Beispiel GmbH");
+        assertThat(cp.firstName()).isNull();
+        assertThat(cp.surName()).isNull();
+        assertThat(cp.email()).isEqualTo("ap@solar-beispiel.de");
+    }
+
+    @Test
+    void deserialize_unknownTopLevelField_ignoredForwardCompat() {
+        String body = """
+                {
+                  "meteringPointId": "DE0001234567890123456789012345",
+                  "energyType": "ELECTRICITY",
+                  "futureField": "ignored-by-jackson"
+                }
+                """;
+
+        EtaPlusAccountingPointData data = mapper.readValue(body, EtaPlusAccountingPointData.class);
+
+        assertThat(data.meteringPointId()).isEqualTo("DE0001234567890123456789012345");
+        assertThat(data.energyType()).isEqualTo("ELECTRICITY");
+    }
+
+    @Test
+    void deserialize_unknownNestedAddressField_ignoredForwardCompat() {
+        String body = """
+                {
+                  "meteringPointId": "DE0001234567890123456789012345",
+                  "deliveryAddress": {
+                    "streetName": "Hauptstraße",
+                    "staircase": "A",
+                    "floor": "2"
+                  }
+                }
+                """;
+
+        EtaPlusAccountingPointData data = mapper.readValue(body, EtaPlusAccountingPointData.class);
+
+        assertThat(data.deliveryAddress()).isNotNull();
+        assertThat(data.deliveryAddress().streetName()).isEqualTo("Hauptstraße");
+    }
+
+    @Test
+    void deserialize_unknownNestedContractPartyField_ignoredForwardCompat() {
+        String body = """
+                {
+                  "meteringPointId": "DE0001234567890123456789012345",
+                  "contractParty": {
+                    "firstName": "Max",
+                    "salutation": "Herr",
+                    "vatNumber": "DE123"
+                  }
+                }
+                """;
+
+        EtaPlusAccountingPointData data = mapper.readValue(body, EtaPlusAccountingPointData.class);
+
+        assertThat(data.contractParty()).isNotNull();
+        assertThat(data.contractParty().firstName()).isEqualTo("Max");
+    }
+
+    @Test
+    void deserialize_explicitJsonNullLeaf_treatedAsAbsent() {
+        String body = """
+                {
+                  "meteringPointId": "DE0001234567890123456789012345",
+                  "customerId": null,
+                  "deliveryAddress": {
+                    "streetName": "Hauptstraße",
+                    "city": null
+                  }
+                }
+                """;
+
+        EtaPlusAccountingPointData data = mapper.readValue(body, EtaPlusAccountingPointData.class);
+
+        assertThat(data.customerId()).isNull();
+        assertThat(data.deliveryAddress()).isNotNull();
+        assertThat(data.deliveryAddress().streetName()).isEqualTo("Hauptstraße");
+        assertThat(data.deliveryAddress().city()).isNull();
+    }
+
+    @Test
+    void deserialize_subObjectExplicitNull_treatedAsAbsentSubObject() {
+        String body = """
+                {
+                  "meteringPointId": "DE0001234567890123456789012345",
+                  "deliveryAddress": null,
+                  "contractParty": null
+                }
+                """;
+
+        EtaPlusAccountingPointData data = mapper.readValue(body, EtaPlusAccountingPointData.class);
+
+        assertThat(data.deliveryAddress()).isNull();
+        assertThat(data.contractParty()).isNull();
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeValidatedHistoricalDataEnvelopeProviderTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeValidatedHistoricalDataEnvelopeProviderTest.java
@@ -38,7 +38,7 @@ class DeValidatedHistoricalDataEnvelopeProviderTest {
                         CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME, "fallback"),
                 new DeEtaPlusConfiguration(
                         "ep-id", "http://api.url", "client-id", "client-secret",
-                        "/meters/historical", "/v1/permissions/{id}", 30,
+                        "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
                         3, 2, true, false, null, null)
         );
 

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelopeTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelopeTest.java
@@ -45,7 +45,7 @@ class IntermediateValidatedHistoricalDataEnvelopeTest {
     private final DeEtaPlusConfiguration deConfiguration = new DeEtaPlusConfiguration(
             ELIGIBLE_PARTY_ID,
             "http://api.url", "client-id", "client-secret",
-            "/meters/historical", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
             3, 2, true, false,
             null, null
     );

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/DeValidatedHistoricalDataMarketDocumentProviderTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/DeValidatedHistoricalDataMarketDocumentProviderTest.java
@@ -39,7 +39,7 @@ class DeValidatedHistoricalDataMarketDocumentProviderTest {
                         CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME, "fallback"),
                 new DeEtaPlusConfiguration(
                         "ep-id", "http://api.url", "client-id", "client-secret",
-                        "/meters/historical", "/v1/permissions/{id}", 30,
+                        "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
                         3, 2, true, false, null, null)
         );
 

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocumentTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocumentTest.java
@@ -45,7 +45,7 @@ class IntermediateValidatedHistoricalDataMarketDocumentTest {
     private final DeEtaPlusConfiguration deConfiguration = new DeEtaPlusConfiguration(
             ELIGIBLE_PARTY_ID,
             "http://api.url", "client-id", "client-secret",
-            "/meters/historical", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
             3, 2, true, false,
             null, null
     );

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestAuthorizationServiceTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestAuthorizationServiceTest.java
@@ -44,7 +44,7 @@ class PermissionRequestAuthorizationServiceTest {
     @SuppressWarnings("UnusedVariable") // injected into service via @InjectMocks
     private DeEtaPlusConfiguration configuration = new DeEtaPlusConfiguration(
             "test-party", "http://test-url", "api-client", "api-secret",
-            "/meters/historical", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
             3, 2, true, false,
             new DeEtaPlusConfiguration.AuthConfig("test-client", "secret", "tokenUrl", "authUrl",
                                                    "redirectUri",

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestCreationServiceTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestCreationServiceTest.java
@@ -7,15 +7,19 @@ import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.data.needs.*;
 import energy.eddie.dataneeds.exceptions.DataNeedNotFoundException;
 import energy.eddie.dataneeds.exceptions.UnsupportedDataNeedException;
+import energy.eddie.regionconnector.de.eta.dtos.CreatedPermissionRequest;
 import energy.eddie.regionconnector.de.eta.dtos.PermissionRequestForCreation;
+import energy.eddie.regionconnector.de.eta.permission.request.events.AccountingPointValidatedEvent;
 import energy.eddie.regionconnector.de.eta.permission.request.events.CreatedEvent;
 import energy.eddie.regionconnector.de.eta.permission.request.events.MalformedEvent;
 import energy.eddie.regionconnector.de.eta.permission.request.events.ValidatedEvent;
 import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
 import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
 
+import energy.eddie.regionconnector.de.eta.permission.request.events.PersistablePermissionEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -48,7 +52,7 @@ class PermissionRequestCreationServiceTest {
     @SuppressWarnings("UnusedVariable") // injected into service via @InjectMocks
     private final DeEtaPlusConfiguration configuration = new DeEtaPlusConfiguration(
             "partner", "http://api.url", "api-client", "api-secret",
-            "/meters/historical", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
             3, 2, true, false,
             new DeEtaPlusConfiguration.AuthConfig(
                     "client-1", "secret", "token-url", "http://auth.url", "http://redirect.uri",
@@ -91,19 +95,35 @@ class PermissionRequestCreationServiceTest {
     }
 
     @Test
-    void createPermissionRequestWhenAccountingPointDataNeedShouldThrowUnsupportedAndCommitMalformed() {
+    void createPermissionRequestWhenAccountingPointDataNeedShouldSucceedAndCommitAccountingPointValidated()
+            throws Exception {
         PermissionRequestForCreation request = new PermissionRequestForCreation(CONNECTION_ID, "dn-1", "mp-1");
-        Timeframe timeframe = new Timeframe(
-                LocalDate.now(ZoneId.systemDefault()),
-                LocalDate.now(ZoneId.systemDefault()).plusDays(1));
+        LocalDate start = LocalDate.now(ZoneId.systemDefault());
+        LocalDate end = LocalDate.now(ZoneId.systemDefault()).plusDays(1);
+        Timeframe timeframe = new Timeframe(start, end);
         when(dataNeedCalculationService.calculate(anyString()))
                 .thenReturn(new AccountingPointDataNeedResult(timeframe));
 
-        assertThatThrownBy(() -> service.createPermissionRequest(request))
-                .isInstanceOf(UnsupportedDataNeedException.class);
+        CreatedPermissionRequest result = service.createPermissionRequest(request);
 
+        assertThat(result).isNotNull();
+        assertThat(result.permissionId()).isNotNull();
+        assertThat(result.redirectUri()).isNotEmpty();
         verify(outbox).commit(any(CreatedEvent.class));
-        verify(outbox).commit(any(MalformedEvent.class));
+        verify(outbox).commit(any(AccountingPointValidatedEvent.class));
+        verify(outbox, never()).commit(any(ValidatedEvent.class));
+        verify(outbox, never()).commit(any(MalformedEvent.class));
+
+        ArgumentCaptor<PersistablePermissionEvent> captor =
+                ArgumentCaptor.forClass(PersistablePermissionEvent.class);
+        verify(outbox, atLeastOnce()).commit(captor.capture());
+        AccountingPointValidatedEvent apEvent = captor.getAllValues().stream()
+                .filter(AccountingPointValidatedEvent.class::isInstance)
+                .map(AccountingPointValidatedEvent.class::cast)
+                .findFirst().orElseThrow();
+        assertThat(apEvent.permissionId()).isEqualTo(result.permissionId());
+        assertThat(apEvent.start()).isEqualTo(start);
+        assertThat(apEvent.end()).isEqualTo(end);
     }
 
     @Test


### PR DESCRIPTION
Wires `AccountingPointDataNeed` end-to-end on the DE-ETA region connector
against the backend's `GET /api/meters/accounting-point` endpoint.

Closes [GH-#2193].

## What this PR includes

1. **Permission-creation path** accepts `AccountingPointDataNeedResult` and
   commits a new dedicated `AccountingPointValidatedEvent` carrying the
   permission timeframe (no granularity).
2. **On `AcceptedEvent`** for an accounting-point permission, a new
   `AccountingPointDataHandler` performs a **single-shot** fetch against
   `/api/meters/accounting-point` using the customer's bearer token from the
   event.
3. **On 200**, the parsed payload is published to a dedicated
   `AccountingPointDataStream` flux and a `FULFILLED` `SimpleEvent` is
   committed to the outbox.
4. **Raw-data emission**: the existing `JsonRawDataProvider` bean now merges
   both the VHD and AP streams, so AP fetches automatically surface as
   `RawDataMessage` on the agnostic outbound flux.
5. **Refresh-on-401 recovery**: on a 401 from the AP endpoint, the handler
   exchanges the refresh token from the same `AcceptedEvent` for a fresh
   access token via a new `EtaAuthService.refresh(...)` method (NL pattern,
   scoped to one-shot) and retries the fetch exactly once. The refreshed
   token is **not** persisted.
6. **Error mapping** for the one-shot fetch:

   | Wire                                                     | Permission state                                                                                                  |
   |----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
   | 400 Bad Request                                          | `UNFULFILLABLE` (programmer error, terminal)                                                                      |
   | 401 → refresh OK → 200                                   | `FULFILLED`                                                                                                       |
   | 401 → refresh fail / no refresh token / second-fetch 401 | `UNABLE_TO_SEND`                                                                                                  |
   | 403 Forbidden                                            | `UNFULFILLABLE` (per FR-Enedis precedent — fresh-token argument; defensive only, backend does not emit 403 today) |
   | 404 Not Found                                            | `UNFULFILLABLE` (definitive: device doesn't exist)                                                                |
   | 429 / 5xx                                                | `UNABLE_TO_SEND` after `retrySpec` exhaustion                                                                     |
   | timeout / decoding error                                 | `UNABLE_TO_SEND`                                                                                                  |
