### PR TITLE
fix(de-eta-region-connector): end termination in the terminated state (GH-2199)

### DIFF
--- a/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/EtaRegionConnector.java
+++ b/region-connectors/region-connector-de-eta/src/main/java/energy/eddie/regionconnector/de/eta/EtaRegionConnector.java
@@ -59,7 +59,6 @@ public class EtaRegionConnector implements RegionConnector {
         }
 
         outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.TERMINATED));
-        outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.REQUIRES_EXTERNAL_TERMINATION));
 
         LOGGER.info("Permission {} marked for termination", permissionId);
     }

--- a/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/EtaRegionConnectorTest.java
+++ b/region-connectors/region-connector-de-eta/src/test/java/energy/eddie/regionconnector/de/eta/EtaRegionConnectorTest.java
@@ -44,7 +44,7 @@ class EtaRegionConnectorTest {
     }
 
     @Test
-    void terminatePermissionWhenPermissionExistsShouldCommitEvents() {
+    void terminatePermissionWhenPermissionAcceptedShouldCommitTerminatedEvent() {
         String permissionId = "test-permission-id";
         DePermissionRequest request = mock(DePermissionRequest.class);
         when(request.status()).thenReturn(PermissionProcessStatus.ACCEPTED);
@@ -53,14 +53,11 @@ class EtaRegionConnectorTest {
         connector.terminatePermission(permissionId);
 
         ArgumentCaptor<SimpleEvent> eventCaptor = ArgumentCaptor.forClass(SimpleEvent.class);
-        verify(outbox, times(2)).commit(eventCaptor.capture());
+        verify(outbox, times(1)).commit(eventCaptor.capture());
 
-        var events = eventCaptor.getAllValues();
-        assertThat(events).hasSize(2);
-        assertThat(events.get(0).permissionId()).isEqualTo(permissionId);
-        assertThat(events.get(0).status()).isEqualTo(PermissionProcessStatus.TERMINATED);
-        assertThat(events.get(1).permissionId()).isEqualTo(permissionId);
-        assertThat(events.get(1).status()).isEqualTo(PermissionProcessStatus.REQUIRES_EXTERNAL_TERMINATION);
+        var event = eventCaptor.getValue();
+        assertThat(event.permissionId()).isEqualTo(permissionId);
+        assertThat(event.status()).isEqualTo(PermissionProcessStatus.TERMINATED);
     }
 
     @Test


### PR DESCRIPTION
## Description

Terminating an accepted permission now ends in the terminated state. The
permission administrator offers no endpoint to terminate or revoke a permission
externally, so termination is completed locally rather than waiting for an
external step that cannot happen.

Previously a second status event was committed after the terminated event to
mark the permission as requiring external termination. The permission read model
keeps the most recent value for each field, so this later event became the
winning value and left every terminated permission in a non final state with
nothing to move it forward. Committing only the terminated event lets
termination settle in the terminated state, which stops further data retrieval
and triggers removal of the stored credentials for the permission.

## Behaviour

- Terminating an accepted permission moves it to the terminated state.
- No state that expects an external termination is emitted.
- Reaching the terminated state removes the stored credentials for the
  permission.