### PR TITLE
fix(aiida): Prevent custom select options from floating on scroll

### DIFF
--- a/aiida/ui/src/components/CustomSelect.vue
+++ b/aiida/ui/src/components/CustomSelect.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <script setup lang="ts">
 import ChevronDownIcon from '@/assets/icons/ChevronDownIcon.svg'
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, ref, useTemplateRef } from 'vue'
 
 const { options, placeholder } = defineProps<{
   options: { label?: string; value: string }[] | string[]
@@ -14,14 +14,6 @@ const { options, placeholder } = defineProps<{
 const model = defineModel()
 const show = ref(false)
 const parentDiv = useTemplateRef('parent')
-
-const boundingRect = ref()
-
-watch([show], () => {
-  if (show.value) {
-    boundingRect.value = parentDiv.value?.getBoundingClientRect()
-  }
-})
 
 const labelValueOptions = computed(() => {
   if (typeof options[0] === 'string') {
@@ -47,15 +39,6 @@ const handleBlur = (e: FocusEvent) => {
     show.value = false
   }
 }
-
-onMounted(() => {
-  window.addEventListener('resize', () => {
-    boundingRect.value = parentDiv.value?.getBoundingClientRect()
-  })
-})
-
-const optionsLeft = computed(() => `${boundingRect.value?.left ?? 0}px`)
-const optionsWidth = computed(() => `${boundingRect.value?.width ?? 0}px`)
 </script>
 
 <template>
@@ -126,15 +109,18 @@ const optionsWidth = computed(() => `${boundingRect.value?.width ?? 0}px`)
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: var(--spacing-sm);
   &.placeholder {
     color: var(--eddie-grey-medium);
   }
 }
 .options {
   position: absolute;
+  top: 100%;
   left: -1px;
-  width: v-bind('optionsWidth');
+  right: -1px;
   z-index: 100;
+  box-sizing: unset;
   background-color: var(--light);
   border: 1px solid var(--eddie-grey-medium);
   border-top: unset;
@@ -167,12 +153,5 @@ const optionsWidth = computed(() => `${boundingRect.value?.width ?? 0}px`)
 .v-enter-from,
 .v-leave-to {
   opacity: 0;
-}
-
-@media screen and (min-width: 1024px) {
-  .options {
-    position: fixed;
-    left: v-bind('optionsLeft');
-  }
 }
 </style>


### PR DESCRIPTION
## Bug

To reproduce
1. Resize window to require scroll on a page (e.g. > 2 data sources)
2. Scroll down a little
3. Click the select field
4. See screenshot

<img width="1273" height="906" alt="image" src="https://github.com/user-attachments/assets/e14604af-70e8-4d8e-84bb-c9f02eca2215" />

Tested in Firefox Developer Edition and Chromium.

## Fix

<img width="1273" height="971" alt="image" src="https://github.com/user-attachments/assets/c9c8a353-d694-4116-9a32-f598a502d991" />

There is a separate issue for screen width < 694 where the `left: -1px` border fix hurts us. Not sure why it happens because there is no media query for this. Did not want to put too much effort into this, but maybe @GoodVibezOnly you have an idea?

<img width="555" height="792" alt="image" src="https://github.com/user-attachments/assets/0a6f2ced-cbc2-4cc0-89ae-00b813de6049" />