### PR TITLE
feat(de-eta-region-connector): time out stale permission requests (GH-2201)

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/TimeoutBeanConfiguration.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/TimeoutBeanConfiguration.java
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 The ETA+ Developers <bilal.sakhawat@etaplus.energy>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta;
+
+import energy.eddie.regionconnector.de.eta.permission.request.events.SimpleEvent;
+import energy.eddie.regionconnector.de.eta.persistence.DePermissionRequestRepository;
+import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
+import energy.eddie.regionconnector.shared.timeout.CommonTimeoutService;
+import energy.eddie.regionconnector.shared.timeout.TimeoutConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the permission request timeout feature for the German (ETA Plus) region connector.
+ *
+ * <p>Final customers sometimes ignore permission requests; since those can never be used to
+ * retrieve data, they are timed out by the shared {@link CommonTimeoutService}. The service runs
+ * on the schedule defined by the shared {@code @Timeout} annotation (enabled by the
+ * {@code @EnableScheduling} on {@link DeEtaSpringConfig}), queries stale requests via
+ * {@link DePermissionRequestRepository#findStalePermissionRequests(int)} and emits the
+ * corresponding timeout events through the {@link Outbox}.
+ */
+@Configuration
+public class TimeoutBeanConfiguration {
+
+    @Bean
+    public CommonTimeoutService timeoutService(
+            DePermissionRequestRepository repository,
+            Outbox outbox,
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+            TimeoutConfiguration timeoutConfiguration
+    ) {
+        return new CommonTimeoutService(
+                repository,
+                SimpleEvent::new,
+                outbox,
+                timeoutConfiguration,
+                EtaRegionConnectorMetadata.getInstance()
+        );
+    }
+}


### PR DESCRIPTION
## Description

Permission requests that have been sent to the permission administrator and left
unanswered can never be used to retrieve data, but they stay open and keep
counting as active. This change closes those abandoned requests automatically.

A scheduled job now looks for permission requests that have been waiting in the
sent to permission administrator state longer than a configured period and moves
each of them to the timed out state. The waiting period and the run schedule are
configurable, with sensible defaults, so no further attention is needed once the
behaviour is enabled.


## Behaviour

- A permission request is timed out when it is in the sent to permission
  administrator state and its creation time is older than the configured
  staleness duration.
- Timing out a request emits a timed out status event through the outbox, which
  updates the permission read model so the request is no longer treated as
  active.
- The staleness duration defaults to one hundred sixty eight hours and the job
  runs every hour. Both values are configurable.