### PR TITLE
fix(admin-console): Ensure Keycloak login directs relative to admin console module

### DIFF
--- a/admin-console/src/main/java/energy/eddie/outbound/admin/console/config/AdminConsoleSecurityConfig.java
+++ b/admin-console/src/main/java/energy/eddie/outbound/admin/console/config/AdminConsoleSecurityConfig.java
@@ -59,8 +59,14 @@ public class AdminConsoleSecurityConfig {
                             .loginPage(ADMIN_CONSOLE_BASE_URL + "/login").defaultSuccessUrl(ADMIN_CONSOLE_BASE_URL)
                             .failureUrl(ADMIN_CONSOLE_BASE_URL + "/login?error").permitAll()
                     );
-            case "keycloak" -> http
-                    .oauth2Login(Customizer.withDefaults());
+            case "keycloak" -> http.oauth2Login(oauth -> oauth
+                    .authorizationEndpoint(authorization -> authorization
+                            .baseUri(ADMIN_CONSOLE_BASE_URL + "/oauth2/authorization")
+                    )
+                    .redirectionEndpoint(redirection -> redirection
+                            .baseUri(ADMIN_CONSOLE_BASE_URL + "/login/oauth2/code/keycloak")
+                    )
+            );
             default -> throw new IllegalStateException(
                     "Unsupported value for outbound-connector.admin.console.login.mode: " + authMode);
         }


### PR DESCRIPTION
Related to an issue where the Keycloak login redirect for the admin console does not work when behind a proxy. This does not add any configuration for ensuring the absolute path is correct. The URIs do not take absolute paths and I did not yet figure out a way to consistently use the public URL here.