### PR TITLE
feat(de-eta-region-connector): react to revocation of permission request (GH-2196)

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
@@ -188,44 +188,6 @@ public class EtaPlusApiClient {
                                 ex));
     }
 
-    /**
-     * Check if permission is still valid at ETA Plus.
-     * Used to verify that the final customer hasn't revoked permission.
-     *
-     * @param permissionRequest the permission request to check
-     * @return a Mono emitting true if permission is valid, false otherwise
-     */
-    public Mono<Boolean> checkPermissionValidity(DePermissionRequest permissionRequest) {
-        LOGGER.atDebug()
-                .addArgument(permissionRequest::permissionId)
-                .log("Checking permission validity for permission request {}");
-
-        return webClient.head()
-                .uri(uriBuilder -> uriBuilder
-                        .path(configuration.permissionCheckEndpoint())
-                        .build(permissionRequest.permissionId()))
-                .retrieve()
-                .toBodilessEntity()
-                .map(response -> response.getStatusCode().is2xxSuccessful())
-                .retryWhen(retrySpec(permissionRequest.permissionId()))
-                .onErrorResume(ex -> {
-                    if (ex instanceof WebClientResponseException wce) {
-                        int status = wce.getStatusCode().value();
-                        if (status == 401) {
-                            return Mono.error(new AuthenticationException(
-                                    "Authentication failed during permission check for " + permissionRequest.permissionId(),
-                                    status, ex));
-                        }
-                        if (status == 429) {
-                            return Mono.error(new RateLimitException(
-                                    "Rate limit exceeded during permission check for " + permissionRequest.permissionId()));
-                        }
-                    }
-                    LOGGER.warn("Permission check failed for {}: {}", permissionRequest.permissionId(), ex.getMessage());
-                    return Mono.just(false);
-                });
-    }
-
     private Retry retrySpec(String permissionId) {
         return Retry.backoff(configuration.retryMaxAttempts(),
                         Duration.ofSeconds(configuration.retryInitialBackoffSeconds()))

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/config/DeEtaPlusConfiguration.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/config/DeEtaPlusConfiguration.java
@@ -20,7 +20,6 @@ public record DeEtaPlusConfiguration(
                 @NotBlank String apiClientSecret,
                 @DefaultValue("/meters/historical") String meteredDataEndpoint,
                 @DefaultValue("/meters/accounting-point") String accountingPointEndpoint,
-                @DefaultValue("/v1/permissions/{id}") String permissionCheckEndpoint,
                 @Positive @DefaultValue("30") int responseTimeoutSeconds,
                 @PositiveOrZero @DefaultValue("3") int retryMaxAttempts,
                 @PositiveOrZero @DefaultValue("2") int retryInitialBackoffSeconds,

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/auth/EtaAuthServiceTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/auth/EtaAuthServiceTest.java
@@ -29,7 +29,7 @@ class EtaAuthServiceTest {
 
         DeEtaPlusConfiguration configuration = new DeEtaPlusConfiguration(
                 "partner", "http://api.url", "client-id", "client-secret",
-                "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+                "/meters/historical", "/meters/accounting-point", 30,
                 3, 2, true, false,
                 authConfig, null);
 

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClientTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClientTest.java
@@ -58,7 +58,6 @@ class EtaPlusApiClientTest {
                 "client-secret",
                 "/meters/historical",
                 "/meters/accounting-point",
-                "/v1/permissions/{id}",
                 30,
                 3, 0,
                 true,
@@ -362,96 +361,6 @@ class EtaPlusApiClientTest {
         RecordedRequest recorded = takeLatestRequest();
         assertThat(recorded).isNotNull();
         assertThat(recorded.getPath()).startsWith("/meters/historical");
-    }
-
-    // ---- checkPermissionValidity ----
-
-    @Test
-    void checkPermissionValidity_200Response_returnsTrue() {
-        server.enqueue(new MockResponse().setResponseCode(200));
-
-        DePermissionRequest request = buildRequest(
-                "perm-valid", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
-
-        StepVerifier.create(apiClient.checkPermissionValidity(request))
-                .expectNext(true)
-                .verifyComplete();
-    }
-
-    @Test
-    void checkPermissionValidity_403Response_returnsFalse() {
-        server.enqueue(new MockResponse().setResponseCode(403));
-
-        DePermissionRequest request = buildRequest(
-                "perm-forbidden", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
-
-        StepVerifier.create(apiClient.checkPermissionValidity(request))
-                .expectNext(false)
-                .verifyComplete();
-    }
-
-    @Test
-    void checkPermissionValidity_500Response_retriesAndReturnsFalse() {
-        for (int i = 0; i < 4; i++) {
-            server.enqueue(new MockResponse().setResponseCode(500));
-        }
-
-        DePermissionRequest request = buildRequest(
-                "perm-server-error", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
-
-        StepVerifier.create(apiClient.checkPermissionValidity(request))
-                .expectNext(false)
-                .verifyComplete();
-    }
-
-    @Test
-    void checkPermissionValidity_401Response_throwsAuthenticationException() {
-        server.enqueue(new MockResponse().setResponseCode(401));
-
-        DePermissionRequest request = buildRequest(
-                "perm-auth-check", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
-
-        StepVerifier.create(apiClient.checkPermissionValidity(request))
-                .expectErrorSatisfies(error -> {
-                    assertThat(error).isInstanceOf(AuthenticationException.class);
-                    assertThat(error.getMessage()).contains("perm-auth-check");
-                    assertThat(((AuthenticationException) error).statusCode()).isEqualTo(401);
-                })
-                .verify();
-    }
-
-    @Test
-    void checkPermissionValidity_429Response_retriesAndThrowsRateLimitException() {
-        for (int i = 0; i < 4; i++) {
-            server.enqueue(new MockResponse().setResponseCode(429));
-        }
-
-        DePermissionRequest request = buildRequest(
-                "perm-rate-check", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
-
-        StepVerifier.create(apiClient.checkPermissionValidity(request))
-                .expectErrorSatisfies(error -> {
-                    assertThat(error).isInstanceOf(RateLimitException.class);
-                    assertThat(error.getMessage()).contains("perm-rate-check");
-                })
-                .verify();
-    }
-
-    @Test
-    void checkPermissionValidity_usesHeadMethodAndCorrectPathWithPermissionId() throws InterruptedException {
-        server.enqueue(new MockResponse().setResponseCode(200));
-
-        DePermissionRequest request = buildRequest(
-                "perm-abc-123", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
-
-        StepVerifier.create(apiClient.checkPermissionValidity(request))
-                .expectNext(true)
-                .verifyComplete();
-
-        RecordedRequest recorded = takeLatestRequest();
-        assertThat(recorded).isNotNull();
-        assertThat(recorded.getMethod()).isEqualTo("HEAD");
-        assertThat(recorded.getPath()).isEqualTo("/v1/permissions/perm-abc-123");
     }
 
     // ------------------------------------------------------------------

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/config/DeEtaPlusConfigurationTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/config/DeEtaPlusConfigurationTest.java
@@ -40,7 +40,6 @@ class DeEtaPlusConfigurationTest {
                     assertThat(config.apiBaseUrl()).isEqualTo("https://int.eta-plus.com/api");
                     assertThat(config.meteredDataEndpoint()).isEqualTo("/meters/historical");
                     assertThat(config.accountingPointEndpoint()).isEqualTo("/meters/accounting-point");
-                    assertThat(config.permissionCheckEndpoint()).isEqualTo("/v1/permissions/{id}");
                     assertThat(config.responseTimeoutSeconds()).isEqualTo(30);
                     assertThat(config.retryMaxAttempts()).isEqualTo(3);
                     assertThat(config.retryInitialBackoffSeconds()).isEqualTo(2);

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/config/EtaPlusClientConfigTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/config/EtaPlusClientConfigTest.java
@@ -43,7 +43,6 @@ class EtaPlusClientConfigTest {
                 "my-secret",
                 "/meters/historical",
                 "/meters/accounting-point",
-                "/v1/permissions/{id}",
                 30,
                 3, 2,
                 sslEnabled,

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeEtaAccountingPointEnvelopeProviderTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeEtaAccountingPointEnvelopeProviderTest.java
@@ -34,7 +34,7 @@ class DeEtaAccountingPointEnvelopeProviderTest {
                         CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME, "fallback"),
                 new DeEtaPlusConfiguration(
                         "ep-id", "http://api.url", "client-id", "client-secret",
-                        "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+                        "/meters/historical", "/meters/accounting-point", 30,
                         3, 2, true, false, null, null)
         );
 

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeValidatedHistoricalDataEnvelopeProviderTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/DeValidatedHistoricalDataEnvelopeProviderTest.java
@@ -38,7 +38,7 @@ class DeValidatedHistoricalDataEnvelopeProviderTest {
                         CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME, "fallback"),
                 new DeEtaPlusConfiguration(
                         "ep-id", "http://api.url", "client-id", "client-secret",
-                        "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+                        "/meters/historical", "/meters/accounting-point", 30,
                         3, 2, true, false, null, null)
         );
 

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateAccountingPointDataMarketDocumentTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateAccountingPointDataMarketDocumentTest.java
@@ -42,7 +42,7 @@ class IntermediateAccountingPointDataMarketDocumentTest {
     private final DeEtaPlusConfiguration deConfiguration = new DeEtaPlusConfiguration(
             ELIGIBLE_PARTY_ID,
             "http://api.url", "client-id", "client-secret",
-            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", 30,
             3, 2, true, false,
             null, null
     );

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelopeTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v0_82/IntermediateValidatedHistoricalDataEnvelopeTest.java
@@ -45,7 +45,7 @@ class IntermediateValidatedHistoricalDataEnvelopeTest {
     private final DeEtaPlusConfiguration deConfiguration = new DeEtaPlusConfiguration(
             ELIGIBLE_PARTY_ID,
             "http://api.url", "client-id", "client-secret",
-            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", 30,
             3, 2, true, false,
             null, null
     );

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/DeValidatedHistoricalDataMarketDocumentProviderTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/DeValidatedHistoricalDataMarketDocumentProviderTest.java
@@ -39,7 +39,7 @@ class DeValidatedHistoricalDataMarketDocumentProviderTest {
                         CodingSchemeTypeList.GERMANY_NATIONAL_CODING_SCHEME, "fallback"),
                 new DeEtaPlusConfiguration(
                         "ep-id", "http://api.url", "client-id", "client-secret",
-                        "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+                        "/meters/historical", "/meters/accounting-point", 30,
                         3, 2, true, false, null, null)
         );
 

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocumentTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/v1_04/IntermediateValidatedHistoricalDataMarketDocumentTest.java
@@ -45,7 +45,7 @@ class IntermediateValidatedHistoricalDataMarketDocumentTest {
     private final DeEtaPlusConfiguration deConfiguration = new DeEtaPlusConfiguration(
             ELIGIBLE_PARTY_ID,
             "http://api.url", "client-id", "client-secret",
-            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", 30,
             3, 2, true, false,
             null, null
     );

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestAuthorizationServiceTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestAuthorizationServiceTest.java
@@ -44,7 +44,7 @@ class PermissionRequestAuthorizationServiceTest {
     @SuppressWarnings("UnusedVariable") // injected into service via @InjectMocks
     private DeEtaPlusConfiguration configuration = new DeEtaPlusConfiguration(
             "test-party", "http://test-url", "api-client", "api-secret",
-            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", 30,
             3, 2, true, false,
             new DeEtaPlusConfiguration.AuthConfig("test-client", "secret", "tokenUrl", "authUrl",
                                                    "redirectUri",

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestCreationServiceTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/service/PermissionRequestCreationServiceTest.java
@@ -52,7 +52,7 @@ class PermissionRequestCreationServiceTest {
     @SuppressWarnings("UnusedVariable") // injected into service via @InjectMocks
     private final DeEtaPlusConfiguration configuration = new DeEtaPlusConfiguration(
             "partner", "http://api.url", "api-client", "api-secret",
-            "/meters/historical", "/meters/accounting-point", "/v1/permissions/{id}", 30,
+            "/meters/historical", "/meters/accounting-point", 30,
             3, 2, true, false,
             new DeEtaPlusConfiguration.AuthConfig(
                     "client-1", "secret", "token-url", "http://auth.url", "http://redirect.uri",


### PR DESCRIPTION
**GitHub Issue:** https://github.com/eddie-energy/eddie/issues/2196

---

## Description

`EtaPlusApiClient` contained a `checkPermissionValidity()` method, a HEAD-based endpoint check written speculatively for a proactive revocation detection path that was never wired up. The `permissionCheckEndpoint` config property was similarly unused. Leaving dead infrastructure in place risks future confusion about which revocation path is active and what the connector actually does.

Revocation in the DE-ETA connector is handled reactively: a 403 response from `fetchMeteredData()` propagates as `WebClientResponseException.Forbidden` and is caught in both `PollingService.handleError()` and `AcceptedHandler.handleError()`, which commit a `REVOKED` event via the outbox. This reactive path is sufficient because the EDDIE framework propagates `REVOKED` to downstream components through `ConnectionStatusMessageHandler` and excludes revoked permissions from future polling via `CommonFutureDataService`'s `findByStatus(ACCEPTED)` query. No proactive endpoint check is required.

---

The reactive revocation path lives in two places:

  - PollingService.java:81-86: WebClientResponseException.Forbidden → commitSafely(permissionId, REVOKED) during periodic polling
  - AcceptedHandler.java:127-132: same catch during the initial accepted-event data fetch
