### PR TITLE
feat(de-eta-region-connector): add ETA+ API health indicator (GH-2202)

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/client/EtaPlusApiClient.java
@@ -47,6 +47,22 @@ public class EtaPlusApiClient {
     }
 
     /**
+     * Lightweight reachability probe for the ETA Plus API, used by the health indicator.
+     * Sends an unauthenticated GET to the API base URL; any received HTTP response other
+     * than a 5xx (including 401/404, which still prove the server is up and serving) is
+     * treated as alive. 5xx responses, connection failures and timeouts are not alive.
+     *
+     * @return a Mono emitting {@code true} when the API is reachable, {@code false} otherwise
+     */
+    public Mono<Boolean> isAlive() {
+        return webClient.get()
+                .uri("")
+                .exchangeToMono(response -> response.releaseBody()
+                        .thenReturn(!response.statusCode().is5xxServerError()))
+                .timeout(Duration.ofSeconds(configuration.responseTimeoutSeconds()));
+    }
+
+    /**
      * Fetch validated historical metered data for a permission request over its full range,
      * capped at today (the API holds no data for future dates).
      *

--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/health/EtaPlusApiHealthIndicator.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/health/EtaPlusApiHealthIndicator.java
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 The ETA+ Developers <bilal.sakhawat@etaplus.energy>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.health;
+
+import energy.eddie.regionconnector.de.eta.client.EtaPlusApiClient;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+/**
+ * Health indicator reporting the reachability of the ETA Plus PA/MDA API.
+ * Delegates to {@link EtaPlusApiClient#isAlive()}: a reachable API is reported as
+ * {@code UP}, an unreachable one (5xx, connection failure or timeout) as {@code DOWN}.
+ */
+@Component
+public class EtaPlusApiHealthIndicator implements HealthIndicator {
+    private final EtaPlusApiClient api;
+
+    public EtaPlusApiHealthIndicator(EtaPlusApiClient api) {
+        this.api = api;
+    }
+
+    @Override
+    public Health health() {
+        return api.isAlive()
+                  .map(isAlive -> Boolean.TRUE.equals(isAlive) ? Health.up() : Health.down())
+                  .onErrorResume(Exception.class, e -> Mono.just(Health.down(e)))
+                  .onErrorResume(e -> Mono.just(Health.down()))
+                  .map(Health.Builder::build)
+                  .block();
+    }
+}

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/health/EtaPlusApiHealthIndicatorTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/health/EtaPlusApiHealthIndicatorTest.java
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 The ETA+ Developers <bilal.sakhawat@etaplus.energy>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.de.eta.health;
+
+import energy.eddie.regionconnector.de.eta.client.EtaPlusApiClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EtaPlusApiHealthIndicatorTest {
+    @Mock
+    private EtaPlusApiClient api;
+    @InjectMocks
+    private EtaPlusApiHealthIndicator indicator;
+
+    @Test
+    void healthIsUp_whenApiIsReachable() {
+        // Given
+        when(api.isAlive()).thenReturn(Mono.just(Boolean.TRUE));
+
+        // When
+        var res = indicator.health();
+
+        // Then
+        assertNotNull(res);
+        assertEquals(Status.UP, res.getStatus());
+    }
+
+    @Test
+    void healthIsDown_whenApiReturnsFalse() {
+        // Given
+        when(api.isAlive()).thenReturn(Mono.just(Boolean.FALSE));
+
+        // When
+        var res = indicator.health();
+
+        // Then
+        assertNotNull(res);
+        assertEquals(Status.DOWN, res.getStatus());
+    }
+
+    @Test
+    void healthIsDown_whenApiThrows() {
+        // Given
+        when(api.isAlive())
+                .thenReturn(
+                        Mono.error(
+                                WebClientResponseException.create(
+                                        HttpStatus.INTERNAL_SERVER_ERROR, "text", null, null, null, null
+                                )
+                        )
+                );
+
+        // When
+        var res = indicator.health();
+
+        // Then
+        assertNotNull(res);
+        assertEquals(Status.DOWN, res.getStatus());
+    }
+}


### PR DESCRIPTION
## Description

The region connector now reports the availability of the ETA Plus PA and MDA API through a health indicator. The status is surfaced on the standard health endpoint so operators and the surrounding platform can tell whether the upstream API is reachable.

The ETA Plus API exposes no dedicated health endpoint, and its data endpoints require a per customer OAuth token that is not available at health check time. The indicator therefore probes plain reachability of the configured API base URL. Any HTTP response returned by the server, including 401 and 404, proves the server is up and serving, so it is reported as UP. Server errors (5xx), connection failures, and timeouts are reported as DOWN.

## Behaviour

- A reachable API base URL results in health status UP.
- A 5xx response, a connection failure, or a timeout results in health status DOWN.
- The probe sends no credentials and reads no response body.