### PR TITLE
feat(aiida): Add property that replaces localhost as hostname for handshakes

### DIFF
--- a/aiida/docs/1-running/OPERATION.md
+++ b/aiida/docs/1-running/OPERATION.md
@@ -39,31 +39,32 @@ A sample configuration for these services is also provided in AIIDA's [compose f
 It is recommended to configure AIIDA using the .env file provided in the `aiida/docker` folder in combination with the
 `compose.yml` file.
 
-| Parameter                                           | Description                                                                                                                          |
-|-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| AIIDA_EXTERNAL_HOST                                 | Network-accessible host of the AIIDA instance (defaults to http://localhost:8080)                                                    |
-| AIIDA_CORS_ALLOWED_ORIGINS                          | The origins that are allowed to communicate with AIIDA (see [reverse proxy deployments](#reverse-proxy-deployment))                  |
-| AIIDA_CLEANUP_INTERVAL                              | Specifies in which fixed duration the cleanup task is scheduled (default: P1D)                                                       |
-| AIIDA_CLEANUP_ENTITIES_AIIDARECORD_RETENTION        | Specifies the time-to-live for an AIIDA_RECORD (default: P1D)                                                                        |
-| AIIDA_CLEANUP_ENTITIES_FAILEDTOSENDENTITY_RETENTION | Specifies the time-to-live for a FAILED_TO_SEND_ENTITY (default: P1D)                                                                |
-| AIIDA_CLEANUP_ENTITIES_INBOUNDRECORD_RETENTION      | Specifies the time-to-live for an INBOUND_RECORD (default: P1D)                                                                      |
-| SPRING_DATASOURCE_HOST                              | The hostname of the TimescaleDB service                                                                                              |
-| SPRING_DATASOURCE_PORT                              | The port of the TimescaleDB service                                                                                                  |
-| SPRING_DATASOURCE_DATABASE                          | The database name for AIIDA in TimescaleDB                                                                                           |
-| SPRING_DATASOURCE_USERNAME                          | The username for accessing the database                                                                                              |
-| SPRING_DATASOURCE_PASSWORD                          | The password for accessing the database                                                                                              |
-| MQTT_INTERNAL_HOST                                  | The hostname for docker internal communication                                                                                       |
-| MQTT_EXTERNAL_HOST                                  | The hostname for external communication                                                                                              |
-| MQTT_BCRYPT_SALT_ROUNDS                             | The bcrypt salt rounds for hashing passwords                                                                                         |
-| MQTT_PASSWORD                                       | The password for the MQTT user `aiida`                                                                                               |
-| MQTT_TLS_CERTIFICATE_PATH                           | Filepath of TLS certificate for MQTT broker (can be mounted to Docker container)                                                     |
-| EMQX_DATABASE_PASSWORD                              | The password for the `emqx` user in TimescaleDB                                                                                      |
-| KEYCLOAK_ADMIN_USERNAME                             | The admin username for Keycloak                                                                                                      |
-| KEYCLOAK_ADMIN_PASSWORD                             | The admin password for Keycloak                                                                                                      |
-| KEYCLOAK_EXTERNAL_HOST                              | The hostname for accessing Keycloak                                                                                                  |
-| KEYCLOAK_INTERNAL_HOST                              | The hostname for docker internal communication                                                                                       |
-| KEYCLOAK_REALM                                      | The Keycloak realm used for AIIDA                                                                                                    |
-| KEYCLOAK_CLIENT ID                                  | The Keycloak client ID used for AIIDA                                                                                                |
+| Parameter                                           | Description                                                                                                         |
+|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| AIIDA_EXTERNAL_HOST                                 | Network-accessible host of the AIIDA instance (defaults to http://localhost:8080)                                   |
+| AIIDA_CORS_ALLOWED_ORIGINS                          | The origins that are allowed to communicate with AIIDA (see [reverse proxy deployments](#reverse-proxy-deployment)) |
+| AIIDA_HANDSHAKE_LOCALHOST_REPLACEMENT               | Replaces "localhost" hostnames in HTTP requests (useful when testing a local EDDIE instance)                        |
+| AIIDA_CLEANUP_INTERVAL                              | Specifies in which fixed duration the cleanup task is scheduled (default: P1D)                                      |
+| AIIDA_CLEANUP_ENTITIES_AIIDARECORD_RETENTION        | Specifies the time-to-live for an AIIDA_RECORD (default: P1D)                                                       |
+| AIIDA_CLEANUP_ENTITIES_FAILEDTOSENDENTITY_RETENTION | Specifies the time-to-live for a FAILED_TO_SEND_ENTITY (default: P1D)                                               |
+| AIIDA_CLEANUP_ENTITIES_INBOUNDRECORD_RETENTION      | Specifies the time-to-live for an INBOUND_RECORD (default: P1D)                                                     |
+| SPRING_DATASOURCE_HOST                              | The hostname of the TimescaleDB service                                                                             |
+| SPRING_DATASOURCE_PORT                              | The port of the TimescaleDB service                                                                                 |
+| SPRING_DATASOURCE_DATABASE                          | The database name for AIIDA in TimescaleDB                                                                          |
+| SPRING_DATASOURCE_USERNAME                          | The username for accessing the database                                                                             |
+| SPRING_DATASOURCE_PASSWORD                          | The password for accessing the database                                                                             |
+| MQTT_INTERNAL_HOST                                  | The hostname for docker internal communication                                                                      |
+| MQTT_EXTERNAL_HOST                                  | The hostname for external communication                                                                             |
+| MQTT_BCRYPT_SALT_ROUNDS                             | The bcrypt salt rounds for hashing passwords                                                                        |
+| MQTT_PASSWORD                                       | The password for the MQTT user `aiida`                                                                              |
+| MQTT_TLS_CERTIFICATE_PATH                           | Filepath of TLS certificate for MQTT broker (can be mounted to Docker container)                                    |
+| EMQX_DATABASE_PASSWORD                              | The password for the `emqx` user in TimescaleDB                                                                     |
+| KEYCLOAK_ADMIN_USERNAME                             | The admin username for Keycloak                                                                                     |
+| KEYCLOAK_ADMIN_PASSWORD                             | The admin password for Keycloak                                                                                     |
+| KEYCLOAK_EXTERNAL_HOST                              | The hostname for accessing Keycloak                                                                                 |
+| KEYCLOAK_INTERNAL_HOST                              | The hostname for docker internal communication                                                                      |
+| KEYCLOAK_REALM                                      | The Keycloak realm used for AIIDA                                                                                   |
+| KEYCLOAK_CLIENT ID                                  | The Keycloak client ID used for AIIDA                                                                               |
 
 ### Reverse Proxy Deployment
 

--- a/aiida/src/main/java/energy/eddie/aiida/config/AiidaConfiguration.java
+++ b/aiida/src/main/java/energy/eddie/aiida/config/AiidaConfiguration.java
@@ -7,12 +7,18 @@ import energy.eddie.aiida.adapters.datasource.at.transformer.OesterreichsEnergie
 import energy.eddie.aiida.adapters.datasource.at.transformer.OesterreichsEnergieAdapterValueDeserializer;
 import energy.eddie.aiida.adapters.datasource.fr.transformer.MicroTeleinfoV3DataField;
 import energy.eddie.aiida.adapters.datasource.fr.transformer.MicroTeleinfoV3DataFieldDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.datatype.hibernate7.Hibernate7Module;
@@ -65,9 +71,25 @@ public class AiidaConfiguration {
     }
 
     /**
+     * Alternative {@link WebClient} to use for the handshake with EDDIE if a localhost replacement is set.
+     * For handshake URLs with "localhost" as hostname, the hostname will be replaced with the replacement string.
+     * This is useful if handshake URLs pointing to "localhost" are to be interpreted as an EDDIE instance on the same host.
+     *
+     * @param replacementHost Host to replace "localhost" with.
+     */
+    @Bean(name = "webClient")
+    @ConditionalOnProperty(prefix = "aiida.handshake", name = "localhost-replacement")
+    public WebClient webClientWithLocalhostReplacement(
+            @Value("${aiida.handshake.localhost-replacement}") String replacementHost
+    ) {
+        return WebClient.builder().filter(localhostReplacementFilter(replacementHost)).build();
+    }
+
+    /**
      * {@link WebClient} used for handshake with EDDIE.
      */
     @Bean
+    @ConditionalOnMissingBean(name = "webClient")
     public WebClient webClient() {
         return WebClient.create();
     }
@@ -77,5 +99,21 @@ public class AiidaConfiguration {
     @SuppressWarnings("java:S1452")
     public ConcurrentMap<UUID, ScheduledFuture<?>> permissionFutures() {
         return new ConcurrentHashMap<>();
+    }
+
+    protected static ExchangeFilterFunction localhostReplacementFilter(String replacementHost) {
+        return (request, next) -> {
+            if ("localhost".equalsIgnoreCase(request.url().getHost())) {
+                var url = UriComponentsBuilder.fromUri(request.url())
+                                              .host(replacementHost)
+                                              .build()
+                                              .toUri();
+
+                var mutated = ClientRequest.from(request).url(url).build();
+                return next.exchange(mutated);
+            }
+
+            return next.exchange(request);
+        };
     }
 }

--- a/aiida/src/test/java/energy/eddie/aiida/config/AiidaConfigurationTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/config/AiidaConfigurationTest.java
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.aiida.config;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AiidaConfigurationTest {
+
+    @Test
+    void localhostRewriteFilter_rewritesLocalhostHost() {
+        var filter = AiidaConfiguration.localhostReplacementFilter("example.org");
+        var next = mock(ExchangeFunction.class);
+
+        when(next.exchange(any())).thenReturn(Mono.just(ClientResponse.create(HttpStatus.OK).build()));
+
+        var request = ClientRequest.create(
+                HttpMethod.GET,
+                URI.create("http://localhost:8080/handshake/test?foo=bar")
+        ).build();
+
+        filter.filter(request, next).block();
+
+        var captor = ArgumentCaptor.forClass(ClientRequest.class);
+        verify(next).exchange(captor.capture());
+
+        assertEquals("http://example.org:8080/handshake/test?foo=bar", captor.getValue().url().toString());
+    }
+}


### PR DESCRIPTION
If set, the value of `aiida.handshake.localhost-replacement` will replace "localhost" hostnames when making HTTP requests. This allows for setups where a local EDDIE instance in the same network states its public URL to be on localhost, which is usually the case when testing both EDDIE and AIIDA locally.

Tested by building a local AIIDA image from this branch and using it in the tutorial setup where AIIDA and EDDIE are in the same bridge network. The property was set as `AIIDA_HANDSHAKE_LOCALHOST_REPLACEMENT=eddie`.

Will use this in the tutorial as soon as it is merged. Did not apply this to our compose files in the repository yet, as I want to test the localhost setup on Windows and Mac before adapting and prominently documenting it.

The reason for this change is that users trying out AIIDA and EDDIE locally by following our documentation will often use the default configuration and have them running on localhost. In the UI, this results in the following error when trying to add a permission.

<img width="915" height="118" alt="aiida-error" src="https://github.com/user-attachments/assets/59708e5e-4c43-42f8-974f-f2b47ddc3549" />