### PR TITLE
feat(de-eta-region-connector): allow retransmission of validated historical data (GH-2200)

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
@@ -47,34 +47,57 @@ public class EtaPlusApiClient {
     }
 
     /**
-     * Fetch validated historical metered data for a permission request.
+     * Fetch validated historical metered data for a permission request over its full range,
+     * capped at today (the API holds no data for future dates).
+     *
      * @param permissionRequest the permission request containing connection details
+     * @param accessToken       the customer's OAuth bearer token
      * @return a Mono emitting the metered data or an error
      */
     public Mono<EtaPlusMeteredData> fetchMeteredData(DePermissionRequest permissionRequest, String accessToken) {
+        LocalDate today = LocalDate.now(EtaRegionConnectorMetadata.DE_ZONE_ID);
+        LocalDate effectiveEnd = permissionRequest.end().isAfter(today) ? today : permissionRequest.end();
+        return fetchMeteredData(permissionRequest, accessToken, permissionRequest.start(), effectiveEnd);
+    }
+
+    /**
+     * Fetch validated historical metered data for a permission request over an explicit window.
+     * Used for retransmission requests, where the eligible party specifies the timeframe. The
+     * caller is responsible for supplying a valid window (within the permission range and in the
+     * past); see {@link energy.eddie.regionconnector.shared.retransmission.RetransmissionValidation}.
+     *
+     * @param permissionRequest the permission request containing connection details
+     * @param accessToken       the customer's OAuth bearer token
+     * @param from              inclusive lower bound of the request window
+     * @param to                inclusive upper bound of the request window
+     * @return a Mono emitting the metered data or an error
+     */
+    public Mono<EtaPlusMeteredData> fetchMeteredData(
+            DePermissionRequest permissionRequest,
+            String accessToken,
+            LocalDate from,
+            LocalDate to
+    ) {
         LOGGER.atInfo()
                 .addArgument(permissionRequest::permissionId)
                 .addArgument(permissionRequest::meteringPointId)
-                .addArgument(permissionRequest::start)
-                .addArgument(permissionRequest::end)
+                .addArgument(() -> from)
+                .addArgument(() -> to)
                 .log("Fetching metered data for permission request {} with metering point {} from {} to {}");
-
-        LocalDate today = LocalDate.now(EtaRegionConnectorMetadata.DE_ZONE_ID);
-        LocalDate effectiveEnd = permissionRequest.end().isAfter(today) ? today : permissionRequest.end();
 
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(configuration.meteredDataEndpoint())
                         .queryParam("meteringPointId", permissionRequest.meteringPointId())
-                        .queryParam("from", permissionRequest.start().atStartOfDay())
-                        .queryParam("to", effectiveEnd.atStartOfDay())
+                        .queryParam("from", from.atStartOfDay())
+                        .queryParam("to", to.atStartOfDay())
                         .build())
                 .header("Authorization", "Bearer " + accessToken)
                 .retrieve()
                 .bodyToFlux(EtaPlusReadingDto.class)
                 .timeout(Duration.ofSeconds(configuration.responseTimeoutSeconds()))
                 .collectList()
