### PR TITLE
docs(aiida): add documentation for permission commands

### DIFF
--- a/aiida/docs/1-running/data-need.md
+++ b/aiida/docs/1-running/data-need.md
@@ -6,22 +6,22 @@ AIIDA supports two types of data needs: inbound and outbound. Outbound data need
 
 ## Fields
 
-| Field                       | Type     | Description                                                                                                                            |
-|-----------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `type`                      | String   | Type of the data need, either `outbound-aiida` or `inbound-aiida`.                                                                     |
-| `id`                        | String   | Unique id that can be used to reference this data need.                                                                                |
-| `name`                      | String   | Short memorable name of the data need that may be presented to the customer.                                                           |
-| `description`               | String   | Multiline string that describes this data need in a human readable form to be shown in the UI.                                         |
-| `purpose`                   | String   | Multiline string that describes the purpose of this data need.                                                                         |
-| `policyLink`                | URL      | URL to the data policy that applies to this data need.                                                                                 |
-| `enabled`                   | boolean  | Enables or disables a data need.                                                                                                       |
-| `duration`                  | Object   | Describes the timeframe for this data need.                                                                                            |
-| `transmissionSchedule`      | String   | Cron expression that defines how often the data should be sent or received.                                                            |
-| `allowedPermissionCommands` | String[] | Permission commands the EP may send to remotely control transmission. See [Transmission Control](#transmission-control). Default `[]`. |
-| `acknowledgementRequired`   | boolean  | Whether an acknowledgement is required for the data transmission. See [Acknowledgement](#acknowledgement).                             |
-| `schemas`                   | String[] | Schemas that define the structure and format of the data, e.g. standardized schemas such as CIM or custom schemas.                     |
-| `asset`                     | String   | The asset that the data need is associated with, linking the data to specific physical or logical assets.                              |
-| `dataTags`                  | String[] | Data tags that further specify the type of data that is expected.                                                                      |
+| Field                       | Type     | Description                                                                                                                          |
+|-----------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `type`                      | String   | Type of the data need, either `outbound-aiida` or `inbound-aiida`.                                                                   |
+| `id`                        | String   | Unique id that can be used to reference this data need.                                                                              |
+| `name`                      | String   | Short memorable name of the data need that may be presented to the customer.                                                         |
+| `description`               | String   | Multiline string that describes this data need in a human readable form to be shown in the UI.                                       |
+| `purpose`                   | String   | Multiline string that describes the purpose of this data need.                                                                       |
+| `policyLink`                | URL      | URL to the data policy that applies to this data need.                                                                               |
+| `enabled`                   | boolean  | Enables or disables a data need.                                                                                                     |
+| `duration`                  | Object   | Describes the timeframe for this data need.                                                                                          |
+| `transmissionSchedule`      | String   | Cron expression that defines how often the data should be sent or received.                                                          |
+| `allowedPermissionCommands` | String[] | Permission commands the EP may send to remotely control transmission. See [Permission Commands](#permission-commands). Default `[]`. |
+| `acknowledgementRequired`   | boolean  | Whether an acknowledgement is required for the data transmission. See [Acknowledgement](#acknowledgement).                           |
+| `schemas`                   | String[] | Schemas that define the structure and format of the data, e.g. standardized schemas such as CIM or custom schemas.                   |
+| `asset`                     | String   | The asset that the data need is associated with, linking the data to specific physical or logical assets.                            |
+| `dataTags`                  | String[] | Data tags that further specify the type of data that is expected.                                                                    |
 
 ## Outbound
 

--- a/cim/src/main/schemas/agnostic/json/permission-command.json
+++ b/cim/src/main/schemas/agnostic/json/permission-command.json
@@ -65,13 +65,13 @@
       ]
     },
     {
-      "description": "Revokes a permission.",
+      "description": "Terminates a permission, causing the region connector to stop transmitting data for it and clean up any associated resources.",
       "type": "object",
       "properties": {
         "action": {
           "type": "string",
           "enum": [
-            "REVOKE_PERMISSION"
+            "TERMINATE"
           ]
         },
         "regionConnectorId": {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -178,6 +178,10 @@ export default withMermaid(
                       text: "Opaque Envelopes",
                       link: "/2-integrating/messages/agnostic.md#opaque-envelopes",
                     },
+                    {
+                      text: "Permission Commands",
+                      link: "/2-integrating/messages/agnostic.md#permission-commands",
+                    },
                   ],
                 },
                 {

--- a/docs/1-running/outbound-connectors/outbound-connector-amqp.md
+++ b/docs/1-running/outbound-connectors/outbound-connector-amqp.md
@@ -32,6 +32,10 @@ The following topics are created upon starting this outbound-connector:
   Allows the eligible party to send [min-max envelopes](../../2-integrating/messages/cim/min-max-envelope.md).
 - `ep.${outbound-connector.amqp.eddie-id}.cim_1_12.energy-sharing-reference-data-md`:
   Provides the eligible party with [Energy Sharing Reference Data Market Documents](../../2-integrating/messages/cim/energy-sharing-reference-data-market-documents.md).
+- `fw.${outbound-connector.amqp.eddie-id}.agnostic.permission-command`:
+  Allows the eligible party to send [permission commands](../../2-integrating/messages/agnostic.md#permission-commands) to remotely control an active permission (adjust the transmission schedule, enable/disable transmission, or terminate).
+- `fw.${outbound-connector.amqp.eddie-id}.agnostic.opaque-envelope`:
+  Allows the eligible party to send [opaque envelopes](../../2-integrating/messages/agnostic.md#opaque-envelopes) to a region connector.
 
 ## Properties of messages
 

--- a/docs/1-running/outbound-connectors/outbound-connector-kafka.md
+++ b/docs/1-running/outbound-connectors/outbound-connector-kafka.md
@@ -63,6 +63,10 @@ The following topics are created upon starting this outbound-connector:
   Allows the eligible party to send [min-max envelopes](../../2-integrating/messages/cim/min-max-envelope.md).
 - `ep.${outbound-connector.kafka.eddie-id}.cim_1_12.energy-sharing-reference-data-md`:
   Provides the eligible party with [Energy Sharing Reference Data Market Documents](../../2-integrating/messages/cim/energy-sharing-reference-data-market-documents.md).
+- `fw.${outbound-connector.kafka.eddie-id}.agnostic.permission-command`:
+  Allows the eligible party to send [permission commands](../../2-integrating/messages/agnostic.md#permission-commands) to remotely control an active permission (adjust the transmission schedule, enable/disable transmission, or terminate).
+- `fw.${outbound-connector.kafka.eddie-id}.agnostic.opaque-envelope`:
+  Allows the eligible party to send [opaque envelopes](../../2-integrating/messages/agnostic.md#opaque-envelopes) to a region connector.
 
 ## Headers of messages
 

--- a/docs/2-integrating/messages/agnostic.md
+++ b/docs/2-integrating/messages/agnostic.md
@@ -80,3 +80,62 @@ classDiagram
         +String payload
     }
 ```
+
+## Permission Commands
+
+Permission commands are control signals the eligible party sends *to* a region connector to remotely
+control an existing permission. This is currently only supported by AIIDA. In contrast to the other agnostic messages, which flow from EDDIE to
+the EP, permission commands flow from the EP into EDDIE (e.g. via the REST outbound connector's
+`POST /agnostic/permission-command` endpoint or the Kafka permission-command topic).
+The JSON schema and XSD files can be found [here](https://github.com/eddie-energy/eddie/tree/main/cim/src/main/schemas/agnostic).
+
+The `action` field is the discriminator and selects the command's payload. The available actions are:
+
+| Action                         | Extra field            | Description                                                                                        |
+|--------------------------------|------------------------|----------------------------------------------------------------------------------------------------|
+| `UPDATE_TRANSMISSION_SCHEDULE` | `transmissionSchedule` | Adjusts the transmission schedule (cron); effective schedule is capped at the data-need frequency. |
+| `SET_TRANSMISSION_ENABLED`     | `enabled`              | Enables or disables transmission for the permission.                                               |
+| `TERMINATE`                    | –                      | Terminates the permission; the region connector stops transmitting and cleans up resources.        |
+
+Whether a command is accepted depends on both the data need and the region connector's ability to
+handle it: `UPDATE_TRANSMISSION_SCHEDULE` and
+`SET_TRANSMISSION_ENABLED` are only honored if the data need lists them in `allowedPermissionCommands`,
+while `TERMINATE` is always accepted. See the AIIDA
+[data-need permission commands](https://architecture.eddie.energy/aiida/1-running/data-need.html#permission-commands)
+documentation for details.
+
+```mermaid
+classDiagram
+    class PermissionCommand {
+        <<interface>>
+        +String regionConnectorId
+        +UUID permissionId
+        +Action action
+    }
+
+    class UpdateTransmissionSchedule {
+        +String transmissionSchedule
+    }
+
+    class SetTransmissionEnabled {
+        +boolean enabled
+    }
+
+    class Terminate {
+    }
+
+    PermissionCommand <|-- UpdateTransmissionSchedule
+    PermissionCommand <|-- SetTransmissionEnabled
+    PermissionCommand <|-- Terminate
+```
+
+Example (`UPDATE_TRANSMISSION_SCHEDULE`):
+
+```json
+{
+  "regionConnectorId": "aiida",
+  "permissionId": "ffcb8491-1f82-4d9d-9ddf-f1312796045a",
+  "action": "UPDATE_TRANSMISSION_SCHEDULE",
+  "transmissionSchedule": "0 */1 * * * *"
+}
+```

--- a/docs/2-integrating/messages/messages.md
+++ b/docs/2-integrating/messages/messages.md
@@ -28,6 +28,7 @@ The data is emitted via [the validated historical data market document](./cim/va
 Furthermore, the data is forwarded **as received from the MDA** via [raw data messages](./agnostic.md#raw-data-messages).
 At this point, it is possible for the eligible party to request the termination of the permission request.
 This is done via [the termination document](./cim/permission-market-documents.md#termination-documents).
+   For AIIDA permissions, the eligible party may also remotely control the transmission of an active permission via [permission commands](./agnostic.md#permission-commands), e.g. to pause/resume transmission, adjust the transmission schedule, or terminate the permission.
 If the data that is received is incomplete, it is possible to re-request data via [the redistribution transaction request document](./cim/redistribution-transaction-request-documents.md).
 6. If the final customer revokes the permission, EDDIE emits a CSM and PMD notifying the eligible party.
 If the eligible party terminates a permission request, they are notified about the status of the permission request in the termination process described in [the permission process model](../permission-requests.md#permission-process-model).


### PR DESCRIPTION
And already modified in arch documentation:

https://architecture.eddie.energy/architecture/appendix/aiida-communication/aiida-communication.html#_4b-eddie-rarr-aiida-permission-command-optional