### PR TITLE
PR: GH-2195: feat(de-eta-region-connector): enforce energy type and granularity data needs on VHD responses (GH-2195)

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/handlers/AcceptedHandler.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/permission/handlers/AcceptedHandler.java
@@ -1,5 +1,7 @@
 package energy.eddie.regionconnector.de.eta.permission.handlers;
 
+import energy.eddie.dataneeds.needs.ValidatedHistoricalDataDataNeed;
+import energy.eddie.dataneeds.services.DataNeedsService;
 import energy.eddie.regionconnector.de.eta.EtaRegionConnectorMetadata;
 import energy.eddie.regionconnector.de.eta.client.EtaPlusApiClient;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusOperationExceptions.RateLimitException;
@@ -31,20 +33,24 @@ public class AcceptedHandler implements EventHandler<AcceptedEvent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AcceptedHandler.class);
 
     private final DePermissionRequestRepository repository;
+    private final DataNeedsService dataNeedsService;
     private final EtaPlusApiClient apiClient;
     private final ValidatedHistoricalDataStream stream;
     private final Outbox outbox;
     private final ObservationRegistry observationRegistry;
 
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     public AcceptedHandler(
             EventBus eventBus,
             DePermissionRequestRepository repository,
+            DataNeedsService dataNeedsService,
             EtaPlusApiClient apiClient,
             ValidatedHistoricalDataStream stream,
             Outbox outbox,
             ObservationRegistry observationRegistry
     ) {
         this.repository = repository;
+        this.dataNeedsService = dataNeedsService;
         this.apiClient = apiClient;
         this.stream = stream;
         this.outbox = outbox;
@@ -67,6 +73,12 @@ public class AcceptedHandler implements EventHandler<AcceptedEvent> {
                 LOGGER.atWarn()
                       .addArgument(event::permissionId)
                       .log("Permission request not found for id: {}, skipping event");
+                observation.stop();
+                return;
+            }
+
+            if (!(dataNeedsService.getById(pr.dataNeedId()) instanceof ValidatedHistoricalDataDataNeed)) {
+                // Not a VHD request — AccountingPointDataHandler handles it
                 observation.stop();
                 return;
             }

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappings.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappings.java
@@ -1,5 +1,10 @@
 package energy.eddie.regionconnector.de.eta.providers;
 
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import jakarta.annotation.Nullable;
+
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 
@@ -30,5 +35,45 @@ public final class EtaPlusVhdMappings {
         return readings.stream()
                 .sorted(Comparator.comparing(EtaPlusMeteredData.MeterReading::timestamp))
                 .toList();
+    }
+
+    /**
+     * Returns the {@link EnergyType} that corresponds to the wire {@code unit} string,
+     * or {@code null} if the unit is not recognised.
+     *
+     * <p>Per ETA Plus contract, the unit is constant within a historical-readings response,
+     * so checking the first reading's unit is sufficient to determine the energy type.
+     */
+    @Nullable
+    public static EnergyType energyTypeFromUnit(@Nullable String unit) {
+        if (unit == null) {
+            return null;
+        }
+        return switch (unit) {
+            case "kWh", "KWH", "MWh", "MWH" -> EnergyType.ELECTRICITY;
+            case "m³", "m3", "M3" -> EnergyType.NATURAL_GAS;
+            default -> null;
+        };
+    }
+
+    /**
+     * Infers the data {@link Granularity} from the interval between the first two entries of an
+     * already-sorted reading list, or {@code null} if fewer than two readings are present or the
+     * interval does not match any known {@link Granularity} value.
+     */
+    @Nullable
+    public static Granularity inferGranularity(List<EtaPlusMeteredData.MeterReading> sortedReadings) {
+        if (sortedReadings.size() < 2) {
+            return null;
+        }
+        Duration interval = Duration.between(
+                sortedReadings.get(0).timestamp(),
+                sortedReadings.get(1).timestamp());
+        for (Granularity g : Granularity.values()) {
+            if (g.duration().equals(interval)) {
+                return g;
+            }
+        }
+        return null;
     }
 }

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/ValidatedHistoricalDataStream.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/ValidatedHistoricalDataStream.java
@@ -1,7 +1,11 @@
 package energy.eddie.regionconnector.de.eta.providers;
 
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
 import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
 import energy.eddie.regionconnector.de.eta.permission.request.events.LatestMeterReadingEvent;
