### PR TITLE
feat(de-eta-region-connector): terminate permission only when in ACCEPTED status (GH-2197)

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/EtaRegionConnector.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/EtaRegionConnector.java
@@ -52,14 +52,12 @@ public class EtaRegionConnector implements RegionConnector {
             return;
         }
 
-        // Mark the permission as terminated in the database
-        // The actual termination will be handled by a scheduled task or event processor
-        // that reads from the outbox and sends termination requests to ETA Plus
+        if (request.get().status() != PermissionProcessStatus.ACCEPTED) {
+            LOGGER.info("Permission request {} is in {} status, ignoring termination request",
+                    permissionId, request.get().status());
+            return;
+        }
 
-        // Implement actual termination logic with ETA Plus API in GH-2197
-        // For now, we just mark it as terminated and requiring external termination
-
-        // Publish termination events
         outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.TERMINATED));
         outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.REQUIRES_EXTERNAL_TERMINATION));
 

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/EtaRegionConnectorTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/EtaRegionConnectorTest.java
@@ -47,6 +47,7 @@ class EtaRegionConnectorTest {
     void terminatePermissionWhenPermissionExistsShouldCommitEvents() {
         String permissionId = "test-permission-id";
         DePermissionRequest request = mock(DePermissionRequest.class);
+        when(request.status()).thenReturn(PermissionProcessStatus.ACCEPTED);
         when(repository.findByPermissionId(permissionId)).thenReturn(Optional.of(request));
 
         connector.terminatePermission(permissionId);
@@ -60,6 +61,18 @@ class EtaRegionConnectorTest {
         assertThat(events.get(0).status()).isEqualTo(PermissionProcessStatus.TERMINATED);
         assertThat(events.get(1).permissionId()).isEqualTo(permissionId);
         assertThat(events.get(1).status()).isEqualTo(PermissionProcessStatus.REQUIRES_EXTERNAL_TERMINATION);
+    }
+
+    @Test
+    void terminatePermissionWhenPermissionNotAcceptedShouldNotCommitEvents() {
+        String permissionId = "test-permission-id";
+        DePermissionRequest request = mock(DePermissionRequest.class);
+        when(request.status()).thenReturn(PermissionProcessStatus.TERMINATED);
+        when(repository.findByPermissionId(permissionId)).thenReturn(Optional.of(request));
+
+        connector.terminatePermission(permissionId);
+
+        verify(outbox, never()).commit(any());
     }
 
     @Test


### PR DESCRIPTION
Added a status check in `EtaRegionConnector.terminatePermission()` to ensure only permissions in `ACCEPTED` status can be terminated. This prevents invalid or duplicate outbox events from being emitted for permissions that are already in a final state. 

---

**Changes** - Added `ACCEPTED` status guard in `terminatePermission()` 
- Added informative logging when termination is skipped due to status 
- Removed obsolete TODO comments - Updated existing happy-path test to use `ACCEPTED` status 
- Added test verifying no events are committed for non-`ACCEPTED` permissions 

---

**Behaviour** 
- `ACCEPTED` -> commits `TERMINATED` and `REQUIRES_EXTERNAL_TERMINATION` 
- Any other status -> logs and returns without committing events 
- Permission not found -> logs warning and returns