-                .map(readings -> mapToDomain(readings, permissionRequest, effectiveEnd))
+                .map(readings -> mapToDomain(readings, permissionRequest, from, to))
                 .retryWhen(retrySpec(permissionRequest.permissionId()))
                 .onErrorMap(WebClientResponseException.Unauthorized.class, ex ->
                         new AuthenticationException(
@@ -104,7 +127,8 @@ public class EtaPlusApiClient {
     private EtaPlusMeteredData mapToDomain(
             List<EtaPlusReadingDto> readings,
             DePermissionRequest request,
-            LocalDate effectiveEnd
+            LocalDate from,
+            LocalDate to
     ) {
         List<EtaPlusMeteredData.MeterReading> domainReadings = readings.stream()
                 .filter(dto -> dto.timestamp() != null)
@@ -119,8 +143,8 @@ public class EtaPlusApiClient {
 
         return new EtaPlusMeteredData(
                 request.meteringPointId(),
-                request.start(),
-                effectiveEnd,
+                from,
+                to,
                 domainReadings
         );
     }

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/ValidatedHistoricalDataStream.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/providers/ValidatedHistoricalDataStream.java
@@ -92,12 +92,39 @@ public class ValidatedHistoricalDataStream implements AutoCloseable {
         }
 
         IdentifiableValidatedHistoricalData identifiableData = new IdentifiableValidatedHistoricalData(permissionRequest, data);
-        Sinks.EmitResult emitResult = sink.tryEmitNext(identifiableData);
+        emit(identifiableData);
+        determineAndEmitLatestReading(identifiableData);
+    }
 
+    /**
+     * Publishes retransmitted validated historical data to the outbound stream without mutating
+     * permission state.
+     *
+     * <p>Unlike {@link #publish(DePermissionRequest, EtaPlusMeteredData)}, this method neither
+     * updates the latest-meter-reading watermark nor emits any status event. A retransmission
+     * re-delivers data the eligible party already received for a window in the past, so it must
+     * not regress the fulfillment watermark — which would otherwise trigger redundant re-polling
+     * of the whole range — nor change the permission's status (e.g. to
+     * {@link PermissionProcessStatus#UNFULFILLABLE}). The data still reaches the outbound
+     * connectors through the same stream consumed by the raw-data and CIM providers.
+     *
+     * @param permissionRequest the permission request the data belongs to
+     * @param data              the validated historical data fetched for the retransmission window
+     */
+    public void publishRetransmission(DePermissionRequest permissionRequest, EtaPlusMeteredData data) {
+        LOGGER.atInfo()
+                .addArgument(permissionRequest::permissionId)
+                .addArgument(data::meteringPointId)
+                .log("Publishing retransmitted validated historical data for permission request {} with metering point {}");
+
+        emit(new IdentifiableValidatedHistoricalData(permissionRequest, data));
+    }
+
+    private void emit(IdentifiableValidatedHistoricalData identifiableData) {
+        Sinks.EmitResult emitResult = sink.tryEmitNext(identifiableData);
         if (emitResult.isFailure()) {
             LOGGER.warn("Failed to emit data to stream: {}", emitResult);
         }
-        determineAndEmitLatestReading(identifiableData);
     }
 
     private boolean isEnergyTypeValid(

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/retransmission/EtaRetransmissionPollingFunction.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/retransmission/EtaRetransmissionPollingFunction.java
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 The ETA+ Developers <bilal.sakhawat@etaplus.energy>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.retransmission;
+
+import energy.eddie.api.agnostic.retransmission.RetransmissionRequest;
+import energy.eddie.api.agnostic.retransmission.result.DataNotAvailable;
+import energy.eddie.api.agnostic.retransmission.result.Failure;
+import energy.eddie.api.agnostic.retransmission.result.RetransmissionResult;
+import energy.eddie.api.agnostic.retransmission.result.Success;
+import energy.eddie.regionconnector.de.eta.EtaRegionConnectorMetadata;
+import energy.eddie.regionconnector.de.eta.client.EtaPlusApiClient;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.persistence.DePermissionCredentialsRepository;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
+import energy.eddie.regionconnector.de.eta.providers.ValidatedHistoricalDataStream;
+import energy.eddie.regionconnector.shared.retransmission.PollingFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * Polls validated historical data for retransmission requests from the ETA Plus API.
+ *
+ * <p>Invoked by {@link energy.eddie.regionconnector.shared.retransmission.CommonRetransmissionService}
+ * only after the request has been validated (permission accepted/fulfilled, validated-historical-data
+ * need, and a window inside the permission range and in the past). The fetched data is emitted to the
+ * outbound connectors via {@link ValidatedHistoricalDataStream#publishRetransmission}, which does not
+ * alter permission state.
+ */
+@Service
+public class EtaRetransmissionPollingFunction implements PollingFunction<DePermissionRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EtaRetransmissionPollingFunction.class);
+
+    private final EtaPlusApiClient apiClient;
+    private final ValidatedHistoricalDataStream stream;
+    private final DePermissionCredentialsRepository credentialsRepository;
+
+    public EtaRetransmissionPollingFunction(
+            EtaPlusApiClient apiClient,
+            ValidatedHistoricalDataStream stream,
+            DePermissionCredentialsRepository credentialsRepository
+    ) {
+        this.apiClient = apiClient;
+        this.stream = stream;
+        this.credentialsRepository = credentialsRepository;
+    }
+
+    @Override
+    public Mono<RetransmissionResult> poll(
+            DePermissionRequest permissionRequest,
+            RetransmissionRequest retransmissionRequest
+    ) {
+        String permissionId = permissionRequest.permissionId();
+        return credentialsRepository.findByPermissionId(permissionId)
+                .map(credentials -> fetchAndPublish(permissionRequest, retransmissionRequest, credentials.accessToken()))
+                .orElseGet(() -> {
+                    LOGGER.atWarn()
+                          .addArgument(permissionId)
+                          .log("Cannot retransmit data for permission {}: no credentials available");
+                    return Mono.just(new Failure(permissionId, now(), "No credentials available for permission " + permissionId));
+                });
+    }
+
+    private Mono<RetransmissionResult> fetchAndPublish(
+            DePermissionRequest permissionRequest,
+            RetransmissionRequest retransmissionRequest,
+            String accessToken
+    ) {
+        String permissionId = permissionRequest.permissionId();
+        LOGGER.atInfo()
+              .addArgument(permissionId)
+              .addArgument(retransmissionRequest::from)
+              .addArgument(retransmissionRequest::to)
+              .log("Polling validated historical data for retransmission of permission {} from {} to {}");
+
+        return apiClient.fetchMeteredData(
+                        permissionRequest, accessToken, retransmissionRequest.from(), retransmissionRequest.to())
+                .filter(EtaRetransmissionPollingFunction::hasReadings)
+                .doOnNext(data -> stream.publishRetransmission(permissionRequest, data))
+                .map(data -> new Success(permissionId, now()))
+                .cast(RetransmissionResult.class)
+                .defaultIfEmpty(new DataNotAvailable(permissionId, now()))
+                .onErrorResume(error -> {
+                    LOGGER.atWarn()
+                          .addArgument(permissionId)
+                          .setCause(error)
+                          .log("Retransmission polling failed for permission {}");
+                    return Mono.just(new Failure(permissionId, now(), error.getMessage()));
+                });
+    }
+
+    private static boolean hasReadings(EtaPlusMeteredData data) {
+        List<EtaPlusMeteredData.MeterReading> readings = data.readings();
+        return readings != null && !readings.isEmpty();
+    }
+
+    private static ZonedDateTime now() {
+        return ZonedDateTime.now(EtaRegionConnectorMetadata.DE_ZONE_ID);
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/retransmission/RetransmissionConfig.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/retransmission/RetransmissionConfig.java
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 The ETA+ Developers <bilal.sakhawat@etaplus.energy>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.retransmission;
+
+import energy.eddie.dataneeds.services.DataNeedsService;
+import energy.eddie.regionconnector.de.eta.EtaRegionConnectorMetadata;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.persistence.DePermissionRequestRepository;
+import energy.eddie.regionconnector.shared.retransmission.CommonRetransmissionService;
+import energy.eddie.regionconnector.shared.retransmission.RetransmissionValidation;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the retransmission feature for the German (ETA Plus) region connector.
+ *
+ * <p>The {@link CommonRetransmissionService} bean is auto-discovered by the core
+ * {@code RetransmissionRouterRegistrar}, which registers it with the retransmission router and
+ * makes the connector advertise support for retransmission requests.
+ */
+@Configuration
+public class RetransmissionConfig {
+
+    @Bean
+    public CommonRetransmissionService<DePermissionRequest> retransmissionService(
+            DePermissionRequestRepository repository,
+            EtaRetransmissionPollingFunction pollingFunction,
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") DataNeedsService dataNeedsService
+    ) {
+        return new CommonRetransmissionService<>(
+                repository,
+                pollingFunction,
+                new RetransmissionValidation(EtaRegionConnectorMetadata.getInstance(), dataNeedsService)
+        );
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClientTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClientTest.java
@@ -326,6 +326,32 @@ class EtaPlusApiClientTest {
     }
 
     @Test
+    void fetchMeteredData_explicitWindow_usesGivenRange_notPermissionRange() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("[]"));
+
+        // Permission spans Jan–Jun; retransmission asks only for February.
+        DePermissionRequest request = buildRequest(
+                "perm-window", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 6, 30));
+        LocalDate from = LocalDate.of(2024, 2, 1);
+        LocalDate to = LocalDate.of(2024, 2, 29);
+
+        StepVerifier.create(apiClient.fetchMeteredData(request, "test-token", from, to))
+                .assertNext(data -> {
+                    assertThat(data.startDate()).isEqualTo(from);
+                    assertThat(data.endDate()).isEqualTo(to);
+                })
+                .verifyComplete();
+
+        RecordedRequest recorded = takeLatestRequest();
+        assertThat(recorded).isNotNull();
+        assertThat(recorded.getPath()).contains("from=2024-02-01T00:00");
+        assertThat(recorded.getPath()).contains("to=2024-02-29T00:00");
+    }
+
+    @Test
     void fetchMeteredData_sendsBearerTokenInAuthorizationHeader() throws InterruptedException {
         server.enqueue(new MockResponse()
                 .setResponseCode(200)

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/ValidatedHistoricalDataStreamTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/providers/ValidatedHistoricalDataStreamTest.java
@@ -25,9 +25,12 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import reactor.test.StepVerifier;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class ValidatedHistoricalDataStreamTest {
@@ -157,6 +160,39 @@ class ValidatedHistoricalDataStreamTest {
         stream.publish(pr, data);
 
         assertLatestMeterReadingCommitted();
+    }
+
+    // ---- Retransmission ----
+
+    @Test
+    void publishRetransmission_emitsToStream_withoutCommittingAnyEvent() {
+        var pr = electricityRequest(Granularity.PT15M);
+        ZonedDateTime t0 = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var data = new EtaPlusMeteredData("MP-1", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1),
+                List.of(reading(t0, "kWh"), reading(t0.plusMinutes(15), "kWh")));
+
+        StepVerifier.create(stream.validatedHistoricalData())
+                    .then(() -> stream.publishRetransmission(pr, data))
+                    .assertNext(emitted -> {
+                        assertThat(emitted.permissionRequest()).isEqualTo(pr);
+                        assertThat(emitted.payload()).isEqualTo(data);
+                    })
+                    .thenCancel()
+                    .verify();
+
+        // A retransmission must not regress the watermark or change permission status.
+        verifyNoInteractions(outbox);
+    }
+
+    @Test
+    void publishRetransmission_doesNotEnforceDataNeedConstraints() {
+        // Wrong commodity unit would mark UNFULFILLABLE via publish(); retransmission must not.
+        var pr = electricityRequest(Granularity.PT15M);
+        var data = meteredData("m³", Granularity.PT15M);
+
+        stream.publishRetransmission(pr, data);
+
+        verifyNoInteractions(outbox);
     }
 
     // ---- Helpers ----

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/retransmission/EtaRetransmissionPollingFunctionTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/retransmission/EtaRetransmissionPollingFunctionTest.java
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 The ETA+ Developers <bilal.sakhawat@etaplus.energy>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.retransmission;
+
+import energy.eddie.api.agnostic.retransmission.RetransmissionRequest;
+import energy.eddie.api.agnostic.retransmission.result.DataNotAvailable;
+import energy.eddie.api.agnostic.retransmission.result.Failure;
+import energy.eddie.api.agnostic.retransmission.result.RetransmissionResult;
+import energy.eddie.api.agnostic.retransmission.result.Success;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.regionconnector.de.eta.client.EtaPlusApiClient;
+import energy.eddie.regionconnector.de.eta.permission.credentials.DePermissionCredentials;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequest;
+import energy.eddie.regionconnector.de.eta.permission.request.DePermissionRequestBuilder;
+import energy.eddie.regionconnector.de.eta.persistence.DePermissionCredentialsRepository;
+import energy.eddie.regionconnector.de.eta.providers.EtaPlusMeteredData;
+import energy.eddie.regionconnector.de.eta.providers.ValidatedHistoricalDataStream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EtaRetransmissionPollingFunctionTest {
+
+    private static final String PERMISSION_ID = "pid";
+    private static final String TOKEN = "token-abc";
+    private static final LocalDate FROM = LocalDate.of(2026, 1, 1);
+    private static final LocalDate TO = LocalDate.of(2026, 2, 1);
+
+    @Mock private EtaPlusApiClient apiClient;
+    @Mock private ValidatedHistoricalDataStream stream;
+    @Mock private DePermissionCredentialsRepository credentialsRepository;
+
+    @InjectMocks private EtaRetransmissionPollingFunction pollingFunction;
+
+    private DePermissionRequest request() {
+        return new DePermissionRequestBuilder()
+                .permissionId(PERMISSION_ID)
+                .meteringPointId("malo-1")
+                .start(FROM.minusDays(10))
+                .end(TO.plusDays(10))
+                .status(PermissionProcessStatus.ACCEPTED)
+                .build();
+    }
+
+    private RetransmissionRequest retransmissionRequest() {
+        return new RetransmissionRequest("de-eta", PERMISSION_ID, FROM, TO);
+    }
+
+    private void withCredentials() {
+        when(credentialsRepository.findByPermissionId(PERMISSION_ID))
+                .thenReturn(Optional.of(new DePermissionCredentials(PERMISSION_ID, TOKEN, null)));
+    }
+
+    @Test
+    void poll_publishesAndReturnsSuccess_whenReadingsPresent() {
+        DePermissionRequest pr = request();
+        EtaPlusMeteredData data = new EtaPlusMeteredData("malo-1", FROM, TO, List.of(
+                new EtaPlusMeteredData.MeterReading(
+                        ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), 1.0, "kWh", "VALIDATED", "Consumption")));
+        withCredentials();
+        when(apiClient.fetchMeteredData(pr, TOKEN, FROM, TO)).thenReturn(Mono.just(data));
+
+        StepVerifier.create(pollingFunction.poll(pr, retransmissionRequest()))
+                    .assertNext(result -> assertThat(result)
+                            .asInstanceOf(InstanceOfAssertFactories.type(Success.class))
+                            .extracting(Success::permissionId)
+                            .isEqualTo(PERMISSION_ID))
+                    .verifyComplete();
+
+        verify(stream).publishRetransmission(pr, data);
+    }
+
+    @Test
+    void poll_returnsDataNotAvailable_andDoesNotPublish_whenNoReadings() {
+        DePermissionRequest pr = request();
+        EtaPlusMeteredData data = new EtaPlusMeteredData("malo-1", FROM, TO, List.of());
+        withCredentials();
+        when(apiClient.fetchMeteredData(pr, TOKEN, FROM, TO)).thenReturn(Mono.just(data));
+
+        StepVerifier.create(pollingFunction.poll(pr, retransmissionRequest()))
+                    .assertNext(result -> assertThat(result)
+                            .isInstanceOf(DataNotAvailable.class)
+                            .extracting(RetransmissionResult::permissionId)
+                            .isEqualTo(PERMISSION_ID))
+                    .verifyComplete();
+
+        verifyNoInteractions(stream);
+    }
+
+    @Test
+    void poll_returnsFailure_onApiError() {
+        DePermissionRequest pr = request();
+        withCredentials();
+        when(apiClient.fetchMeteredData(pr, TOKEN, FROM, TO))
+                .thenReturn(Mono.error(new RuntimeException("boom")));
+
+        StepVerifier.create(pollingFunction.poll(pr, retransmissionRequest()))
+                    .assertNext(result -> assertThat(result)
+                            .asInstanceOf(InstanceOfAssertFactories.type(Failure.class))
+                            .satisfies(failure -> {
+                                assertThat(failure.permissionId()).isEqualTo(PERMISSION_ID);
+                                assertThat(failure.reason()).isEqualTo("boom");
+                            }))
+                    .verifyComplete();
+
+        verifyNoInteractions(stream);
+    }
+
+    @Test
+    void poll_returnsFailure_andDoesNotCallApi_whenNoCredentials() {
+        DePermissionRequest pr = request();
+        when(credentialsRepository.findByPermissionId(PERMISSION_ID)).thenReturn(Optional.empty());
+
+        StepVerifier.create(pollingFunction.poll(pr, retransmissionRequest()))
+                    .assertNext(result -> assertThat(result)
+                            .asInstanceOf(InstanceOfAssertFactories.type(Failure.class))
+                            .extracting(Failure::permissionId)
+                            .isEqualTo(PERMISSION_ID))
+                    .verifyComplete();
+
+        verifyNoInteractions(apiClient);
+        verifyNoInteractions(stream);
+    }
+}


### PR DESCRIPTION
GH-2200 Allow retransmission of validated historical data

---

## Description

Eligible parties sometimes need a past window of validated historical data to be
sent again for a permission, for example when part of the data is missing on their
side. This change adds support for retransmission of validated historical data for
a single permission.

An eligible party specifies the permission and the time window. The request is
validated, the data for that window is fetched, and it is emitted to the outbound
connectors so it reaches the eligible party through the same delivery path used for
normal data. The outcome is reported back as success, no data available, or
failure.

A request is served only when the permission exists and is accepted or fulfilled,
its data need is validated historical data, and the requested window lies inside
the permission dates and is fully in the past.

Emitting retransmitted data does not change permission state. It does not update
the latest meter reading watermark and does not emit any status event. The
permission read model derives the latest meter reading from the most recent event,
so updating it from a past window would move the watermark backwards. That would
make the scheduled poll treat data as missing and re-fetch and re-send the whole
range on its next run. A dedicated emit path avoids this.


## Behaviour

- Window with readings: data is emitted to the outbound connectors and the result
  is success.
- Window with no readings: nothing is emitted and the result is no data available.
- Fetch error: nothing is emitted and the result is failure carrying the error
  reason.
- No access token for the permission: no fetch is performed and the result is
  failure.
- Retransmission never updates the latest meter reading watermark and never emits a
  status event, so the permission state and the scheduled poll are not affected.