+import energy.eddie.regionconnector.de.eta.permission.request.events.SimpleEvent;
 import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,11 +14,16 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * Central stream for validated historical data from ETA Plus.
  * This component manages the reactive stream of validated historical data AND
  * is responsible for tracking the latest meter reading for fulfillment checks.
+ *
+ * <p>Before emitting, data need constraints (energy type and granularity) are enforced:
+ * if the received data does not satisfy the constraints stored on the permission request,
+ * the request is marked {@link PermissionProcessStatus#UNFULFILLABLE} and no data is published.
  */
 @Component
 public class ValidatedHistoricalDataStream implements AutoCloseable {
@@ -43,7 +52,22 @@ public class ValidatedHistoricalDataStream implements AutoCloseable {
     }
 
     /**
-     * Publish validated historical data to the stream and update latest reading state.
+     * Validates data need constraints and, if satisfied, publishes validated historical data
+     * to the stream and updates the latest reading state.
+     *
+     * <p>When the permission request carries an energy type (VHD data needs), the following
+     * checks are applied to the received readings:
+     * <ul>
+     *   <li><b>Energy type</b>: the unit of the first reading must correspond to
+     *       {@link DePermissionRequest#energyType()}. A mismatch means the MDA is serving
+     *       the wrong commodity (e.g. gas instead of electricity).</li>
+     *   <li><b>Granularity</b>: when at least two readings are present, the interval between
+     *       the first two sorted readings must match {@link DePermissionRequest#granularity()}.
+     *       If the interval cannot be mapped to a known {@link Granularity}, it passes through
+     *       (the MDA may have a temporary data gap).</li>
+     * </ul>
+     * If either check fails, a {@link PermissionProcessStatus#UNFULFILLABLE} event is committed
+     * and no data is published to the stream.
      *
      * @param permissionRequest the permission request the data belongs to
      * @param data              the validated historical data from ETA Plus
@@ -54,6 +78,19 @@ public class ValidatedHistoricalDataStream implements AutoCloseable {
                 .addArgument(data::meteringPointId)
                 .log("Publishing validated historical data for permission request {} with metering point {}");
 
+        List<EtaPlusMeteredData.MeterReading> readings = data.readings();
+
+        // Data need constraints apply only when energyType is set (VHD requests).
+        // Accounting-point requests have null energyType and are not subject to these checks.
+        if (readings != null && !readings.isEmpty() && permissionRequest.energyType() != null) {
+            if (!isEnergyTypeValid(permissionRequest, readings)) {
+                return;
+            }
+            if (!isGranularityValid(permissionRequest, readings)) {
+                return;
+            }
+        }
+
         IdentifiableValidatedHistoricalData identifiableData = new IdentifiableValidatedHistoricalData(permissionRequest, data);
         Sinks.EmitResult emitResult = sink.tryEmitNext(identifiableData);
 
@@ -61,6 +98,55 @@ public class ValidatedHistoricalDataStream implements AutoCloseable {
             LOGGER.warn("Failed to emit data to stream: {}", emitResult);
         }
         determineAndEmitLatestReading(identifiableData);
+    }
+
+    private boolean isEnergyTypeValid(
+            DePermissionRequest permissionRequest,
+            List<EtaPlusMeteredData.MeterReading> readings
+    ) {
+        EnergyType actualEnergyType = EtaPlusVhdMappings.energyTypeFromUnit(readings.get(0).unit());
+        if (actualEnergyType == permissionRequest.energyType()) {
+            return true;
+        }
+        LOGGER.atWarn()
+              .addArgument(permissionRequest::permissionId)
+              .addArgument(permissionRequest::energyType)
+              .addArgument(() -> readings.get(0).unit())
+              .log("Discarding data for permission {}: expected energy type {} but MDA returned unit '{}'; marking UNFULFILLABLE");
+        commitUnfulfillable(permissionRequest.permissionId());
+        return false;
+    }
+
+    private boolean isGranularityValid(
+            DePermissionRequest permissionRequest,
+            List<EtaPlusMeteredData.MeterReading> readings
+    ) {
+        if (readings.size() < 2 || permissionRequest.granularity() == null) {
+            return true;
+        }
+        List<EtaPlusMeteredData.MeterReading> sorted = EtaPlusVhdMappings.sortByTimestamp(readings);
+        Granularity actualGranularity = EtaPlusVhdMappings.inferGranularity(sorted);
+        if (actualGranularity == null || actualGranularity == permissionRequest.granularity()) {
+            return true;
+        }
+        LOGGER.atWarn()
+              .addArgument(permissionRequest::permissionId)
+              .addArgument(permissionRequest::granularity)
+              .addArgument(actualGranularity)
+              .log("Discarding data for permission {}: required granularity {} but MDA returned {}; marking UNFULFILLABLE");
+        commitUnfulfillable(permissionRequest.permissionId());
+        return false;
+    }
+
+    private void commitUnfulfillable(String permissionId) {
+        try {
+            outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.UNFULFILLABLE));
+        } catch (Exception ex) {
+            LOGGER.atError()
+                  .addArgument(permissionId)
+                  .setCause(ex)
+                  .log("Failed to persist UNFULFILLABLE event for permission {}");
+        }
     }
 
     private void determineAndEmitLatestReading(IdentifiableValidatedHistoricalData identifiableData) {

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/AcceptedHandlerFlowTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/AcceptedHandlerFlowTest.java
@@ -4,6 +4,9 @@ import energy.eddie.api.agnostic.Granularity;
 import energy.eddie.api.agnostic.data.needs.EnergyType;
 import energy.eddie.api.agnostic.process.model.events.PermissionEvent;
 import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.dataneeds.needs.AccountingPointDataNeed;
+import energy.eddie.dataneeds.needs.ValidatedHistoricalDataDataNeed;
+import energy.eddie.dataneeds.services.DataNeedsService;
 import energy.eddie.regionconnector.de.eta.client.EtaPlusApiClient;
 import energy.eddie.regionconnector.de.eta.exceptions.EtaPlusOperationExceptions.RateLimitException;
 import energy.eddie.regionconnector.de.eta.permission.handlers.AcceptedHandler;
@@ -50,6 +53,9 @@ class AcceptedHandlerFlowTest {
     private DePermissionRequestRepository repository;
 
     @Mock
+    private DataNeedsService dataNeedsService;
+
+    @Mock
     private EtaPlusApiClient apiClient;
 
     @Mock
@@ -64,10 +70,13 @@ class AcceptedHandlerFlowTest {
         realStream = new ValidatedHistoricalDataStream(outbox);
 
         when(eventBus.filteredFlux(AcceptedEvent.class)).thenReturn(Flux.empty());
+        // Default: treat all data needs as VHD (some tests skip before getById is called, hence lenient)
+        lenient().when(dataNeedsService.getById(anyString())).thenReturn(mock(ValidatedHistoricalDataDataNeed.class));
 
         acceptedHandler = new AcceptedHandler(
                 eventBus,
                 repository,
+                dataNeedsService,
                 apiClient,
                 realStream,
                 outbox,
@@ -257,5 +266,23 @@ class AcceptedHandlerFlowTest {
         acceptedHandler.accept(new AcceptedEvent(permissionId, "test-access-token", null));
 
         verify(outbox).commit(any());
+    }
+
+    @Test
+    @DisplayName("Should skip event when data need is not ValidatedHistoricalData (e.g. accounting point)")
+    void shouldSkipEventWhenDataNeedIsNotVhd() {
+        String permissionId = "perm-ap";
+        LocalDate start = LocalDate.now(EtaRegionConnectorMetadata.DE_ZONE_ID).minusMonths(1);
+        LocalDate end = LocalDate.now(EtaRegionConnectorMetadata.DE_ZONE_ID).minusDays(1);
+
+        DePermissionRequest permissionRequest = buildDefaultRequest(permissionId, start, end);
+
+        when(repository.findByPermissionId(permissionId)).thenReturn(Optional.of(permissionRequest));
+        when(dataNeedsService.getById(anyString())).thenReturn(mock(AccountingPointDataNeed.class));
+
+        acceptedHandler.accept(new AcceptedEvent(permissionId, "test-access-token", null));
+
+        verifyNoInteractions(apiClient);
+        verifyNoInteractions(outbox);
     }
 }

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappingsTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/EtaPlusVhdMappingsTest.java
@@ -1,5 +1,7 @@
 package energy.eddie.regionconnector.de.eta.providers;
 
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -69,6 +71,75 @@ class EtaPlusVhdMappingsTest {
         assertThat(EtaPlusVhdMappings.sortByTimestamp(sortedInput))
                 .extracting(EtaPlusMeteredData.MeterReading::value)
                 .containsExactly(1.0, 2.0);
+    }
+
+    // ---- energyTypeFromUnit ----
+
+    @ParameterizedTest
+    @CsvSource({
+            "kWh,ELECTRICITY",
+            "KWH,ELECTRICITY",
+            "MWh,ELECTRICITY",
+            "MWH,ELECTRICITY",
+            "m³,NATURAL_GAS",
+            "m3,NATURAL_GAS",
+            "M3,NATURAL_GAS",
+    })
+    void energyTypeFromUnit_mapsKnownUnitsCorrectly(String unit, EnergyType expected) {
+        assertThat(EtaPlusVhdMappings.energyTypeFromUnit(unit)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"BTU", "therm", "GJ", "ft3"})
+    void energyTypeFromUnit_unknownUnit_returnsNull(String unit) {
+        assertThat(EtaPlusVhdMappings.energyTypeFromUnit(unit)).isNull();
+    }
+
+    @Test
+    void energyTypeFromUnit_null_returnsNull() {
+        assertThat(EtaPlusVhdMappings.energyTypeFromUnit(null)).isNull();
+    }
+
+    // ---- inferGranularity ----
+
+    @Test
+    void inferGranularity_singleReading_returnsNull() {
+        var t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        assertThat(EtaPlusVhdMappings.inferGranularity(List.of(reading(t0, 1.0)))).isNull();
+    }
+
+    @Test
+    void inferGranularity_emptyList_returnsNull() {
+        assertThat(EtaPlusVhdMappings.inferGranularity(List.of())).isNull();
+    }
+
+    @Test
+    void inferGranularity_15minInterval_returnsPT15M() {
+        var t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var readings = List.of(reading(t0, 1.0), reading(t0.plusMinutes(15), 2.0));
+        assertThat(EtaPlusVhdMappings.inferGranularity(readings)).isEqualTo(Granularity.PT15M);
+    }
+
+    @Test
+    void inferGranularity_60minInterval_returnsPT1H() {
+        var t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var readings = List.of(reading(t0, 1.0), reading(t0.plusHours(1), 2.0));
+        assertThat(EtaPlusVhdMappings.inferGranularity(readings)).isEqualTo(Granularity.PT1H);
+    }
+
+    @Test
+    void inferGranularity_24hourInterval_returnsP1D() {
+        var t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var readings = List.of(reading(t0, 1.0), reading(t0.plusDays(1), 2.0));
+        assertThat(EtaPlusVhdMappings.inferGranularity(readings)).isEqualTo(Granularity.P1D);
+    }
+
+    @Test
+    void inferGranularity_unrecognisedInterval_returnsNull() {
+        var t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        // 7-minute interval does not correspond to any Granularity enum value
+        var readings = List.of(reading(t0, 1.0), reading(t0.plusMinutes(7), 2.0));
+        assertThat(EtaPlusVhdMappings.inferGranularity(readings)).isNull();
     }
 
     private static EtaPlusMeteredData.MeterReading reading(ZonedDateTime ts, double value) {

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/ValidatedHistoricalDataStreamTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/ValidatedHistoricalDataStreamTest.java
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.providers;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.api.agnostic.process.model.events.PermissionEvent;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.regionconnector.de.eta.EtaRegionConnectorMetadata;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.permission.request.events.LatestMeterReadingEvent;
+import energy.eddie.regionconnector.de.eta.permission.request.events.SimpleEvent;
+import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ValidatedHistoricalDataStreamTest {
+
+    @Mock
+    private Outbox outbox;
+
+    private ValidatedHistoricalDataStream stream;
+
+    @BeforeEach
+    void setUp() {
+        stream = new ValidatedHistoricalDataStream(outbox);
+    }
+
+    // ---- Energy-type enforcement ----
+
+    @Test
+    void publish_gasUnitForElectricityNeed_commitsUnfulfillable() {
+        var pr = electricityRequest();
+        var data = meteredData("m³", Granularity.PT15M);
+
+        stream.publish(pr, data);
+
+        assertUnfulfillable(pr.permissionId());
+    }
+
+    @Test
+    void publish_electricityUnitForGasNeed_commitsUnfulfillable() {
+        var pr = gasRequest();
+        var data = meteredData("kWh", Granularity.PT15M);
+
+        stream.publish(pr, data);
+
+        assertUnfulfillable(pr.permissionId());
+    }
+
+    @Test
+    void publish_unknownUnit_commitsUnfulfillable() {
+        var pr = electricityRequest();
+        var data = meteredData("BTU", Granularity.PT15M);
+
+        stream.publish(pr, data);
+
+        assertUnfulfillable(pr.permissionId());
+    }
+
+    // ---- Granularity enforcement ----
+
+    @Test
+    void publish_hourlyDataForQuarterHourlyNeed_commitsUnfulfillable() {
+        var pr = electricityRequest(Granularity.PT15M);
+        ZonedDateTime t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var readings = List.of(
+                reading(t0, "kWh"),
+                reading(t0.plusHours(1), "kWh")   // interval = PT1H ≠ required PT15M
+        );
+        var data = new EtaPlusMeteredData("MP-1", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1), readings);
+
+        stream.publish(pr, data);
+
+        assertUnfulfillable(pr.permissionId());
+    }
+
+    // ---- Happy path ----
+
+    @Test
+    void publish_correctElectricityTypeAndGranularity_commitsLatestMeterReading() {
+        var pr = electricityRequest(Granularity.PT15M);
+        ZonedDateTime t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var readings = List.of(
+                reading(t0, "kWh"),
+                reading(t0.plusMinutes(15), "kWh")
+        );
+        var data = new EtaPlusMeteredData("MP-1", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1), readings);
+
+        stream.publish(pr, data);
+
+        assertLatestMeterReadingCommitted();
+    }
+
+    @Test
+    void publish_correctGasTypeAndGranularity_commitsLatestMeterReading() {
+        var pr = gasRequest();
+        ZonedDateTime t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var readings = List.of(
+                reading(t0, "m³"),
+                reading(t0.plusMinutes(15), "m³")
+        );
+        var data = new EtaPlusMeteredData("MP-GAS", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1), readings);
+
+        stream.publish(pr, data);
+
+        assertLatestMeterReadingCommitted();
+    }
+
+    @Test
+    void publish_singleReading_granularityCannotBeInferred_passesThrough() {
+        // With only one reading, granularity cannot be inferred — the data passes through
+        var pr = electricityRequest(Granularity.PT15M);
+        var data = new EtaPlusMeteredData("MP-1", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1),
+                List.of(reading(ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), "kWh")));
+
+        stream.publish(pr, data);
+
+        assertLatestMeterReadingCommitted();
+    }
+
+    @Test
+    void publish_unrecognisedReadingInterval_granularityCannotBeInferred_passesThrough() {
+        // A 7-minute interval does not match any Granularity value; the check is skipped
+        var pr = electricityRequest(Granularity.PT15M);
+        ZonedDateTime t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var readings = List.of(reading(t0, "kWh"), reading(t0.plusMinutes(7), "kWh"));
+        var data = new EtaPlusMeteredData("MP-1", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1), readings);
+
+        stream.publish(pr, data);
+
+        assertLatestMeterReadingCommitted();
+    }
+
+    @Test
+    void publish_emptyReadings_passesThrough_noUnfulfillable() {
+        // Empty readings are not a data-need violation (data may not be available yet)
+        var pr = electricityRequest();
+        var data = new EtaPlusMeteredData("MP-1", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1), List.of());
+
+        stream.publish(pr, data);
+
+        assertLatestMeterReadingCommitted();
+    }
+
+    // ---- Helpers ----
+
+    private void assertUnfulfillable(String permissionId) {
+        ArgumentCaptor<PermissionEvent> captor = ArgumentCaptor.forClass(PermissionEvent.class);
+        verify(outbox, times(1)).commit(captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(SimpleEvent.class);
+        SimpleEvent event = (SimpleEvent) captor.getValue();
+        assertThat(event.permissionId()).isEqualTo(permissionId);
+        assertThat(event.status()).isEqualTo(PermissionProcessStatus.UNFULFILLABLE);
+    }
+
+    private void assertLatestMeterReadingCommitted() {
+        ArgumentCaptor<PermissionEvent> captor = ArgumentCaptor.forClass(PermissionEvent.class);
+        verify(outbox, times(1)).commit(captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(LatestMeterReadingEvent.class);
+    }
+
+    private DePermissionRequest electricityRequest() {
+        return electricityRequest(Granularity.PT15M);
+    }
+
+    private DePermissionRequest electricityRequest(Granularity granularity) {
+        return new DePermissionRequestBuilder()
+                .permissionId("perm-elec")
+                .connectionId("conn-1")
+                .meteringPointId("MP-1")
+                .start(LocalDate.of(2026, 1, 1))
+                .end(LocalDate.of(2026, 1, 31))
+                .granularity(granularity)
+                .energyType(EnergyType.ELECTRICITY)
+                .status(PermissionProcessStatus.ACCEPTED)
+                .created(ZonedDateTime.now(EtaRegionConnectorMetadata.DE_ZONE_ID))
+                .dataNeedId("need-1")
+                .build();
+    }
+
+    private DePermissionRequest gasRequest() {
+        return new DePermissionRequestBuilder()
+                .permissionId("perm-gas")
+                .connectionId("conn-gas")
+                .meteringPointId("MP-GAS")
+                .start(LocalDate.of(2026, 1, 1))
+                .end(LocalDate.of(2026, 1, 31))
+                .granularity(Granularity.PT15M)
+                .energyType(EnergyType.NATURAL_GAS)
+                .status(PermissionProcessStatus.ACCEPTED)
+                .created(ZonedDateTime.now(EtaRegionConnectorMetadata.DE_ZONE_ID))
+                .dataNeedId("need-gas")
+                .build();
+    }
+
+    private static EtaPlusMeteredData meteredData(String unit, Granularity granularity) {
+        ZonedDateTime t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        return new EtaPlusMeteredData("MP-1", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1),
+                List.of(reading(t0, unit), reading(t0.plus(granularity.duration()), unit)));
+    }
+
+    private static EtaPlusMeteredData.MeterReading reading(ZonedDateTime ts, String unit) {
+        return new EtaPlusMeteredData.MeterReading(ts, 1.0, unit, "VALIDATED", "Consumption");
+    }
+}


### PR DESCRIPTION
**GitHub Issue:** https://github.com/eddie-energy/eddie/issues/2195

---

## Description

The ETA Plus MDA can return data for the wrong energy commodity (e.g. gas readings on an electricity meter point) or at a different granularity than the permission request specifies. Without enforcement, these mismatches flow through to CIM document generation and produce incorrect envelopes.

Enforcement is added in `ValidatedHistoricalDataStream.publish()`, the single call site shared by both the initial backfill (`AcceptedHandler`) and ongoing polling (`PollingService`). If the returned unit does not match the requested energy type, or the inferred reading interval does not match the required granularity, the permission is marked `UNFULFILLABLE` and no data is published to the stream. `AcceptedHandler` also receives a VHD type guard so it no longer processes accounting-point requests, which previously had no such guard.

---

## Changes

**`providers/EtaPlusVhdMappings.java`**
- Added `energyTypeFromUnit(String unit)`: maps ETA Plus wire unit strings (`kWh`, `MWh`, `m3`) to `EnergyType`; returns `null` for unrecognised units
- Added `inferGranularity(List<MeterReading> sortedReadings)`: infers `Granularity` from the interval between the first two sorted readings; returns `null` if interval is unrecognised or fewer than two readings exist

**`providers/ValidatedHistoricalDataStream.java`**
- `publish()` now enforces energy type and granularity before emitting; on mismatch commits `UNFULFILLABLE` via outbox and returns without publishing
- Guard is skipped when `permissionRequest.energyType()` is `null` (accounting-point requests are not subject to these checks)
- Unrecognised reading intervals and empty reading lists pass through (not permanent failures)

**`permission/handlers/AcceptedHandler.java`**
- Added `DataNeedsService` constructor parameter and VHD type guard: events for non-VHD data needs (e.g. accounting point) are skipped immediately, consistent with the inverse guard already present in `AccountingPointDataHandler`

---

### Behaviour

- Energy type mismatch (e.g. MDA returns `m3` for an electricity data need): commits `UNFULFILLABLE`
- Granularity mismatch (e.g. MDA returns hourly data when `PT15M` is required): commits `UNFULFILLABLE`
- Unrecognised reading interval (transient data gap): passes through, not marked `UNFULFILLABLE`
- Empty readings: passes through (data not yet available, polling will retry)
- Accounting-point requests: unaffected by all of the above