### PR TITLE
GH-2194: map accounting point data to CIM v0.82 envelopes

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/request/events/AccountingPointValidatedEvent.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/request/events/AccountingPointValidatedEvent.java
@@ -18,10 +18,10 @@ import java.time.LocalDate;
 @SuppressWarnings({"NullAway", "unused"})
 public class AccountingPointValidatedEvent extends PersistablePermissionEvent {
 
-    @Column(name = "permission_start")
+    @Column(name = "data_start")
     private final LocalDate start;
 
-    @Column(name = "permission_end")
+    @Column(name = "data_end")
     private final LocalDate end;
 
     public AccountingPointValidatedEvent(String permissionId, LocalDate start, LocalDate end) {

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeEtaAccountingPointEnvelopeProvider.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeEtaAccountingPointEnvelopeProvider.java
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.providers.v0_82;
+
+import energy.eddie.api.agnostic.MessageStream;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.cim.v0_82.ap.AccountingPointEnvelope;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.providers.AccountingPointDataStream;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableAccountingPointData;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+/**
+ * CIM v0.82 Accounting Point provider for the German ETA Plus connector.
+ */
+@Component
+public class DeEtaAccountingPointEnvelopeProvider {
+
+    private final Flux<IdentifiableAccountingPointData> identifiableData;
+    private final CommonInformationModelConfiguration cimConfig;
+    private final DeEtaPlusConfiguration deConfiguration;
+
+    public DeEtaAccountingPointEnvelopeProvider(
+            AccountingPointDataStream stream,
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+            CommonInformationModelConfiguration cimConfig,
+            DeEtaPlusConfiguration deConfiguration
+    ) {
+        this.identifiableData = stream.accountingPointData();
+        this.cimConfig = cimConfig;
+        this.deConfiguration = deConfiguration;
+    }
+
+    @MessageStream(AccountingPointEnvelope.class)
+    public Flux<AccountingPointEnvelope> getAccountingPointMarketDocumentsStream() {
+        return identifiableData
+                .map(data -> new IntermediateAccountingPointDataMarketDocument(cimConfig, deConfiguration, data))
+                .map(IntermediateAccountingPointDataMarketDocument::toEnvelope);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateAccountingPointDataMarketDocument.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateAccountingPointDataMarketDocument.java
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.providers.v0_82;
+
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.cim.CommonInformationModelVersions;
+import energy.eddie.cim.v0_82.ap.AccountingPointComplexType;
+import energy.eddie.cim.v0_82.ap.AccountingPointEnvelope;
+import energy.eddie.cim.v0_82.ap.AccountingPointMarketDocumentComplexType;
+import energy.eddie.cim.v0_82.ap.AddressComplexType;
+import energy.eddie.cim.v0_82.ap.AddressRoleType;
+import energy.eddie.cim.v0_82.ap.CodingSchemeTypeList;
+import energy.eddie.cim.v0_82.ap.CommodityKind;
+import energy.eddie.cim.v0_82.ap.ContractPartyComplexType;
+import energy.eddie.cim.v0_82.ap.ContractPartyRoleType;
+import energy.eddie.cim.v0_82.ap.DirectionTypeList;
+import energy.eddie.cim.v0_82.ap.MeasurementPointIDStringComplexType;
+import energy.eddie.cim.v0_82.ap.MessageTypeList;
+import energy.eddie.cim.v0_82.ap.PartyIDStringComplexType;
+import energy.eddie.cim.v0_82.ap.RoleTypeList;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusAccountingPointData;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableAccountingPointData;
+import energy.eddie.regionconnector.shared.cim.v0_82.EsmpDateTime;
+import energy.eddie.regionconnector.shared.cim.v0_82.ap.APEnvelope;
+import jakarta.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+/**
+ * Maps a single ETA Plus accounting-point response to a CIM v0.82 {@link AccountingPointEnvelope}.
+ *
+ * <p>One MP → one envelope → one {@link AccountingPointComplexType}.
+ */
+class IntermediateAccountingPointDataMarketDocument {
+    private static final Logger LOGGER = LoggerFactory.getLogger(IntermediateAccountingPointDataMarketDocument.class);
+
+    private final CommonInformationModelConfiguration cimConfig;
+    private final DeEtaPlusConfiguration deConfiguration;
+    private final IdentifiableAccountingPointData identifiableData;
+
+    IntermediateAccountingPointDataMarketDocument(
+            CommonInformationModelConfiguration cimConfig,
+            DeEtaPlusConfiguration deConfiguration,
+            IdentifiableAccountingPointData identifiableData
+    ) {
+        this.cimConfig = cimConfig;
+        this.deConfiguration = deConfiguration;
+        this.identifiableData = identifiableData;
+    }
+
+    public AccountingPointEnvelope toEnvelope() {
+        var permissionRequest = identifiableData.permissionRequest();
+        var payload = identifiableData.payload();
+        var senderId = permissionRequest.dataSourceInformation().meteredDataAdministratorId();
+
+        var ap = new AccountingPointMarketDocumentComplexType()
+                .withMRID(UUID.randomUUID().toString())
+                .withRevisionNumber(CommonInformationModelVersions.V0_82.version())
+                .withType(MessageTypeList.ACCOUNTING_POINT_MASTER_DATA)
+                .withCreatedDateTime(new EsmpDateTime(ZonedDateTime.now(ZoneOffset.UTC)).toString())
+                .withSenderMarketParticipantMarketRoleType(RoleTypeList.METERING_POINT_ADMINISTRATOR)
+                .withReceiverMarketParticipantMarketRoleType(RoleTypeList.CONSUMER)
+                .withSenderMarketParticipantMRID(
+                        new PartyIDStringComplexType()
+                                .withCodingScheme(CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME)
+                                .withValue(senderId)
+                )
+                .withReceiverMarketParticipantMRID(
+                        new PartyIDStringComplexType()
+                                .withCodingScheme(CodingSchemeTypeList.fromValue(
+                                        cimConfig.eligiblePartyNationalCodingScheme().value()))
+                                .withValue(deConfiguration.eligiblePartyId())
+                )
+                .withAccountingPointList(
+                        new AccountingPointMarketDocumentComplexType.AccountingPointList()
+                                .withAccountingPoints(accountingPoint(payload))
+                );
+
+        return new APEnvelope(ap, permissionRequest).wrap();
+    }
+
+    private AccountingPointComplexType accountingPoint(EtaPlusAccountingPointData payload) {
+        var point = new AccountingPointComplexType()
+                .withMRID(new MeasurementPointIDStringComplexType()
+                        .withCodingScheme(CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME)
+                        .withValue(payload.meteringPointId()))
+                .withContractPartyList(contractPartyList(payload.contractParty()))
+                .withAddressList(addressList(payload.deliveryAddress()));
+
+        var commodity = commodityFor(payload.energyType());
+        if (commodity != null) {
+            point.withCommodity(commodity);
+        }
+        var direction = directionFor(payload.direction());
+        if (direction != null) {
+            point.withDirection(direction);
+        }
+        return point;
+    }
+
+    private AccountingPointComplexType.ContractPartyList contractPartyList(@Nullable EtaPlusAccountingPointData.ContractParty contractParty) {
+        var list = new AccountingPointComplexType.ContractPartyList();
+        if (contractParty == null) {
+            return list;
+        }
+        var party = new ContractPartyComplexType()
+                .withContractPartyRole(ContractPartyRoleType.CONTRACTPARTNER);
+        if (contractParty.firstName() != null) {
+            party.setFirstName(contractParty.firstName());
+        }
+        if (contractParty.surName() != null) {
+            party.setSurName(contractParty.surName());
+        }
+        if (contractParty.companyName() != null) {
+            party.setCompanyName(contractParty.companyName());
+        }
+        if (contractParty.email() != null) {
+            party.setEmail(contractParty.email());
+        }
+        return list.withContractParties(party);
+    }
+
+    private AccountingPointComplexType.AddressList addressList(@Nullable EtaPlusAccountingPointData.Address address) {
+        var list = new AccountingPointComplexType.AddressList();
+        if (address == null) {
+            return list;
+        }
+        var entry = new AddressComplexType()
+                .withAddressRole(AddressRoleType.DELIVERY);
+        if (address.streetName() != null) {
+            String fullStreet = address.buildingNumber() != null
+                    ? address.streetName() + " " + address.buildingNumber()
+                    : address.streetName();
+            entry.setStreetName(fullStreet);
+        }
+        if (address.postalCode() != null) {
+            entry.setPostalCode(address.postalCode());
+        }
+        if (address.city() != null) {
+            entry.setCityName(address.city());
+        }
+        if (address.addressSuffix() != null) {
+            entry.setAddressSuffix(address.addressSuffix());
+        }
+        return list.withAddresses(entry);
+    }
+
+    @Nullable
+    private CommodityKind commodityFor(@Nullable String energyType) {
+        if (energyType == null) {
+            return null;
+        }
+        return switch (energyType) {
+            case "ELECTRICITY" -> CommodityKind.ELECTRICITYPRIMARYMETERED;
+            case "NATURAL_GAS" -> CommodityKind.NATURALGAS;
+            default -> {
+                LOGGER.warn("Unsupported energyType '{}' on metering point {}; omitting commodity",
+                        energyType, identifiableData.payload().meteringPointId());
+                yield null;
+            }
+        };
+    }
+
+    @Nullable
+    private DirectionTypeList directionFor(@Nullable String direction) {
+        if (direction == null) {
+            return null;
+        }
+        return switch (direction) {
+            case "Consumption" -> DirectionTypeList.DOWN;
+            case "Generation", "Production" -> DirectionTypeList.UP;
+            case "ConsumptionAndGeneration", "ConsumptionAndProduction" -> DirectionTypeList.UP_AND_DOWN;
+            default -> {
+                LOGGER.warn("Unknown direction '{}' on metering point {}; omitting direction",
+                        direction, identifiableData.payload().meteringPointId());
+                yield null;
+            }
+        };
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/resources/db/migration/de-eta/V1_3__rename_permission_dates_to_data_dates.sql
+++ b/region-connectors/region-connector-de-eta/src/main/resources/db/migration/de-eta/V1_3__rename_permission_dates_to_data_dates.sql
@@ -1,0 +1,25 @@
+-- Align the permission timeframe columns with the JPA entity mappings.
+-- Both DeValidatedEvent and DeAccountingPointValidatedEvent map their start/end
+-- fields to data_start/data_end; the original columns were named permission_start/_end.
+ALTER TABLE de_eta.permission_event RENAME COLUMN permission_start TO data_start;
+ALTER TABLE de_eta.permission_event RENAME COLUMN permission_end TO data_end;
+
+CREATE OR REPLACE VIEW de_eta.eta_permission_request AS
+SELECT DISTINCT ON (permission_id) permission_id,
+                                   de_eta.firstval_agg(connection_id) OVER w        AS data_source_connection_id,
+                                   de_eta.firstval_agg(metering_point_id) OVER w    AS metering_point_id,
+                                   de_eta.firstval_agg(data_start) OVER w           AS data_start,
+                                   de_eta.firstval_agg(data_end) OVER w             AS data_end,
+                                   de_eta.firstval_agg(granularity) OVER w          AS granularity,
+                                   de_eta.firstval_agg(energy_type) OVER w          AS energy_type,
+                                   de_eta.firstval_agg(status) OVER w               AS status,
+                                   MIN(event_created) OVER w                        AS created,
+                                   de_eta.firstval_agg(data_need_id_str) OVER w     AS data_need_id,
+                                   de_eta.firstval_agg(message) OVER w              AS message,
+                                   de_eta.firstval_agg(cause) OVER w                AS cause,
+                                   de_eta.firstval_agg(access_token) OVER w         AS access_token,
+                                   de_eta.firstval_agg(refresh_token) OVER w        AS refresh_token,
+                                   de_eta.firstval_agg(latest_meter_reading) OVER w AS latest_meter_reading
+FROM de_eta.permission_event
+    WINDOW w AS (PARTITION BY permission_id ORDER BY event_created DESC)
+ORDER BY permission_id, event_created;

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeEtaAccountingPointEnvelopeProviderTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeEtaAccountingPointEnvelopeProviderTest.java
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.providers.v0_82;
+
+import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
+import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.providers.AccountingPointDataStream;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusAccountingPointData;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableAccountingPointData;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DeEtaAccountingPointEnvelopeProviderTest {
+
+    @Test
+    void getAccountingPointMarketDocumentsStream_emitsOneEnvelopePerInputPayload() {
+        var stream = mock(AccountingPointDataStream.class);
+        when(stream.accountingPointData()).thenReturn(Flux.just(samplePayload()));
+
+        var provider = new DeEtaAccountingPointEnvelopeProvider(
+                stream,
+                new PlainCommonInformationModelConfiguration(
+                        CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME, "fallback"),
+                new DeEtaPlusConfiguration(
+                        "ep-id", "http://api.url", "client-id", "client-secret",
+                        "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+                        3, 2, true, false, null, null)
+        );
+
+        StepVerifier.create(provider.getAccountingPointMarketDocumentsStream())
+                .assertNext(envelope -> {
+                    assertThat(envelope.getAccountingPointMarketDocument()).isNotNull();
+                    assertThat(envelope.getAccountingPointMarketDocument()
+                                       .getAccountingPointList()
+                                       .getAccountingPoints()).hasSize(1);
+                })
+                .verifyComplete();
+    }
+
+    private static IdentifiableAccountingPointData samplePayload() {
+        DePermissionRequest pr = new DePermissionRequestBuilder()
+                .permissionId("pid").connectionId("cid").meteringPointId("mp")
+                .start(LocalDate.of(2026, 4, 30)).end(LocalDate.of(2026, 5, 1))
+                .dataNeedId("dnid")
+                .build();
+        EtaPlusAccountingPointData payload = new EtaPlusAccountingPointData(
+                "mp", "cust", "ELECTRICITY", "Consumption", null, null);
+        return new IdentifiableAccountingPointData(pr, payload);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateAccountingPointDataMarketDocumentTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateAccountingPointDataMarketDocumentTest.java
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.providers.v0_82;
+
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
+import energy.eddie.cim.v0_82.ap.AccountingPointEnvelope;
+import energy.eddie.cim.v0_82.ap.AddressRoleType;
+import energy.eddie.cim.v0_82.ap.CodingSchemeTypeList;
+import energy.eddie.cim.v0_82.ap.CommodityKind;
+import energy.eddie.cim.v0_82.ap.ContractPartyRoleType;
+import energy.eddie.cim.v0_82.ap.DirectionTypeList;
+import energy.eddie.cim.v0_82.ap.MessageTypeList;
+import energy.eddie.cim.v0_82.ap.RoleTypeList;
+import energy.eddie.regionconnector.de.eta.config.DeEtaPlusConfiguration;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusAccountingPointData;
+import energy.eddie.regionconnector.de.eta.providers.IdentifiableAccountingPointData;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IntermediateAccountingPointDataMarketDocumentTest {
+
+    private static final String METERING_POINT_ID = "DE0001234567890123456789012345";
+    private static final String ELIGIBLE_PARTY_ID = "test-ep-id";
+
+    private final CommonInformationModelConfiguration cimConfig = new PlainCommonInformationModelConfiguration(
+            energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME,
+            "unused-fallback"
+    );
+
+    private final DeEtaPlusConfiguration deConfiguration = new DeEtaPlusConfiguration(
+            ELIGIBLE_PARTY_ID,
+            "http://api.url", "client-id", "client-secret",
+            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+            3, 2, true, false,
+            null, null
+    );
+
+    private static DePermissionRequest permissionRequest() {
+        return new DePermissionRequestBuilder()
+                .permissionId("perm-1")
+                .connectionId("conn-1")
+                .meteringPointId(METERING_POINT_ID)
+                .start(LocalDate.of(2024, 1, 1))
+                .end(LocalDate.of(2024, 12, 31))
+                .dataNeedId("dn-ap")
+                .build();
+    }
+
+    private AccountingPointEnvelope toEnvelope(EtaPlusAccountingPointData payload) {
+        return new IntermediateAccountingPointDataMarketDocument(
+                cimConfig, deConfiguration,
+                new IdentifiableAccountingPointData(permissionRequest(), payload)
+        ).toEnvelope();
+    }
+
+    @Test
+    void toEnvelope_fullElectricityPayload_emitsCompletedDocument() {
+        EtaPlusAccountingPointData payload = new EtaPlusAccountingPointData(
+                METERING_POINT_ID, "42", "ELECTRICITY", "Consumption",
+                new EtaPlusAccountingPointData.Address(
+                        "Hauptstraße", "12", "10115", "Berlin", "DE", "Hinterhof"),
+                new EtaPlusAccountingPointData.ContractParty(
+                        "Max", "Mustermann", null, "max@example.de")
+        );
+
+        AccountingPointEnvelope envelope = toEnvelope(payload);
+        var doc = envelope.getAccountingPointMarketDocument();
+
+        assertThat(doc.getType()).isEqualTo(MessageTypeList.ACCOUNTING_POINT_MASTER_DATA);
+        assertThat(doc.getSenderMarketParticipantMarketRoleType())
+                .isEqualTo(RoleTypeList.METERING_POINT_ADMINISTRATOR);
+        assertThat(doc.getReceiverMarketParticipantMarketRoleType()).isEqualTo(RoleTypeList.CONSUMER);
+        assertThat(doc.getReceiverMarketParticipantMRID().getValue()).isEqualTo(ELIGIBLE_PARTY_ID);
+        assertThat(doc.getSenderMarketParticipantMRID().getCodingScheme())
+                .isEqualTo(CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME);
+        assertThat(doc.getCreatedDateTime()).isNotBlank();
+
+        assertThat(doc.getAccountingPointList().getAccountingPoints()).hasSize(1);
+        var point = doc.getAccountingPointList().getAccountingPoints().get(0);
+        assertThat(point.getMRID().getValue()).isEqualTo(METERING_POINT_ID);
+        assertThat(point.getMRID().getCodingScheme()).isEqualTo(CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME);
+        assertThat(point.getCommodity()).isEqualTo(CommodityKind.ELECTRICITYPRIMARYMETERED);
+        assertThat(point.getDirection()).isEqualTo(DirectionTypeList.DOWN);
+
+        var party = point.getContractPartyList().getContractParties().get(0);
+        assertThat(party.getContractPartyRole()).isEqualTo(ContractPartyRoleType.CONTRACTPARTNER);
+        assertThat(party.getFirstName()).isEqualTo("Max");
+        assertThat(party.getSurName()).isEqualTo("Mustermann");
+        assertThat(party.getCompanyName()).isNull();
+        assertThat(party.getEmail()).isEqualTo("max@example.de");
+
+        var addr = point.getAddressList().getAddresses().get(0);
+        assertThat(addr.getAddressRole()).isEqualTo(AddressRoleType.DELIVERY);
+        assertThat(addr.getStreetName()).isEqualTo("Hauptstraße 12");
+        assertThat(addr.getPostalCode()).isEqualTo("10115");
+        assertThat(addr.getCityName()).isEqualTo("Berlin");
+        assertThat(addr.getAddressSuffix()).isEqualTo("Hinterhof");
+    }
+
+    @Test
+    void toEnvelope_naturalGasMinimalPayload_omitsAbsentSubObjects() {
+        EtaPlusAccountingPointData payload = new EtaPlusAccountingPointData(
+                METERING_POINT_ID, null, "NATURAL_GAS", "Consumption", null, null
+        );
+
+        AccountingPointEnvelope envelope = toEnvelope(payload);
+        var point = envelope.getAccountingPointMarketDocument()
+                .getAccountingPointList().getAccountingPoints().get(0);
+
+        assertThat(point.getCommodity()).isEqualTo(CommodityKind.NATURALGAS);
+        assertThat(point.getDirection()).isEqualTo(DirectionTypeList.DOWN);
+        assertThat(point.getContractPartyList().getContractParties()).isEmpty();
+        assertThat(point.getAddressList().getAddresses()).isEmpty();
+    }
+
+    @Test
+    void toEnvelope_prosumerCompany_emitsUpDirectionAndCompanyName() {
+        EtaPlusAccountingPointData payload = new EtaPlusAccountingPointData(
+                METERING_POINT_ID, "4711", "ELECTRICITY", "Generation",
+                new EtaPlusAccountingPointData.Address(
+                        "Marienplatz", "1", "80331", "München", "DE", null),
+                new EtaPlusAccountingPointData.ContractParty(
+                        null, null, "Solar Beispiel GmbH", "ap@solar-beispiel.de")
+        );
+
+        AccountingPointEnvelope envelope = toEnvelope(payload);
+        var point = envelope.getAccountingPointMarketDocument()
+                .getAccountingPointList().getAccountingPoints().get(0);
+
+        assertThat(point.getDirection()).isEqualTo(DirectionTypeList.UP);
+        var party = point.getContractPartyList().getContractParties().get(0);
+        assertThat(party.getCompanyName()).isEqualTo("Solar Beispiel GmbH");
+        assertThat(party.getFirstName()).isNull();
+        assertThat(party.getSurName()).isNull();
+
+        var addr = point.getAddressList().getAddresses().get(0);
+        assertThat(addr.getStreetName()).isEqualTo("Marienplatz 1");
+        assertThat(addr.getAddressSuffix()).isNull();
+    }
+
+    @Test
+    void toEnvelope_unknownDirectionAndEnergyType_omitsBoth() {
+        EtaPlusAccountingPointData payload = new EtaPlusAccountingPointData(
+                METERING_POINT_ID, null, "PLUTONIUM", "Sideways", null, null
+        );
+
+        AccountingPointEnvelope envelope = toEnvelope(payload);
+        var point = envelope.getAccountingPointMarketDocument()
+                .getAccountingPointList().getAccountingPoints().get(0);
+
+        assertThat(point.getCommodity()).isNull();
+        assertThat(point.getDirection()).isNull();
+    }
+
+    @Test
+    void toEnvelope_messageHeaderCarriesPermissionMetadata() {
+        EtaPlusAccountingPointData payload = new EtaPlusAccountingPointData(
+                METERING_POINT_ID, null, "ELECTRICITY", "Consumption", null, null
+        );
+
+        AccountingPointEnvelope envelope = toEnvelope(payload);
+
+        var header = envelope.getMessageDocumentHeader();
+        assertThat(header.getMessageDocumentHeaderMetaInformation().getPermissionid()).isEqualTo("perm-1");
+        assertThat(header.getMessageDocumentHeaderMetaInformation().getConnectionid()).isEqualTo("conn-1");
+        assertThat(header.getMessageDocumentHeaderMetaInformation().getDataNeedid()).isEqualTo("dn-ap");
+    }
+
+    @Test
+    void toEnvelope_addressWithoutBuildingNumber_streetNameUsedAsIs() {
+        EtaPlusAccountingPointData payload = new EtaPlusAccountingPointData(
+                METERING_POINT_ID, null, "ELECTRICITY", "Consumption",
+                new EtaPlusAccountingPointData.Address(
+                        "Hauptstraße", null, "10115", "Berlin", "DE", null),
+                null
+        );
+
+        AccountingPointEnvelope envelope = toEnvelope(payload);
+        var addr = envelope.getAccountingPointMarketDocument()
+                .getAccountingPointList().getAccountingPoints().get(0)
+                .getAddressList().getAddresses().get(0);
+
+        assertThat(addr.getStreetName()).isEqualTo("Hauptstraße");
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateAccountingPointDataMarketDocumentTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateAccountingPointDataMarketDocumentTest.java
@@ -5,6 +5,10 @@ package energy.eddie.regionconnector.de.eta.providers.v0_82;
 
 import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
 import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
+import energy.eddie.cim.serde.SerdeInitializationException;
+import energy.eddie.cim.serde.SerializationException;
+import energy.eddie.cim.serde.XmlMessageSerde;
+import energy.eddie.cim.testing.XmlValidator;
 import energy.eddie.cim.v0_82.ap.AccountingPointEnvelope;
 import energy.eddie.cim.v0_82.ap.AddressRoleType;
 import energy.eddie.cim.v0_82.ap.CodingSchemeTypeList;
@@ -20,6 +24,7 @@ import energy.eddie.regionconnector.de.eta.providers.EtaPlusAccountingPointData;
 import energy.eddie.regionconnector.de.eta.providers.IdentifiableAccountingPointData;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +47,16 @@ class IntermediateAccountingPointDataMarketDocumentTest {
             null, null
     );
 
+    private final XmlMessageSerde serde = newSerde();
+
+    private static XmlMessageSerde newSerde() {
+        try {
+            return new XmlMessageSerde();
+        } catch (SerdeInitializationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
     private static DePermissionRequest permissionRequest() {
         return new DePermissionRequestBuilder()
                 .permissionId("perm-1")
@@ -54,10 +69,24 @@ class IntermediateAccountingPointDataMarketDocumentTest {
     }
 
     private AccountingPointEnvelope toEnvelope(EtaPlusAccountingPointData payload) {
-        return new IntermediateAccountingPointDataMarketDocument(
+        var envelope = new IntermediateAccountingPointDataMarketDocument(
                 cimConfig, deConfiguration,
                 new IdentifiableAccountingPointData(permissionRequest(), payload)
         ).toEnvelope();
+        assertValidatesAgainstXsd(envelope);
+        return envelope;
+    }
+
+    private void assertValidatesAgainstXsd(AccountingPointEnvelope envelope) {
+        String xml;
+        try {
+            xml = new String(serde.serialize(envelope), StandardCharsets.UTF_8);
+        } catch (SerializationException e) {
+            throw new AssertionError("Failed to serialize AccountingPointEnvelope", e);
+        }
+        assertThat(XmlValidator.validateAccountingPointMarketDocument(xml))
+                .as("Serialized envelope must validate against the AccountingPoint XSD:\n%s", xml)
+                .isTrue();
     }
 
     @Test


### PR DESCRIPTION
Closes #2194

(YouTrack: DV-2695)

## Summary
- Adds the CIM v0.82 `AccountingPointEnvelope` mapping for the de-eta region connector. `DeEtaAccountingPointEnvelopeProvider` consumes the accounting point data stream (from GH-2193) and maps each ETA Plus payload to an envelope via `IntermediateAccountingPointDataMarketDocument` (metering point id, commodity, direction, contract party, delivery address), exposed through `@MessageStream(AccountingPointEnvelope.class)`.
- Fixes a latent schema/entity drift: `DeAccountingPointValidatedEvent` mapped its start/end fields to `permission_start`/`permission_end` while `DeValidatedEvent` used `data_start`/`data_end`. Persisting an accounting-point validated event against the Flyway-migrated schema failed with `column "permission_end" ... does not exist`. Both events now map to `data_start`/`data_end`, and migration `V1_3` renames the columns and rebuilds the `eta_permission_request` view.

## Why the fix is needed
The drift was invisible to the test suite because tests build the schema from the JPA entities (Hibernate `ddl-auto`), where column names match by construction. It only surfaces against a real Flyway-migrated database, i.e. the first local/integration run of the accounting-point permission flow.

## Test plan
- [x] `:region-connectors:region-connector-de-eta:test` green (mapping unit tests + existing de-eta tests incl. Flyway-backed integration)
- [ ] Local E2E: trigger an accounting-point permission request and confirm the envelope is emitted (REST `cim_0_82/accounting-point-data-md` / Kafka `ep.eddie.cim_0_82.accounting-point-md`)