### PR TITLE
GH-2394 Allow selection of AIIDA inbound permissions as data sources

### DIFF
--- a/aiida/docs/1-running/data-need.md
+++ b/aiida/docs/1-running/data-need.md
@@ -6,22 +6,22 @@ AIIDA supports two types of data needs: inbound and outbound. Outbound data need
 
 ## Fields
 
-| Field                       | Type     | Description                                                                                                                          |
-|-----------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `type`                      | String   | Type of the data need, either `outbound-aiida` or `inbound-aiida`.                                                                   |
-| `id`                        | String   | Unique id that can be used to reference this data need.                                                                              |
-| `name`                      | String   | Short memorable name of the data need that may be presented to the customer.                                                         |
-| `description`               | String   | Multiline string that describes this data need in a human readable form to be shown in the UI.                                       |
-| `purpose`                   | String   | Multiline string that describes the purpose of this data need.                                                                       |
-| `policyLink`                | URL      | URL to the data policy that applies to this data need.                                                                               |
-| `enabled`                   | boolean  | Enables or disables a data need.                                                                                                     |
-| `duration`                  | Object   | Describes the timeframe for this data need.                                                                                          |
-| `transmissionSchedule`      | String   | Cron expression that defines how often the data should be sent or received.                                                          |
-| `allowedPermissionCommands` | String[] | Permission commands the EP may send to remotely control transmission. See [Permission Commands](#permission-commands). Default `[]`. |
-| `acknowledgementRequired`   | boolean  | Whether an acknowledgement is required for the data transmission. See [Acknowledgement](#acknowledgement).                           |
-| `schemas`                   | String[] | Schemas that define the structure and format of the data, e.g. standardized schemas such as CIM or custom schemas.                   |
-| `asset`                     | String   | The asset that the data need is associated with, linking the data to specific physical or logical assets.                            |
-| `dataTags`                  | String[] | Data tags that further specify the type of data that is expected.                                                                    |
+| Field                       | Type     | Description                                                                                                                                |
+|-----------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `type`                      | String   | Type of the data need, either `outbound-aiida` or `inbound-aiida`.                                                                         |
+| `id`                        | String   | Unique id that can be used to reference this data need.                                                                                    |
+| `name`                      | String   | Short memorable name of the data need that may be presented to the customer.                                                               |
+| `description`               | String   | Multiline string that describes this data need in a human readable form to be shown in the UI.                                             |
+| `purpose`                   | String   | Multiline string that describes the purpose of this data need.                                                                             |
+| `policyLink`                | URL      | URL to the data policy that applies to this data need.                                                                                     |
+| `enabled`                   | boolean  | Enables or disables a data need.                                                                                                           |
+| `duration`                  | Object   | Describes the timeframe for this data need.                                                                                                |
+| `transmissionSchedule`      | String   | Cron expression that defines how often the data should be sent or received.                                                                |
+| `allowedPermissionCommands` | String[] | Permission commands the EP may send to remotely control transmission. See [Permission Commands](#permission-commands). Default `[]`.       |
+| `acknowledgementRequired`   | boolean  | Whether an acknowledgement is required for the data transmission. See [Acknowledgement](#acknowledgement).                                 |
+| `schemas`                   | String[] | [Schemas](./schemas/schemas.md) that define the structure and format of the data, e.g. standardized schemas such as CIM or custom schemas. |
+| `asset`                     | String   | The asset that the data need is associated with, linking the data to specific physical or logical assets.                                  |
+| `dataTags`                  | String[] | Data tags that further specify the type of data that is expected.                                                                          |
 
 ## Outbound
 
@@ -56,6 +56,10 @@ AIIDA supports two types of data needs: inbound and outbound. Outbound data need
   ]
 }
 ```
+
+> [!TIP]
+> Outbound AIIDA data needs may also include inbound data schemas like `MIN-MAX-ENVELOPE-CIM-V1-12` and `OPAQUE`.
+> This will inform AIIDA that an inbound data source should be selected to forward such messages to the eligible party.
 
 ## Inbound
 

--- a/aiida/src/main/java/energy/eddie/aiida/aggregator/InboundAggregator.java
+++ b/aiida/src/main/java/energy/eddie/aiida/aggregator/InboundAggregator.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.health.registry.HealthContributorRegistry;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 
 @Component
 public class InboundAggregator extends Aggregator<InboundRecord> {
@@ -45,5 +46,9 @@ public class InboundAggregator extends Aggregator<InboundRecord> {
     protected void saveRecordToDatabase(InboundRecord dataRecord) {
         LOGGER.trace("Saving new inbound record to db");
         inboundRecordRepository.save(dataRecord);
+    }
+
+    public Flux<InboundRecord> inboundRecordFlux() {
+        return combinedRecordSink.asFlux().ofType(InboundRecord.class);
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/errors/GlobalExceptionHandler.java
+++ b/aiida/src/main/java/energy/eddie/aiida/errors/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import energy.eddie.aiida.errors.auth.InvalidUserException;
 import energy.eddie.aiida.errors.auth.UnauthorizedException;
 import energy.eddie.aiida.errors.datasource.DataSourceNotFoundException;
 import energy.eddie.aiida.errors.datasource.DataSourceSecretGenerationNotSupportedException;
+import energy.eddie.aiida.errors.datasource.IncompatibleDataSourceException;
 import energy.eddie.aiida.errors.datasource.InvalidDataSourceTypeException;
 import energy.eddie.aiida.errors.datasource.modbus.ModbusConnectionException;
 import energy.eddie.aiida.errors.datasource.modbus.ModbusDeviceConfigException;
@@ -91,6 +92,7 @@ public class GlobalExceptionHandler {
             ImageFormatException.class,
             ImageReadException.class,
             InvalidDataSourceTypeException.class,
+            IncompatibleDataSourceException.class,
             InvalidInboundPermissionException.class,
             MissingInboundMessageFormatException.class,
             ModbusDeviceConfigException.class,
@@ -135,6 +137,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({
+            InboundDataSourceInUseException.class,
             PermissionUnfulfillableException.class,
             PermissionStateTransitionException.class
     })

--- a/aiida/src/main/java/energy/eddie/aiida/errors/datasource/IncompatibleDataSourceException.java
+++ b/aiida/src/main/java/energy/eddie/aiida/errors/datasource/IncompatibleDataSourceException.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.aiida.errors.datasource;
+
+import java.util.UUID;
+
+public class IncompatibleDataSourceException extends Exception {
+    public IncompatibleDataSourceException(String message) {
+        super(message);
+    }
+
+    public IncompatibleDataSourceException(UUID dataSourceId, String message) {
+        super("Data source %s is incompatible: %s".formatted(dataSourceId, message));
+    }
+}

--- a/aiida/src/main/java/energy/eddie/aiida/errors/permission/InboundDataSourceInUseException.java
+++ b/aiida/src/main/java/energy/eddie/aiida/errors/permission/InboundDataSourceInUseException.java
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.aiida.errors.permission;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class InboundDataSourceInUseException extends Exception {
+    public InboundDataSourceInUseException(
+            UUID inboundPermissionId,
+            UUID inboundDataSourceId,
+            List<UUID> outboundPermissionIds
+    ) {
+        super("Cannot revoke inbound permission %s because inbound data source %s is still used by outbound permissions: %s"
+                      .formatted(inboundPermissionId, inboundDataSourceId, formatPermissionIds(outboundPermissionIds)));
+    }
+
+    private static String formatPermissionIds(List<UUID> permissionIds) {
+        return permissionIds.stream()
+                            .map(UUID::toString)
+                            .collect(Collectors.joining(", "));
+    }
+}

--- a/aiida/src/main/java/energy/eddie/aiida/errors/permission/InboundDataSourceInUseException.java
+++ b/aiida/src/main/java/energy/eddie/aiida/errors/permission/InboundDataSourceInUseException.java
@@ -8,18 +8,13 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class InboundDataSourceInUseException extends Exception {
-    public InboundDataSourceInUseException(
-            UUID inboundPermissionId,
-            UUID inboundDataSourceId,
-            List<UUID> outboundPermissionIds
-    ) {
-        super("Cannot revoke inbound permission %s because inbound data source %s is still used by outbound permissions: %s"
-                      .formatted(inboundPermissionId, inboundDataSourceId, formatPermissionIds(outboundPermissionIds)));
+    public InboundDataSourceInUseException(UUID inboundPermissionId, List<UUID> outboundPermissionIds) {
+        super("Cannot revoke inbound permission %s because it is still used by outbound permissions: %s".formatted(
+                inboundPermissionId,
+                formatPermissionIds(outboundPermissionIds)));
     }
 
     private static String formatPermissionIds(List<UUID> permissionIds) {
-        return permissionIds.stream()
-                            .map(UUID::toString)
-                            .collect(Collectors.joining(", "));
+        return permissionIds.stream().map(UUID::toString).collect(Collectors.joining(", "));
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/models/datasource/mqtt/inbound/InboundDataSource.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/datasource/mqtt/inbound/InboundDataSource.java
@@ -13,11 +13,13 @@ import energy.eddie.aiida.models.datasource.mqtt.SecretGenerator;
 import energy.eddie.aiida.models.mqtt.MqttConnection;
 import energy.eddie.aiida.models.permission.MqttStreamingConfig;
 import energy.eddie.aiida.models.permission.Permission;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -31,7 +33,9 @@ public class InboundDataSource extends MqttDataSource {
     @JsonProperty
     protected String accessCode;
 
-    @OneToOne(mappedBy = "dataSource")
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "permission_id", table = TABLE_NAME)
+    @JsonIgnore
     protected Permission permission;
 
     @Transient
@@ -62,6 +66,12 @@ public class InboundDataSource extends MqttDataSource {
 
     public Permission permission() {
         return permission;
+    }
+
+    @JsonProperty
+    public Set<AiidaSchema> schemas() {
+        var dataNeed = permission == null ? null : permission.dataNeed();
+        return dataNeed == null ? Set.of() : dataNeed.schemas();
     }
 
     @Nullable

--- a/aiida/src/main/java/energy/eddie/aiida/models/permission/PermissionStatus.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/permission/PermissionStatus.java
@@ -56,6 +56,7 @@ public enum PermissionStatus {
      */
     FAILED_TO_START;
 
+    public static final Set<PermissionStatus> STREAMING = Set.of(WAITING_FOR_START, STREAMING_DATA);
     public static final Set<PermissionStatus> ACTIVE = Set.of(ACCEPTED, WAITING_FOR_START, STREAMING_DATA);
 
     public boolean isActive() {

--- a/aiida/src/main/java/energy/eddie/aiida/models/permission/PermissionStatus.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/permission/PermissionStatus.java
@@ -3,6 +3,8 @@
 
 package energy.eddie.aiida.models.permission;
 
+import java.util.Set;
+
 public enum PermissionStatus {
     /**
      * The permission has been created on AIIDA.
@@ -52,5 +54,11 @@ public enum PermissionStatus {
     /**
      * An error occurred and the permission could not be started.
      */
-    FAILED_TO_START
+    FAILED_TO_START;
+
+    public static final Set<PermissionStatus> ACTIVE = Set.of(ACCEPTED, WAITING_FOR_START, STREAMING_DATA);
+
+    public boolean isActive() {
+        return ACTIVE.contains(this);
+    }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/repositories/DataSourceRepository.java
+++ b/aiida/src/main/java/energy/eddie/aiida/repositories/DataSourceRepository.java
@@ -12,9 +12,6 @@ import java.util.UUID;
 
 public interface DataSourceRepository extends JpaRepository<DataSource, UUID> {
 
-    @Query("select d from DataSource d where d.userId = :userId and d.type = DataSourceType.INBOUND")
-    List<DataSource> findInboundByUserId(UUID userId);
-
     @Query("select d from DataSource d where d.userId = :userId and not d.type = DataSourceType.INBOUND")
     List<DataSource> findOutboundByUserId(UUID userId);
 }

--- a/aiida/src/main/java/energy/eddie/aiida/repositories/PermissionRepository.java
+++ b/aiida/src/main/java/energy/eddie/aiida/repositories/PermissionRepository.java
@@ -7,35 +7,24 @@ import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.models.permission.PermissionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public interface PermissionRepository extends JpaRepository<Permission, UUID> {
-    /**
-     * Returns all permission objects for the given userId, sorted by their grantTime descending.
-     *
-     * @return A list of permissions, sorted by grantTime descending, i.e. the permission with the newest grantTime is the first item.
-     */
     List<Permission> findByUserIdOrderByGrantTimeDesc(UUID userId);
 
-    /**
-     * Returns a list of all active permission, i.e. all permissions, whose status is either {@link PermissionStatus#ACCEPTED} or {@link PermissionStatus#WAITING_FOR_START} or {@link PermissionStatus#STREAMING_DATA}.
-     *
-     * @return A list of permissions that have the status {@link PermissionStatus#ACCEPTED} or {@link PermissionStatus#WAITING_FOR_START} or {@link PermissionStatus#STREAMING_DATA}.
-     */
-    @Query("SELECT p FROM Permission p WHERE p.status IN (energy.eddie.aiida.models.permission.PermissionStatus.WAITING_FOR_START, energy.eddie.aiida.models.permission.PermissionStatus.STREAMING_DATA)")
-    List<Permission> findAllActivePermissions();
+    List<Permission> findByStatusIn(Set<PermissionStatus> statuses);
 
     @Query("""
             SELECT p.permissionId
             FROM Permission p
             WHERE p.dataSource.id = :dataSourceId
               AND p.dataNeed.type = energy.eddie.dataneeds.needs.aiida.OutboundAiidaDataNeed.DISCRIMINATOR_VALUE
-              AND p.status IN (energy.eddie.aiida.models.permission.PermissionStatus.WAITING_FOR_START, energy.eddie.aiida.models.permission.PermissionStatus.STREAMING_DATA)
+              AND p.status IN (:statuses)
             """)
-    List<UUID> findActiveOutboundPermissionIdsByDataSourceId(UUID dataSourceId);
+    List<UUID> findOutboundByDataSourceIdAndStatus(UUID dataSourceId, Set<PermissionStatus> statuses);
 
     @Query("""
             SELECT p
@@ -43,12 +32,8 @@ public interface PermissionRepository extends JpaRepository<Permission, UUID> {
             WHERE p.userId = :userId
               AND p.dataNeed.type = energy.eddie.dataneeds.needs.aiida.InboundAiidaDataNeed.DISCRIMINATOR_VALUE
               AND p.dataSource IS NOT NULL
-              AND p.status IN (
-                    energy.eddie.aiida.models.permission.PermissionStatus.FETCHED_MQTT_CREDENTIALS,
-                    energy.eddie.aiida.models.permission.PermissionStatus.WAITING_FOR_START,
-                    energy.eddie.aiida.models.permission.PermissionStatus.STREAMING_DATA
-              )
+              AND p.status IN (:statuses)
             ORDER BY p.grantTime DESC
             """)
-    List<Permission> findActiveInboundPermissionsByUserId(@Param("userId") UUID userId);
+    List<Permission> findInboundByUserIdAndStatus(UUID userId, Set<PermissionStatus> statuses);
 }

--- a/aiida/src/main/java/energy/eddie/aiida/repositories/PermissionRepository.java
+++ b/aiida/src/main/java/energy/eddie/aiida/repositories/PermissionRepository.java
@@ -26,4 +26,13 @@ public interface PermissionRepository extends JpaRepository<Permission, UUID> {
      */
     @Query("SELECT p FROM Permission p WHERE p.status IN (energy.eddie.aiida.models.permission.PermissionStatus.WAITING_FOR_START, energy.eddie.aiida.models.permission.PermissionStatus.STREAMING_DATA)")
     List<Permission> findAllActivePermissions();
+
+    @Query("""
+            SELECT p.permissionId
+            FROM Permission p
+            WHERE p.dataSource.id = :dataSourceId
+              AND p.dataNeed.type = energy.eddie.dataneeds.needs.aiida.OutboundAiidaDataNeed.DISCRIMINATOR_VALUE
+              AND p.status IN (energy.eddie.aiida.models.permission.PermissionStatus.WAITING_FOR_START, energy.eddie.aiida.models.permission.PermissionStatus.STREAMING_DATA)
+            """)
+    List<UUID> findActiveOutboundPermissionIdsByDataSourceId(UUID dataSourceId);
 }

--- a/aiida/src/main/java/energy/eddie/aiida/repositories/PermissionRepository.java
+++ b/aiida/src/main/java/energy/eddie/aiida/repositories/PermissionRepository.java
@@ -18,13 +18,13 @@ public interface PermissionRepository extends JpaRepository<Permission, UUID> {
     List<Permission> findByStatusIn(Set<PermissionStatus> statuses);
 
     @Query("""
-            SELECT p.permissionId
+            SELECT p
             FROM Permission p
             WHERE p.dataSource.id = :dataSourceId
               AND p.dataNeed.type = energy.eddie.dataneeds.needs.aiida.OutboundAiidaDataNeed.DISCRIMINATOR_VALUE
               AND p.status IN (:statuses)
             """)
-    List<UUID> findOutboundByDataSourceIdAndStatus(UUID dataSourceId, Set<PermissionStatus> statuses);
+    List<Permission> findOutboundByDataSourceIdAndStatus(UUID dataSourceId, Set<PermissionStatus> statuses);
 
     @Query("""
             SELECT p

--- a/aiida/src/main/java/energy/eddie/aiida/repositories/PermissionRepository.java
+++ b/aiida/src/main/java/energy/eddie/aiida/repositories/PermissionRepository.java
@@ -7,6 +7,7 @@ import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.models.permission.PermissionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
@@ -35,4 +36,19 @@ public interface PermissionRepository extends JpaRepository<Permission, UUID> {
               AND p.status IN (energy.eddie.aiida.models.permission.PermissionStatus.WAITING_FOR_START, energy.eddie.aiida.models.permission.PermissionStatus.STREAMING_DATA)
             """)
     List<UUID> findActiveOutboundPermissionIdsByDataSourceId(UUID dataSourceId);
+
+    @Query("""
+            SELECT p
+            FROM Permission p
+            WHERE p.userId = :userId
+              AND p.dataNeed.type = energy.eddie.dataneeds.needs.aiida.InboundAiidaDataNeed.DISCRIMINATOR_VALUE
+              AND p.dataSource IS NOT NULL
+              AND p.status IN (
+                    energy.eddie.aiida.models.permission.PermissionStatus.FETCHED_MQTT_CREDENTIALS,
+                    energy.eddie.aiida.models.permission.PermissionStatus.WAITING_FOR_START,
+                    energy.eddie.aiida.models.permission.PermissionStatus.STREAMING_DATA
+              )
+            ORDER BY p.grantTime DESC
+            """)
+    List<Permission> findActiveInboundPermissionsByUserId(@Param("userId") UUID userId);
 }

--- a/aiida/src/main/java/energy/eddie/aiida/services/AiidaEventListener.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/AiidaEventListener.java
@@ -10,6 +10,7 @@ import energy.eddie.aiida.dtos.events.OutboundPermissionAcceptEvent;
 import energy.eddie.aiida.errors.auth.InvalidUserException;
 import energy.eddie.aiida.errors.auth.UnauthorizedException;
 import energy.eddie.aiida.errors.datasource.DataSourceNotFoundException;
+import energy.eddie.aiida.errors.permission.InboundDataSourceInUseException;
 import energy.eddie.aiida.errors.permission.PermissionNotFoundException;
 import energy.eddie.api.agnostic.process.model.PermissionStateTransitionException;
 import jakarta.transaction.Transactional;
@@ -80,6 +81,10 @@ public class AiidaEventListener {
             } catch (PermissionStateTransitionException e) {
                 LOGGER.error(
                         "Permission {} associated with deleted data source cannot be revoked, because it is not in an eligible state.",
+                        permissionId);
+            } catch (InboundDataSourceInUseException e) {
+                LOGGER.error(
+                        "Permission {} associated with deleted data source cannot be revoked, because its inbound data source is still used by outbound permissions.",
                         permissionId);
             } catch (UnauthorizedException | InvalidUserException e) {
                 LOGGER.error(

--- a/aiida/src/main/java/energy/eddie/aiida/services/DataSourceService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/DataSourceService.java
@@ -106,11 +106,6 @@ public class DataSourceService {
                          .orElseThrow(() -> new DataSourceNotFoundException(dataSourceId));
     }
 
-    public List<DataSource> getInboundDataSources() throws InvalidUserException {
-        var currentUserId = authService.getCurrentUserId();
-        return repository.findInboundByUserId(currentUserId);
-    }
-
     public List<DataSource> getOutboundDataSources() throws InvalidUserException {
         var currentUserId = authService.getCurrentUserId();
         return repository.findOutboundByUserId(currentUserId);

--- a/aiida/src/main/java/energy/eddie/aiida/services/InboundPermissionRelayService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/InboundPermissionRelayService.java
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.aiida.services;
+
+import energy.eddie.aiida.aggregator.InboundAggregator;
+import energy.eddie.aiida.models.permission.Permission;
+import energy.eddie.aiida.models.permission.PermissionStatus;
+import energy.eddie.aiida.models.record.InboundRecord;
+import energy.eddie.aiida.repositories.PermissionRepository;
+import energy.eddie.aiida.streamers.StreamerManager;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
+import energy.eddie.cim.agnostic.OpaqueEnvelope;
+import energy.eddie.cim.v1_12.recmmoe.RECMMOEEnvelope;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.scheduler.Schedulers;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+public class InboundPermissionRelayService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InboundPermissionRelayService.class);
+
+    private final InboundAggregator inboundAggregator;
+    private final PermissionRepository permissionRepository;
+    private final StreamerManager streamerManager;
+    private final ObjectMapper objectMapper;
+
+    public InboundPermissionRelayService(
+            InboundAggregator inboundAggregator,
+            PermissionRepository permissionRepository,
+            StreamerManager streamerManager,
+            ObjectMapper objectMapper
+    ) {
+        this.inboundAggregator = inboundAggregator;
+        this.permissionRepository = permissionRepository;
+        this.streamerManager = streamerManager;
+        this.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    void subscribeToInboundRecords() {
+        inboundAggregator.inboundRecordFlux()
+                        .publishOn(Schedulers.boundedElastic())
+                        .doOnNext(this::relayInboundRecord)
+                        .onErrorContinue((error, value) -> LOGGER.error("Inbound relay dropped record {}", value, error))
+                        .subscribe();
+    }
+
+    private void relayInboundRecord(InboundRecord inboundRecord) {
+        var outboundPermissions = permissionRepository.findOutboundByDataSourceIdAndStatus(
+                inboundRecord.dataSource().id(),
+                PermissionStatus.ACTIVE
+        );
+
+        for (var outboundPermission : outboundPermissions) {
+            relayToOutboundPermission(inboundRecord, outboundPermission);
+        }
+    }
+
+    private void relayToOutboundPermission(InboundRecord inboundRecord, Permission outboundPermission) {
+        if (!isSchemaRequested(outboundPermission, inboundRecord.schema())) {
+            return;
+        }
+
+        try {
+            var rewrittenPayload = switch (inboundRecord.schema()) {
+                case OPAQUE -> rewriteOpaquePayload(inboundRecord.payload(), outboundPermission);
+                case MIN_MAX_ENVELOPE_CIM_V1_12 -> rewriteMinMaxPayload(inboundRecord.payload(), outboundPermission);
+                default -> null;
+            };
+
+            if (rewrittenPayload != null) {
+                streamerManager.publishSchemaPayload(outboundPermission.id(), inboundRecord.schema(), rewrittenPayload);
+            }
+        } catch (NullPointerException | JacksonException exception) {
+            LOGGER.error("Failed to rewrite {} payload for inbound message when forwarding to outbound permission {}",
+                         inboundRecord.schema(),
+                         outboundPermission.id(),
+                         exception);
+        }
+    }
+
+    private boolean isSchemaRequested(Permission outboundPermission, AiidaSchema schema) {
+        var dataNeed = outboundPermission.dataNeed();
+        return dataNeed != null && dataNeed.schemas() != null && dataNeed.schemas().contains(schema);
+    }
+
+    private String rewriteOpaquePayload(String payload, Permission outboundPermission) {
+        var inboundEnvelope = objectMapper.readValue(payload, OpaqueEnvelope.class);
+
+        var outboundEnvelope = new OpaqueEnvelope(
+                inboundEnvelope.regionConnectorId(),
+                outboundPermission.id().toString(),
+                outboundPermission.connectionId(),
+                Objects.requireNonNull(outboundPermission.dataNeed()).dataNeedId().toString(),
+                UUID.randomUUID().toString(),
+                inboundEnvelope.timestamp(),
+                inboundEnvelope.payload()
+        );
+
+        return objectMapper.writeValueAsString(outboundEnvelope);
+    }
+
+    private String rewriteMinMaxPayload(String payload, Permission outboundPermission) {
+        var minMaxEnvelope = objectMapper.readValue(payload, RECMMOEEnvelope.class);
+        var header = minMaxEnvelope.getMessageDocumentHeader();
+        var meta = header.getMetaInformation();
+
+        meta.setRequestPermissionId(outboundPermission.id().toString());
+        meta.setConnectionId(outboundPermission.connectionId());
+        meta.setDataNeedId(Objects.requireNonNull(outboundPermission.dataNeed()).dataNeedId().toString());
+
+        header.setMetaInformation(meta);
+        minMaxEnvelope.setMessageDocumentHeader(header);
+
+        return objectMapper.writeValueAsString(minMaxEnvelope);
+    }
+}

--- a/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
@@ -504,7 +504,12 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
             var permissions = permissionRepository.findOutboundByDataSourceIdAndStatus(dataSourceId, ACTIVE);
             if (!permissions.isEmpty()) {
                 var blockingIds = permissions.stream().map(Permission::id).toList();
-                throw new InboundDataSourceInUseException(permission.id(), dataSourceId, blockingIds);
+                LOGGER.trace(
+                        "Revoke on inbound permission {} was blocked because its data source {} is used by outbound permissions {}.",
+                        permission.id(),
+                        dataSourceId,
+                        blockingIds);
+                throw new InboundDataSourceInUseException(permission.id(), blockingIds);
             }
         }
     }

--- a/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
@@ -316,21 +316,22 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
     }
 
     /**
-     * Gets all active permissions from the database and checks if they have expired. If not, streaming is resumed,
-     * otherwise their database entry will be updated accordingly. This is done when a {@link ContextRefreshedEvent} is
-     * received, which ensures that all beans are started and the database is set up correctly.
+     * Gets all permissions from the database that should be streaming data and checks if they have expired.
+     * If not, streaming is resumed, otherwise their database entry will be updated accordingly.
+     * This is done when a {@link ContextRefreshedEvent} is received,
+     * which ensures that all beans are started and the database is set up correctly.
      */
     @Override
     @Transactional
     public void onApplicationEvent(@NonNull ContextRefreshedEvent event) {
         // fields of permissions are loaded eagerly to avoid n+1 select problem in loop
-        var allActivePermissions = permissionRepository.findByStatusIn(ACTIVE);
+        var streamingPermissions = permissionRepository.findByStatusIn(STREAMING);
         LOGGER.info(
-                "Fetched {} active permissions from database and will resume streaming or update them if they are expired.",
-                allActivePermissions.size());
+                "Fetched {} permission from database that should resume streaming or be updated if expired.",
+                streamingPermissions.size());
 
         var now = clock.instant();
-        for (Permission permission : allActivePermissions) {
+        for (Permission permission : streamingPermissions) {
             var expirationTime = permission.expirationTime();
             if (expirationTime == null) {
                 LOGGER.error("expirationTime of permission {} is null, this is an unexpected error",

--- a/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
@@ -300,6 +300,11 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
         return permissionRepository.findByUserIdOrderByGrantTimeDesc(currentUserId);
     }
 
+    public List<Permission> getActiveInboundPermissions() throws InvalidUserException {
+        var currentUserId = authService.getCurrentUserId();
+        return permissionRepository.findActiveInboundPermissionsByUserId(currentUserId);
+    }
+
     /**
      * Returns the permission with the specified ID.
      *

--- a/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
@@ -501,9 +501,10 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
     private void validateInboundDataSourceNotInUse(Permission permission) throws InboundDataSourceInUseException {
         var dataSourceId = inboundDataSourceIdIfInboundPermission(permission);
         if (dataSourceId != null) {
-            var permissionIds = permissionRepository.findOutboundByDataSourceIdAndStatus(dataSourceId, ACTIVE);
-            if (!permissionIds.isEmpty()) {
-                throw new InboundDataSourceInUseException(permission.id(), dataSourceId, permissionIds);
+            var permissions = permissionRepository.findOutboundByDataSourceIdAndStatus(dataSourceId, ACTIVE);
+            if (!permissions.isEmpty()) {
+                var blockingIds = permissions.stream().map(Permission::id).toList();
+                throw new InboundDataSourceInUseException(permission.id(), dataSourceId, blockingIds);
             }
         }
     }

--- a/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
@@ -104,12 +104,10 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
         LOGGER.info("Got request to revoke permission with id '{}'.", permission.id());
         authService.checkAuthorizationForPermission(permission);
 
-        if (!isEligibleForRevocation(permission))
+        if (!permission.status().isActive())
             throw new PermissionStateTransitionException(permission.id().toString(),
                                                          REVOKED.name(),
-                                                         List.of(ACCEPTED.name(),
-                                                                 STREAMING_DATA.name(),
-                                                                 WAITING_FOR_START.name()),
+                                                         ACTIVE.stream().map(Enum::name).toList(),
                                                          permission.status().name());
 
         validateInboundDataSourceNotInUse(permission);
@@ -302,7 +300,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
 
     public List<Permission> getActiveInboundPermissions() throws InvalidUserException {
         var currentUserId = authService.getCurrentUserId();
-        return permissionRepository.findActiveInboundPermissionsByUserId(currentUserId);
+        return permissionRepository.findInboundByUserIdAndStatus(currentUserId, PermissionStatus.ACTIVE);
     }
 
     /**
@@ -326,7 +324,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
     @Transactional
     public void onApplicationEvent(@NonNull ContextRefreshedEvent event) {
         // fields of permissions are loaded eagerly to avoid n+1 select problem in loop
-        List<Permission> allActivePermissions = permissionRepository.findAllActivePermissions();
+        var allActivePermissions = permissionRepository.findByStatusIn(ACTIVE);
         LOGGER.info(
                 "Fetched {} active permissions from database and will resume streaming or update them if they are expired.",
                 allActivePermissions.size());
@@ -457,20 +455,6 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
     }
 
     /**
-     * Indicates whether the permission's current status allows it to be revoked. The status needs to be one of the
-     * following, to be eligible for revocation: ACCEPTED, WAITING_FOR_START, STREAMING_DATA
-     *
-     * @param permission Permission to check.
-     * @return True if the permission is eligible for revocation, false otherwise.
-     */
-    private boolean isEligibleForRevocation(Permission permission) {
-        return switch (permission.status()) {
-            case ACCEPTED, WAITING_FOR_START, STREAMING_DATA -> true;
-            default -> false;
-        };
-    }
-
-    /**
      * Sets the provided {@code permission} as unfulfillable and throws a {@code PermissionUnfulfillableException}
      */
     private void markPermissionAsUnfulfillable(Permission permission) throws PermissionUnfulfillableException {
@@ -517,7 +501,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
     private void validateInboundDataSourceNotInUse(Permission permission) throws InboundDataSourceInUseException {
         var dataSourceId = inboundDataSourceIdIfInboundPermission(permission);
         if (dataSourceId != null) {
-            var permissionIds = permissionRepository.findActiveOutboundPermissionIdsByDataSourceId(dataSourceId);
+            var permissionIds = permissionRepository.findOutboundByDataSourceIdAndStatus(dataSourceId, ACTIVE);
             if (!permissionIds.isEmpty()) {
                 throw new InboundDataSourceInUseException(permission.id(), dataSourceId, permissionIds);
             }

--- a/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/PermissionService.java
@@ -9,9 +9,11 @@ import energy.eddie.aiida.dtos.events.InboundPermissionRevokeEvent;
 import energy.eddie.aiida.dtos.events.OutboundPermissionAcceptEvent;
 import energy.eddie.aiida.errors.auth.InvalidUserException;
 import energy.eddie.aiida.errors.auth.UnauthorizedException;
+import energy.eddie.aiida.errors.datasource.DataSourceNotFoundException;
+import energy.eddie.aiida.errors.datasource.IncompatibleDataSourceException;
 import energy.eddie.aiida.errors.permission.*;
 import energy.eddie.aiida.models.datasource.DataSource;
-import energy.eddie.aiida.models.datasource.DataSourceType;
+import energy.eddie.aiida.models.datasource.mqtt.inbound.InboundDataSource;
 import energy.eddie.aiida.models.permission.InboundMessageFormat;
 import energy.eddie.aiida.models.permission.MqttStreamingConfig;
 import energy.eddie.aiida.models.permission.Permission;
@@ -23,6 +25,7 @@ import energy.eddie.aiida.repositories.PermissionRepository;
 import energy.eddie.aiida.streamers.StreamerManager;
 import energy.eddie.api.agnostic.aiida.AiidaConnectionStatusMessageDto;
 import energy.eddie.api.agnostic.aiida.AiidaPermissionRequestsDto;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
 import energy.eddie.api.agnostic.process.model.PermissionStateTransitionException;
 import energy.eddie.cim.agnostic.PermissionProcessStatus;
 import energy.eddie.dataneeds.needs.aiida.InboundAiidaDataNeed;
@@ -39,9 +42,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriTemplate;
 
 import java.time.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static energy.eddie.aiida.config.AiidaConfiguration.AIIDA_ZONE_ID;
 import static energy.eddie.aiida.models.permission.PermissionStatus.*;
@@ -56,6 +57,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
     private final HandshakeService handshakeService;
     private final PermissionScheduler permissionScheduler;
     private final AuthService authService;
+    private final DataSourceService dataSourceService;
     private final AiidaLocalDataNeedService aiidaLocalDataNeedService;
     private final AiidaEventPublisher aiidaEventPublisher;
 
@@ -67,6 +69,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
             HandshakeService handshakeService,
             PermissionScheduler permissionScheduler,
             AuthService authService,
+            DataSourceService dataSourceService,
             AiidaLocalDataNeedService aiidaLocalDataNeedService,
             AiidaEventPublisher aiidaEventPublisher
     ) {
@@ -76,6 +79,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
         this.handshakeService = handshakeService;
         this.permissionScheduler = permissionScheduler;
         this.authService = authService;
+        this.dataSourceService = dataSourceService;
         this.aiidaLocalDataNeedService = aiidaLocalDataNeedService;
         this.aiidaEventPublisher = aiidaEventPublisher;
     }
@@ -95,7 +99,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
     @Transactional
     public Permission revokePermission(
             UUID permissionId
-    ) throws PermissionNotFoundException, PermissionStateTransitionException, UnauthorizedException, InvalidUserException {
+    ) throws PermissionNotFoundException, PermissionStateTransitionException, UnauthorizedException, InvalidUserException, InboundDataSourceInUseException {
         var permission = findById(permissionId);
         LOGGER.info("Got request to revoke permission with id '{}'.", permission.id());
         authService.checkAuthorizationForPermission(permission);
@@ -108,6 +112,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
                                                                  WAITING_FOR_START.name()),
                                                          permission.status().name());
 
+        validateInboundDataSourceNotInUse(permission);
         permissionScheduler.removePermission(permissionId);
 
 
@@ -232,8 +237,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
             UUID permissionId,
             @Nullable UUID dataSourceId,
             @Nullable InboundMessageFormat inboundMessageFormat
-    ) throws PermissionStateTransitionException, PermissionNotFoundException, DetailFetchingFailedException,
-             UnauthorizedException, InvalidUserException, InvalidInboundPermissionException {
+    ) throws PermissionStateTransitionException, PermissionNotFoundException, DetailFetchingFailedException, UnauthorizedException, InvalidUserException, InvalidInboundPermissionException, DataSourceNotFoundException, IncompatibleDataSourceException {
         var permission = findById(permissionId);
         authService.checkAuthorizationForPermission(permission);
 
@@ -252,6 +256,7 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
         permission.setStatus(ACCEPTED);
 
         if (dataSourceId != null) {
+            validateDataSourceSelection(permission, dataSourceId);
             aiidaEventPublisher.publishEvent(new OutboundPermissionAcceptEvent(permissionId, dataSourceId));
         }
 
@@ -473,12 +478,49 @@ public class PermissionService implements ApplicationListener<ContextRefreshedEv
         throw new PermissionUnfulfillableException(permission.id());
     }
 
-    private void removeInboundDataSourceIfExists(Permission permission) {
-        var dataSource = permission.dataSource();
+    private void validateDataSourceSelection(Permission permission, UUID dataSourceId)
+            throws DataSourceNotFoundException, IncompatibleDataSourceException {
+        var dataSource = dataSourceService.dataSourceByIdOrThrow(dataSourceId);
 
-        if (dataSource != null && dataSource.type() == DataSourceType.INBOUND) {
-            aiidaEventPublisher.publishEvent(new InboundPermissionRevokeEvent(dataSource.id()));
+        if (!Objects.equals(dataSource.userId(), permission.userId())) {
+            throw new DataSourceNotFoundException(dataSourceId);
+        }
+
+        if (dataSource instanceof InboundDataSource inboundDataSource) {
+            var requiredSchemas = requireNonNull(permission.dataNeed()).schemas();
+            if (!hasSchemaOverlap(requiredSchemas, inboundDataSource.schemas())) {
+                throw new IncompatibleDataSourceException(
+                        dataSourceId,
+                        "The selected inbound data source does not match any requested schema."
+                );
+            }
+        }
+    }
+
+    private boolean hasSchemaOverlap(Set<AiidaSchema> requiredSchemas, Set<AiidaSchema> availableSchemas) {
+        return requiredSchemas.stream().anyMatch(availableSchemas::contains);
+    }
+
+    private void removeInboundDataSourceIfExists(Permission permission) {
+        var dataSourceId = inboundDataSourceIdIfInboundPermission(permission);
+        if (dataSourceId != null) {
+            aiidaEventPublisher.publishEvent(new InboundPermissionRevokeEvent(dataSourceId));
             permission.setDataSource(null);
         }
+    }
+
+    private void validateInboundDataSourceNotInUse(Permission permission) throws InboundDataSourceInUseException {
+        var dataSourceId = inboundDataSourceIdIfInboundPermission(permission);
+        if (dataSourceId != null) {
+            var permissionIds = permissionRepository.findActiveOutboundPermissionIdsByDataSourceId(dataSourceId);
+            if (!permissionIds.isEmpty()) {
+                throw new InboundDataSourceInUseException(permission.id(), dataSourceId, permissionIds);
+            }
+        }
+    }
+
+    private @Nullable UUID inboundDataSourceIdIfInboundPermission(Permission permission) {
+        return permission.dataSource() instanceof InboundDataSource inboundDataSource &&
+               permission.equals(inboundDataSource.permission()) ? inboundDataSource.id() : null;
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/streamers/AiidaStreamer.java
+++ b/aiida/src/main/java/energy/eddie/aiida/streamers/AiidaStreamer.java
@@ -6,9 +6,12 @@ package energy.eddie.aiida.streamers;
 import energy.eddie.aiida.models.record.AiidaRecord;
 import energy.eddie.aiida.schemas.rtd.SchemaFormatterRegistry;
 import energy.eddie.api.agnostic.aiida.AiidaConnectionStatusMessageDto;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
 import energy.eddie.cim.agnostic.PermissionCommand;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
+
+import java.util.UUID;
 
 public abstract class AiidaStreamer implements AutoCloseable {
     protected final Sinks.Many<PermissionCommand> commandSink;
@@ -64,4 +67,9 @@ public abstract class AiidaStreamer implements AutoCloseable {
      * schedule, which re-aggregates the upstream records on a different cadence.
      */
     public abstract void updateRecordFlux(Flux<AiidaRecord> recordFlux);
+
+    /**
+     * Publishes a payload of the provided schema to the permission of the provided id.
+     */
+    public abstract void publishSchemaPayload(UUID permissionId, AiidaSchema schema, String payload);
 }

--- a/aiida/src/main/java/energy/eddie/aiida/streamers/StreamerManager.java
+++ b/aiida/src/main/java/energy/eddie/aiida/streamers/StreamerManager.java
@@ -11,6 +11,7 @@ import energy.eddie.aiida.models.record.PermissionLatestRecordMap;
 import energy.eddie.aiida.repositories.FailedToSendRepository;
 import energy.eddie.aiida.schemas.rtd.SchemaFormatterRegistry;
 import energy.eddie.api.agnostic.aiida.AiidaConnectionStatusMessageDto;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
 import energy.eddie.cim.agnostic.PermissionCommand;
 import jakarta.transaction.Transactional;
 import org.eclipse.paho.mqttv5.common.MqttException;
@@ -114,6 +115,14 @@ public class StreamerManager implements AutoCloseable {
     public void updateSchedule(Permission permission) {
         requireStreamer(permission.id())
                 .ifPresent(streamer -> buildFilteredFlux(permission).ifPresent(streamer::updateRecordFlux));
+    }
+
+    /**
+     * Publishes a payload of the provided schema to the streamer for the provided permission.
+     */
+    public void publishSchemaPayload(UUID permissionId, AiidaSchema schema, String payload) {
+        requireStreamer(permissionId)
+                .ifPresent(streamer -> streamer.publishSchemaPayload(permissionId, schema, payload));
     }
 
     /**

--- a/aiida/src/main/java/energy/eddie/aiida/streamers/mqtt/MqttStreamer.java
+++ b/aiida/src/main/java/energy/eddie/aiida/streamers/mqtt/MqttStreamer.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 public class MqttStreamer extends AiidaStreamer implements MqttCallback {
     private static final Logger LOGGER = LoggerFactory.getLogger(MqttStreamer.class);
@@ -218,6 +219,17 @@ public class MqttStreamer extends AiidaStreamer implements MqttCallback {
         subscription = recordFlux.publishOn(Schedulers.boundedElastic()).subscribe(this::publishRecord);
         LOGGER.info("MqttStreamer for permission {} resubscribed to an updated record flux",
                     streamingConfig.permissionId());
+    }
+
+    @Override
+    public void publishSchemaPayload(UUID permissionId, AiidaSchema schema, String payload) {
+        var topic = schema.buildTopicPath(streamingConfig.dataTopic());
+
+        publishMessage(topic, payload.getBytes(StandardCharsets.UTF_8));
+
+        var latestRecord = new PermissionLatestRecord(streamingConfig.dataTopic(), streamingConfig.serverUri());
+        latestRecord.putSchema(schema, new LatestRecordSchema(Instant.now(), payload));
+        permissionLatestRecordMap.put(permissionId, latestRecord);
     }
 
     @Override

--- a/aiida/src/main/java/energy/eddie/aiida/utils/PermissionExpiredRunnable.java
+++ b/aiida/src/main/java/energy/eddie/aiida/utils/PermissionExpiredRunnable.java
@@ -53,9 +53,7 @@ public class PermissionExpiredRunnable implements Runnable {
               .log("Will expire permission permission {}, running {} ms too late compared to target time (negative number would be too early)");
 
         // safeguard if e.g. a revocation operation could not properly cancel this runnable before it runs
-        if (!(permission.status() == PermissionStatus.ACCEPTED ||
-              permission.status() == PermissionStatus.WAITING_FOR_START ||
-              permission.status() == PermissionStatus.STREAMING_DATA)) {
+        if (!permission.status().isActive()) {
             LOGGER.warn("Permission {} was modified, its status is {}. Will NOT expire the permission",
                         permission.id(), permission.status());
             return;

--- a/aiida/src/main/java/energy/eddie/aiida/web/DataSourceController.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/DataSourceController.java
@@ -100,21 +100,6 @@ public class DataSourceController {
         return ResponseEntity.ok(dataSources);
     }
 
-    @Operation(summary = "Get all inbound datasources", description = "Retrieve all inbound datasources.",
-            operationId = "getAllInboundDataSources", tags = {"datasource"})
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successful operation",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = DataSourceDto.class)))),
-            @ApiResponse(responseCode = "401", description = "Unauthorized User",
-                    content = @Content(schema = @Schema(implementation = EddieApiError.class)))
-    })
-    @GetMapping(path = "/inbound", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<DataSource>> getAllInboundDataSources() throws InvalidUserException {
-        var dataSources = service.getInboundDataSources();
-
-        return ResponseEntity.ok(dataSources);
-    }
-
     @Operation(summary = "Add a new datasource", description = "Add a new datasource.",
             operationId = "addDatasource", tags = {"datasource"})
     @ApiResponses(value = {

--- a/aiida/src/main/java/energy/eddie/aiida/web/PermissionController.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/PermissionController.java
@@ -56,6 +56,13 @@ public class PermissionController {
         return ResponseEntity.ok(permissionService.getAllPermissionsSortedByGrantTime());
     }
 
+    @Operation(summary = "Get active inbound permissions", description = "Get active inbound permissions that can be used as a data source selection.", operationId = "getActiveInboundPermissions", tags = {"permission"})
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "successful operation", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Permission.class))))})
+    @GetMapping(path = "/inbound/active", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<Permission>> getActiveInboundPermissions() throws InvalidUserException {
+        return ResponseEntity.ok(permissionService.getActiveInboundPermissions());
+    }
+
     @Operation(summary = "Set up new permissions", description = "Set up a new permissions with data from e.g. a QR code.", operationId = "setupNewPermission", tags = {"permission"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Permission.class))}),

--- a/aiida/src/main/java/energy/eddie/aiida/web/PermissionController.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/PermissionController.java
@@ -6,6 +6,8 @@ package energy.eddie.aiida.web;
 import energy.eddie.aiida.dtos.PatchPermissionDto;
 import energy.eddie.aiida.errors.auth.InvalidUserException;
 import energy.eddie.aiida.errors.auth.UnauthorizedException;
+import energy.eddie.aiida.errors.datasource.DataSourceNotFoundException;
+import energy.eddie.aiida.errors.datasource.IncompatibleDataSourceException;
 import energy.eddie.aiida.errors.permission.*;
 import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.services.PermissionService;
@@ -96,7 +98,8 @@ public class PermissionController {
             @Parameter(name = "permissionId", description = "Unique ID of the permission", example = "f38a1953-ae7a-480c-814f-1cca3989981e") @PathVariable UUID permissionId
     ) throws PermissionStateTransitionException, PermissionNotFoundException, DetailFetchingFailedException,
              UnauthorizedException, InvalidUserException, MissingInboundMessageFormatException,
-             InvalidInboundPermissionException {
+             InvalidInboundPermissionException, DataSourceNotFoundException, IncompatibleDataSourceException,
+             InboundDataSourceInUseException {
         LOGGER.atInfo()
               // Validate that it's a real permission ID and not some malicious string
               .addArgument(() -> permissionId)

--- a/aiida/src/main/resources/db/aiida/migration/V9_1__link_inbound_data_source_to_owner_permission.sql
+++ b/aiida/src/main/resources/db/aiida/migration/V9_1__link_inbound_data_source_to_owner_permission.sql
@@ -1,0 +1,22 @@
+--  SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+--  SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE data_source_mqtt_inbound
+    ADD COLUMN permission_id uuid;
+
+UPDATE data_source_mqtt_inbound inbound
+SET permission_id = p.permission_id
+FROM permission p
+WHERE p.data_source_id = inbound.id;
+
+ALTER TABLE data_source_mqtt_inbound
+    ADD CONSTRAINT fk_data_source_mqtt_inbound_permission
+        FOREIGN KEY (permission_id) REFERENCES permission (permission_id);
+
+ALTER TABLE data_source_mqtt_inbound
+    ADD CONSTRAINT uk_data_source_mqtt_inbound_permission UNIQUE (permission_id);
+
+ALTER TABLE permission
+    DROP CONSTRAINT fk_permission_to_data_source,
+    ADD CONSTRAINT fk_permission_to_data_source
+        FOREIGN KEY (data_source_id) REFERENCES data_source (id) ON DELETE RESTRICT;

--- a/aiida/src/test/java/energy/eddie/aiida/services/AiidaEventListenerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/AiidaEventListenerTest.java
@@ -10,6 +10,7 @@ import energy.eddie.aiida.dtos.events.OutboundPermissionAcceptEvent;
 import energy.eddie.aiida.errors.auth.InvalidUserException;
 import energy.eddie.aiida.errors.auth.UnauthorizedException;
 import energy.eddie.aiida.errors.datasource.DataSourceNotFoundException;
+import energy.eddie.aiida.errors.permission.InboundDataSourceInUseException;
 import energy.eddie.aiida.errors.permission.PermissionNotFoundException;
 import energy.eddie.aiida.models.datasource.DataSource;
 import energy.eddie.aiida.models.datasource.mqtt.inbound.InboundDataSource;
@@ -102,7 +103,9 @@ class AiidaEventListenerTest {
 
 
     @Test
-    void testOnDataSourceDeletionEvent() throws UnauthorizedException, PermissionNotFoundException, PermissionStateTransitionException, InvalidUserException {
+    void testOnDataSourceDeletionEvent() throws UnauthorizedException, PermissionNotFoundException,
+                                                PermissionStateTransitionException, InvalidUserException,
+                                                InboundDataSourceInUseException {
         // Given
         var event = mock(DataSourceDeletionEvent.class);
         var permissionId1 = UUID.fromString("00000000-0000-0000-0000-000000000000");

--- a/aiida/src/test/java/energy/eddie/aiida/services/InboundPermissionRelayServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/InboundPermissionRelayServiceTest.java
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.aiida.services;
+
+import energy.eddie.aiida.aggregator.InboundAggregator;
+import energy.eddie.aiida.models.datasource.mqtt.inbound.InboundDataSource;
+import energy.eddie.aiida.models.permission.Permission;
+import energy.eddie.aiida.models.permission.PermissionStatus;
+import energy.eddie.aiida.models.permission.dataneed.AiidaLocalDataNeed;
+import energy.eddie.aiida.models.record.InboundRecord;
+import energy.eddie.aiida.repositories.PermissionRepository;
+import energy.eddie.aiida.streamers.StreamerManager;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
+import energy.eddie.cim.agnostic.OpaqueEnvelope;
+import energy.eddie.cim.v1_12.recmmoe.RECMMOEEnvelope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.publisher.TestPublisher;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InboundPermissionRelayServiceTest {
+    private static final UUID INBOUND_DATA_SOURCE_ID = UUID.fromString("5ed36996-76ce-45f7-b462-3c06b17a0e71");
+    private static final UUID OUTBOUND_PERMISSION_ID = UUID.fromString("6e0af81e-8f3f-47f5-b74f-3acc54d16673");
+    private static final UUID OUTBOUND_DATA_NEED_ID = UUID.fromString("21f7ddd9-a6d3-4742-8ba0-bde66f68f8d7");
+    private static final String OUTBOUND_CONNECTION_ID = "outbound-connection";
+
+    @Mock
+    private InboundAggregator inboundAggregator;
+    @Mock
+    private PermissionRepository permissionRepository;
+    @Mock
+    private StreamerManager streamerManager;
+    @Mock
+    private Permission outboundPermission;
+    @Mock
+    private AiidaLocalDataNeed outboundDataNeed;
+    @Mock
+    private InboundDataSource inboundDataSource;
+
+    private ObjectMapper objectMapper;
+    private InboundPermissionRelayService relayService;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        relayService = new InboundPermissionRelayService(inboundAggregator,
+                                                         permissionRepository,
+                                                         streamerManager,
+                                                         objectMapper);
+    }
+
+    @Test
+    void givenOpaqueInboundRecord_relaysWithOutboundMetadata() {
+        // Given
+        var inboundPublisher = TestPublisher.<InboundRecord>create();
+        when(inboundAggregator.inboundRecordFlux()).thenReturn(inboundPublisher.flux());
+        when(inboundDataSource.id()).thenReturn(INBOUND_DATA_SOURCE_ID);
+        mockOutboundPermissionWithSchemas(Set.of(AiidaSchema.OPAQUE));
+        when(outboundPermission.connectionId()).thenReturn(OUTBOUND_CONNECTION_ID);
+        when(outboundDataNeed.dataNeedId()).thenReturn(OUTBOUND_DATA_NEED_ID);
+        when(permissionRepository.findOutboundByDataSourceIdAndStatus(INBOUND_DATA_SOURCE_ID, PermissionStatus.ACTIVE))
+                .thenReturn(List.of(outboundPermission));
+
+        relayService.subscribeToInboundRecords();
+        var inboundPayload = """
+                {
+                  "regionConnectorId":"aiida",
+                  "permissionId":"inbound-permission",
+                  "connectionId":"inbound-connection",
+                  "dataNeedId":"inbound-data-need",
+                  "messageId":"inbound-message",
+                  "timestamp":"2026-06-19T12:00:00Z",
+                  "payload":"opaque-payload"
+                }
+                """;
+        var inboundRecord = new InboundRecord(Instant.parse("2026-06-19T12:00:00Z"),
+                                              inboundDataSource,
+                                              AiidaSchema.OPAQUE,
+                                              inboundPayload);
+
+        // When
+        inboundPublisher.next(inboundRecord);
+
+        // Then
+        verify(streamerManager, timeout(1000)).publishSchemaPayload(
+                eq(OUTBOUND_PERMISSION_ID),
+                eq(AiidaSchema.OPAQUE),
+                argThat(payload -> {
+                    var opaque = objectMapper.readValue(payload, OpaqueEnvelope.class);
+                    return OUTBOUND_PERMISSION_ID.toString().equals(opaque.permissionId()) &&
+                           OUTBOUND_CONNECTION_ID.equals(opaque.connectionId()) &&
+                           OUTBOUND_DATA_NEED_ID.toString().equals(opaque.dataNeedId()) &&
+                           "opaque-payload".equals(opaque.payload());
+                }));
+    }
+
+    @Test
+    void givenMinMaxInboundRecord_relaysWithOutboundMetadata() {
+        // Given
+        var inboundPublisher = TestPublisher.<InboundRecord>create();
+        when(inboundAggregator.inboundRecordFlux()).thenReturn(inboundPublisher.flux());
+        when(inboundDataSource.id()).thenReturn(INBOUND_DATA_SOURCE_ID);
+        mockOutboundPermissionWithSchemas(Set.of(AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12));
+        when(outboundPermission.connectionId()).thenReturn("outbound-connection");
+        when(outboundDataNeed.dataNeedId()).thenReturn(OUTBOUND_DATA_NEED_ID);
+        when(permissionRepository.findOutboundByDataSourceIdAndStatus(INBOUND_DATA_SOURCE_ID, PermissionStatus.ACTIVE))
+                .thenReturn(List.of(outboundPermission));
+
+        relayService.subscribeToInboundRecords();
+        var inboundPayload = """
+                {
+                  "messageDocumentHeader": {
+                    "metaInformation": {
+                      "requestPermissionId": "inbound-permission",
+                      "connectionId": "inbound-connection",
+                      "dataNeedId": "inbound-data-need"
+                    }
+                  },
+                  "marketDocument": {
+                    "mRID": "market-document-id"
+                  }
+                }
+                """;
+        var inboundRecord = new InboundRecord(Instant.parse("2026-06-19T12:00:00Z"),
+                                              inboundDataSource,
+                                              AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12,
+                                              inboundPayload);
+
+        // When
+        inboundPublisher.next(inboundRecord);
+
+        // Then
+        verify(streamerManager, timeout(1000)).publishSchemaPayload(
+                eq(OUTBOUND_PERMISSION_ID),
+                eq(AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12),
+                argThat(payload -> {
+                    var minmax = objectMapper.readValue(payload, RECMMOEEnvelope.class);
+                    var meta = minmax.getMessageDocumentHeader().getMetaInformation();
+                    return OUTBOUND_PERMISSION_ID.toString().equals(meta.getRequestPermissionId()) &&
+                           OUTBOUND_CONNECTION_ID.equals(meta.getConnectionId()) &&
+                           OUTBOUND_DATA_NEED_ID.toString().equals(meta.getDataNeedId());
+                }));
+    }
+
+    @Test
+    void givenInboundRecordWithNonRequestedSchema_doesNotRelay() {
+        // Given
+        var inboundPublisher = TestPublisher.<InboundRecord>create();
+        when(inboundAggregator.inboundRecordFlux()).thenReturn(inboundPublisher.flux());
+
+        relayService.subscribeToInboundRecords();
+        var inboundRecord = new InboundRecord(Instant.parse("2026-06-19T12:00:00Z"),
+                                              inboundDataSource,
+                                              AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12,
+                                              "{\"messageDocumentHeader\":{\"metaInformation\":{}}}");
+
+        // When
+        inboundPublisher.next(inboundRecord);
+
+        // Then
+        verify(streamerManager, never()).publishSchemaPayload(eq(OUTBOUND_PERMISSION_ID),
+                                                              eq(AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12),
+                                                              anyString());
+    }
+
+    private void mockOutboundPermissionWithSchemas(Set<AiidaSchema> schemas) {
+        when(outboundPermission.id()).thenReturn(OUTBOUND_PERMISSION_ID);
+        when(outboundPermission.dataNeed()).thenReturn(outboundDataNeed);
+        when(outboundDataNeed.schemas()).thenReturn(schemas);
+    }
+}

--- a/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
@@ -627,6 +627,10 @@ class PermissionServiceTest {
     void givenInboundPermissionWithBlockingOutboundPermissions_revokePermission_throws() {
         var blockingPermissionId1 = UUID.fromString("a57a9f3d-2b5a-4b84-a32c-51bfa4b865c1");
         var blockingPermissionId2 = UUID.fromString("6dbc4ec9-4f2f-4aa7-b016-36c28945a6e4");
+        var blockingPermission1 = mock(Permission.class);
+        when(blockingPermission1.id()).thenReturn(blockingPermissionId1);
+        var blockingPermission2 = mock(Permission.class);
+        when(blockingPermission2.id()).thenReturn(blockingPermissionId2);
 
         when(mockPermissionRepository.findById(permissionId1)).thenReturn(Optional.of(mockPermission));
         when(mockPermission.id()).thenReturn(permissionId1);
@@ -635,7 +639,7 @@ class PermissionServiceTest {
         when(mockInboundDataSource.permission()).thenReturn(mockPermission);
         when(mockInboundDataSource.id()).thenReturn(dataSourceId);
         when(mockPermissionRepository.findOutboundByDataSourceIdAndStatus(dataSourceId, PermissionStatus.ACTIVE))
-                .thenReturn(List.of(blockingPermissionId1, blockingPermissionId2));
+                .thenReturn(List.of(blockingPermission1, blockingPermission2));
 
         var exception = assertThrows(InboundDataSourceInUseException.class,
                                      () -> service.revokePermission(permissionId1));

--- a/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
@@ -764,7 +764,7 @@ class PermissionServiceTest {
             doReturn(Instant.parse("2023-10-01T12:00:00.00Z")).when(mockClock).instant();
             permission.setStartTime(Instant.parse(start));
             permission.setExpirationTime(Instant.parse(end));
-            when(mockPermissionRepository.findByStatusIn(PermissionStatus.ACTIVE)).thenReturn(List.of(permission));
+            when(mockPermissionRepository.findByStatusIn(PermissionStatus.STREAMING)).thenReturn(List.of(permission));
 
             // strict stubbing requires us to only stub the .schedule if a runnable will be scheduled
             if (expectedState == PermissionStatus.WAITING_FOR_START || expectedState == PermissionStatus.STREAMING_DATA)

--- a/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
@@ -540,7 +540,8 @@ class PermissionServiceTest {
         // Given
         var uuid = UUID.fromString("dc9ff3d3-1f1f-445d-a4ee-85c1faffb715");
         when(mockAuthService.getCurrentUserId()).thenReturn(uuid);
-        when(mockPermissionRepository.findActiveInboundPermissionsByUserId(uuid)).thenReturn(List.of(mockPermission));
+        when(mockPermissionRepository.findInboundByUserIdAndStatus(uuid, PermissionStatus.ACTIVE))
+                .thenReturn(List.of(mockPermission));
 
         // When
         var result = service.getActiveInboundPermissions();
@@ -633,7 +634,7 @@ class PermissionServiceTest {
         when(mockPermission.dataSource()).thenReturn(mockInboundDataSource);
         when(mockInboundDataSource.permission()).thenReturn(mockPermission);
         when(mockInboundDataSource.id()).thenReturn(dataSourceId);
-        when(mockPermissionRepository.findActiveOutboundPermissionIdsByDataSourceId(dataSourceId))
+        when(mockPermissionRepository.findOutboundByDataSourceIdAndStatus(dataSourceId, PermissionStatus.ACTIVE))
                 .thenReturn(List.of(blockingPermissionId1, blockingPermissionId2));
 
         var exception = assertThrows(InboundDataSourceInUseException.class,
@@ -759,7 +760,7 @@ class PermissionServiceTest {
             doReturn(Instant.parse("2023-10-01T12:00:00.00Z")).when(mockClock).instant();
             permission.setStartTime(Instant.parse(start));
             permission.setExpirationTime(Instant.parse(end));
-            when(mockPermissionRepository.findAllActivePermissions()).thenReturn(List.of(permission));
+            when(mockPermissionRepository.findByStatusIn(PermissionStatus.ACTIVE)).thenReturn(List.of(permission));
 
             // strict stubbing requires us to only stub the .schedule if a runnable will be scheduled
             if (expectedState == PermissionStatus.WAITING_FOR_START || expectedState == PermissionStatus.STREAMING_DATA)

--- a/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
@@ -8,14 +8,17 @@ import energy.eddie.aiida.dtos.events.InboundPermissionAcceptEvent;
 import energy.eddie.aiida.dtos.events.InboundPermissionRevokeEvent;
 import energy.eddie.aiida.dtos.events.OutboundPermissionAcceptEvent;
 import energy.eddie.aiida.errors.auth.InvalidUserException;
+import energy.eddie.aiida.errors.datasource.DataSourceNotFoundException;
+import energy.eddie.aiida.errors.datasource.IncompatibleDataSourceException;
 import energy.eddie.aiida.errors.permission.*;
 import energy.eddie.aiida.models.datasource.DataSource;
-import energy.eddie.aiida.models.datasource.DataSourceType;
+import energy.eddie.aiida.models.datasource.mqtt.inbound.InboundDataSource;
 import energy.eddie.aiida.models.permission.InboundMessageFormat;
 import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.models.permission.PermissionStatus;
 import energy.eddie.aiida.models.permission.dataneed.AiidaLocalDataNeed;
 import energy.eddie.aiida.models.permission.dataneed.InboundAiidaLocalDataNeed;
+import energy.eddie.aiida.models.permission.dataneed.OutboundAiidaLocalDataNeed;
 import energy.eddie.aiida.publisher.AiidaEventPublisher;
 import energy.eddie.aiida.repositories.PermissionRepository;
 import energy.eddie.aiida.streamers.StreamerManager;
@@ -94,11 +97,17 @@ class PermissionServiceTest {
     @Mock
     private InboundAiidaLocalDataNeed mockInboundAiidaLocalDataNeed;
     @Mock
+    private OutboundAiidaLocalDataNeed mockOutboundAiidaLocalDataNeed;
+    @Mock
     private AuthService mockAuthService;
+    @Mock
+    private DataSourceService mockDataSourceService;
     @Mock
     private Permission mockPermission;
     @Mock
     private DataSource mockDataSource;
+    @Mock
+    private InboundDataSource mockInboundDataSource;
     @Mock
     private MqttDto mockMqttDto;
     @Mock
@@ -108,13 +117,18 @@ class PermissionServiceTest {
     private PermissionService service;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
+        lenient().when(mockDataSourceService.dataSourceByIdOrThrow(any())).thenReturn(mockDataSource);
+        lenient().when(mockDataSource.userId()).thenReturn(userId);
+        lenient().when(mockPermission.userId()).thenReturn(userId);
+
         service = new PermissionService(mockPermissionRepository,
                                         clock,
                                         streamerManager,
                                         mockHandshakeService,
                                         mockPermissionScheduler,
                                         mockAuthService,
+                                        mockDataSourceService,
                                         mockAiidaLocalDataNeedService,
                                         mockAiidaEventPublisher);
     }
@@ -375,6 +389,80 @@ class PermissionServiceTest {
     }
 
     @Test
+    void givenDataSourceOfOtherUser_acceptPermission_throwsDataSourceNotFound() throws Exception {
+        var otherUserId = UUID.randomUUID();
+        when(mockPermissionRepository.findById(permissionId1)).thenReturn(Optional.of(mockPermission));
+        when(mockPermission.status()).thenReturn(PermissionStatus.FETCHED_DETAILS);
+        when(mockPermission.userId()).thenReturn(userId);
+        when(mockDataSourceService.dataSourceByIdOrThrow(dataSourceId)).thenReturn(mockDataSource);
+        when(mockDataSource.userId()).thenReturn(otherUserId);
+
+        assertThrows(DataSourceNotFoundException.class,
+                     () -> service.acceptPermission(permissionId1, dataSourceId, null));
+
+        verify(mockHandshakeService, never()).fetchMqttDetails(any());
+    }
+
+    @Test
+    void givenInboundDataSourceWithIncompatibleSchemas_acceptPermission_throwsIncompatibleDataSource() throws Exception {
+        when(mockPermissionRepository.findById(permissionId1)).thenReturn(Optional.of(mockPermission));
+        when(mockPermission.status()).thenReturn(PermissionStatus.FETCHED_DETAILS);
+        when(mockPermission.userId()).thenReturn(userId);
+        when(mockDataSourceService.dataSourceByIdOrThrow(dataSourceId)).thenReturn(mockInboundDataSource);
+        when(mockInboundDataSource.userId()).thenReturn(userId);
+        when(mockPermission.dataNeed()).thenReturn(mockOutboundAiidaLocalDataNeed);
+        when(mockOutboundAiidaLocalDataNeed.schemas()).thenReturn(Set.of(AiidaSchema.SMART_METER_P1_RAW));
+        when(mockInboundDataSource.schemas()).thenReturn(Set.of(AiidaSchema.OPAQUE));
+
+        assertThrows(IncompatibleDataSourceException.class,
+                     () -> service.acceptPermission(permissionId1, dataSourceId, null));
+
+        verify(mockHandshakeService, never()).fetchMqttDetails(any());
+    }
+
+    @Test
+    void givenInboundDataSourceWithCompatibleSchemas_acceptPermission_succeeds() throws Exception {
+        when(mockPermissionRepository.save(any(Permission.class))).then(i -> i.getArgument(0));
+        when(mockPermissionRepository.findById(permissionId1)).thenReturn(Optional.of(mockPermission));
+        when(mockPermission.status()).thenReturn(PermissionStatus.FETCHED_DETAILS);
+        when(mockPermission.userId()).thenReturn(userId);
+        when(mockDataSourceService.dataSourceByIdOrThrow(dataSourceId)).thenReturn(mockInboundDataSource);
+        when(mockInboundDataSource.userId()).thenReturn(userId);
+        when(mockPermission.dataNeed()).thenReturn(mockOutboundAiidaLocalDataNeed);
+        when(mockOutboundAiidaLocalDataNeed.schemas()).thenReturn(Set.of(AiidaSchema.OPAQUE));
+        when(mockInboundDataSource.schemas()).thenReturn(Set.of(AiidaSchema.OPAQUE, AiidaSchema.SMART_METER_P1_RAW));
+        when(mockHandshakeService.fetchMqttDetails(any())).thenReturn(Mono.just(mockMqttDto));
+        when(mockMqttDto.dataTopic()).thenReturn("dataTopic");
+        when(mockMqttDto.username()).thenReturn(permissionId1.toString());
+
+        service.acceptPermission(permissionId1, dataSourceId, null);
+
+        verify(mockAiidaEventPublisher).publishEvent(any(OutboundPermissionAcceptEvent.class));
+        verify(mockPermissionScheduler).scheduleOrStart(any());
+    }
+
+    @Test
+    void givenInboundDataSourceWithPartialSchemaOverlap_acceptPermission_succeeds() throws Exception {
+        when(mockPermissionRepository.save(any(Permission.class))).then(i -> i.getArgument(0));
+        when(mockPermissionRepository.findById(permissionId1)).thenReturn(Optional.of(mockPermission));
+        when(mockPermission.status()).thenReturn(PermissionStatus.FETCHED_DETAILS);
+        when(mockPermission.userId()).thenReturn(userId);
+        when(mockDataSourceService.dataSourceByIdOrThrow(dataSourceId)).thenReturn(mockInboundDataSource);
+        when(mockInboundDataSource.userId()).thenReturn(userId);
+        when(mockPermission.dataNeed()).thenReturn(mockOutboundAiidaLocalDataNeed);
+        when(mockOutboundAiidaLocalDataNeed.schemas()).thenReturn(Set.of(AiidaSchema.OPAQUE, AiidaSchema.SMART_METER_P1_RAW));
+        when(mockInboundDataSource.schemas()).thenReturn(Set.of(AiidaSchema.OPAQUE));
+        when(mockHandshakeService.fetchMqttDetails(any())).thenReturn(Mono.just(mockMqttDto));
+        when(mockMqttDto.dataTopic()).thenReturn("dataTopic");
+        when(mockMqttDto.username()).thenReturn(permissionId1.toString());
+
+        service.acceptPermission(permissionId1, dataSourceId, null);
+
+        verify(mockAiidaEventPublisher).publishEvent(any(OutboundPermissionAcceptEvent.class));
+        verify(mockPermissionScheduler).scheduleOrStart(any());
+    }
+
+    @Test
     void givenValidInboundPermission_createsAndStartsDataSource() throws Exception {
         // Given
         when(mockPermissionRepository.save(any(Permission.class))).then(i -> i.getArgument(0));
@@ -485,10 +573,10 @@ class PermissionServiceTest {
         when(mockPermission.connectionId()).thenReturn("connectionId");
         when(mockPermission.dataNeed()).thenReturn(mockInboundAiidaLocalDataNeed);
         when(mockPermission.status()).thenReturn(PermissionStatus.STREAMING_DATA);
-        when(mockPermission.dataSource()).thenReturn(mockDataSource);
+        when(mockPermission.dataSource()).thenReturn(mockInboundDataSource);
         when(mockPermission.id()).thenReturn(permissionId1);
-        when(mockPermission.dataSource()).thenReturn(mockDataSource);
-        when(mockDataSource.type()).thenReturn(DataSourceType.INBOUND);
+        when(mockInboundDataSource.permission()).thenReturn(mockPermission);
+        when(mockInboundDataSource.id()).thenReturn(UUID.randomUUID());
 
         // When
         service.revokePermission(permissionId1);
@@ -499,6 +587,47 @@ class PermissionServiceTest {
         verify(mockPermission).setRevokeTime(fixedInstant);
         verify(streamerManager).stopStreamer(argThat(msg -> msg.status() == PermissionProcessStatus.REVOKED));
         verify(mockAiidaEventPublisher, times(1)).publishEvent(any(InboundPermissionRevokeEvent.class));
+    }
+
+    @Test
+    void givenOutboundPermissionUsingInboundDataSource_revokePermission_doesNotDeleteInboundDataSource() throws Exception {
+        // Given
+        var ownerPermission = mock(Permission.class);
+        when(mockPermissionRepository.findById(permissionId1)).thenReturn(Optional.of(mockPermission));
+        when(mockPermission.connectionId()).thenReturn("connectionId");
+        when(mockPermission.dataNeed()).thenReturn(mockOutboundAiidaLocalDataNeed);
+        when(mockPermission.status()).thenReturn(PermissionStatus.STREAMING_DATA);
+        when(mockPermission.dataSource()).thenReturn(mockInboundDataSource);
+        when(mockPermission.id()).thenReturn(permissionId1);
+        when(mockInboundDataSource.permission()).thenReturn(ownerPermission);
+
+        // When
+        service.revokePermission(permissionId1);
+
+        // Then
+        verify(mockAiidaEventPublisher, never()).publishEvent(any(InboundPermissionRevokeEvent.class));
+    }
+
+    @Test
+    void givenInboundPermissionWithBlockingOutboundPermissions_revokePermission_throws() {
+        var blockingPermissionId1 = UUID.fromString("a57a9f3d-2b5a-4b84-a32c-51bfa4b865c1");
+        var blockingPermissionId2 = UUID.fromString("6dbc4ec9-4f2f-4aa7-b016-36c28945a6e4");
+
+        when(mockPermissionRepository.findById(permissionId1)).thenReturn(Optional.of(mockPermission));
+        when(mockPermission.id()).thenReturn(permissionId1);
+        when(mockPermission.status()).thenReturn(PermissionStatus.STREAMING_DATA);
+        when(mockPermission.dataSource()).thenReturn(mockInboundDataSource);
+        when(mockInboundDataSource.permission()).thenReturn(mockPermission);
+        when(mockInboundDataSource.id()).thenReturn(dataSourceId);
+        when(mockPermissionRepository.findActiveOutboundPermissionIdsByDataSourceId(dataSourceId))
+                .thenReturn(List.of(blockingPermissionId1, blockingPermissionId2));
+
+        var exception = assertThrows(InboundDataSourceInUseException.class,
+                                     () -> service.revokePermission(permissionId1));
+
+        assertTrue(exception.getMessage().contains(blockingPermissionId1.toString()));
+        assertTrue(exception.getMessage().contains(blockingPermissionId2.toString()));
+        verify(mockPermissionScheduler, never()).removePermission(any());
     }
 
     @Test
@@ -591,6 +720,7 @@ class PermissionServiceTest {
                                             mockHandshakeService,
                                             permissionScheduler,
                                             mockAuthService,
+                                            mockDataSourceService,
                                             mockAiidaLocalDataNeedService,
                                             mockAiidaEventPublisher);
         }

--- a/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
@@ -536,6 +536,20 @@ class PermissionServiceTest {
     }
 
     @Test
+    void givenValidUser_getActiveInboundPermissions() throws InvalidUserException {
+        // Given
+        var uuid = UUID.fromString("dc9ff3d3-1f1f-445d-a4ee-85c1faffb715");
+        when(mockAuthService.getCurrentUserId()).thenReturn(uuid);
+        when(mockPermissionRepository.findActiveInboundPermissionsByUserId(uuid)).thenReturn(List.of(mockPermission));
+
+        // When
+        var result = service.getActiveInboundPermissions();
+
+        // Then
+        assertEquals(List.of(mockPermission), result);
+    }
+
+    @Test
     void givenPermissionInInvalidState_revokePermission_throws() {
         // Given
         when(mockPermissionRepository.findById(permissionId1)).thenReturn(Optional.of(mockPermission));

--- a/aiida/src/test/java/energy/eddie/aiida/streamers/StreamerManagerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/streamers/StreamerManagerTest.java
@@ -13,6 +13,7 @@ import energy.eddie.aiida.repositories.FailedToSendRepository;
 import energy.eddie.aiida.schemas.rtd.SchemaFormatterRegistry;
 import energy.eddie.api.agnostic.aiida.AiidaAsset;
 import energy.eddie.api.agnostic.aiida.AiidaConnectionStatusMessageDto;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
 import energy.eddie.api.agnostic.aiida.ObisCode;
 import org.eclipse.paho.mqttv5.common.MqttException;
 import org.junit.jupiter.api.BeforeEach;
@@ -184,6 +185,19 @@ class StreamerManagerTest {
 
         // Then
         verify(mockAiidaStreamer).closeTerminally(any());
+    }
+
+    @Test
+    void verify_publishSchemaPayload_publishesToStreamer() {
+        // Given
+        ReflectionTestUtils.setField(manager, "streamers", mockMap);
+        when(mockMap.get(permissionId)).thenReturn(mockAiidaStreamer);
+
+        // When
+        manager.publishSchemaPayload(permissionId, AiidaSchema.OPAQUE, "test-payload");
+
+        // Then
+        verify(mockAiidaStreamer).publishSchemaPayload(permissionId, AiidaSchema.OPAQUE, "test-payload");
     }
 
     @Test

--- a/aiida/src/test/java/energy/eddie/aiida/streamers/mqtt/MqttStreamerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/streamers/mqtt/MqttStreamerTest.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import static energy.eddie.api.agnostic.aiida.ObisCode.NEGATIVE_ACTIVE_ENERGY;
 import static energy.eddie.api.agnostic.aiida.ObisCode.POSITIVE_ACTIVE_ENERGY;
 import static energy.eddie.api.agnostic.aiida.UnitOfMeasurement.KILO_WATT_HOUR;
+import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -333,6 +334,20 @@ class MqttStreamerTest {
         // Then
         // record is published on Schedulers.boundedElastic(), so await the async side effect
         verify(mockClient, timeout(2000)).publish(eq(EXPECTED_DATA_TOPIC), any(), eq(1), eq(false));
+    }
+
+    @Test
+    void givenOpaquePayload_publishInboundRecord_sendsViaMqtt() throws MqttException {
+        // Given
+        streamer.connect();
+        var expectedPayload = "opaque".getBytes(StandardCharsets.UTF_8);
+        var expectedTopic = AiidaSchema.OPAQUE.buildTopicPath(DATA_TOPIC);
+
+        // When
+        streamer.publishSchemaPayload(UUID.randomUUID(), AiidaSchema.OPAQUE, "opaque");
+
+        // Then
+        verify(mockClient, timeout(2000)).publish(eq(expectedTopic), aryEq(expectedPayload), eq(1), eq(false));
     }
 
     @Test

--- a/aiida/src/test/java/energy/eddie/aiida/web/DataSourceControllerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/web/DataSourceControllerTest.java
@@ -74,22 +74,6 @@ class DataSourceControllerTest {
 
     @Test
     @WithMockUser
-    void getAllInboundDataSources_shouldReturnListOfDataSources() throws Exception {
-        List<DataSource> dataSources = List.of(DATA_SOURCE);
-
-        when(service.getInboundDataSources()).thenReturn(dataSources);
-
-        mockMvc.perform(get("/datasources/inbound")
-                                .with(csrf())
-                                .accept(MediaType.APPLICATION_JSON))
-               .andExpect(status().isOk())
-               .andExpect(jsonPath("$.length()").value(1));
-
-        verify(service, times(1)).getInboundDataSources();
-    }
-
-    @Test
-    @WithMockUser
     void addDataSource_shouldReturn201() throws Exception {
         doReturn(new DataSourceSecretsDto(DATA_SOURCE_ID, PLAIN_TEXT_PASSWORD))
                 .when(service).addDataSource(any(DataSourceDto.class));

--- a/aiida/src/test/java/energy/eddie/aiida/web/PermissionControllerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/web/PermissionControllerTest.java
@@ -113,7 +113,6 @@ class PermissionControllerTest {
         assertEquals(permissionId, response.getFirst().id());
         assertEquals(PermissionStatus.CREATED, permissions.get(1).status());
         assertEquals(eddieId, permissions.get(2).eddieId());
-
     }
 
     @Test
@@ -177,10 +176,12 @@ class PermissionControllerTest {
 
         // When
         mockMvc.perform(post("/permissions").with(csrf()).contentType(MediaType.APPLICATION_JSON).content(requestJson))
-                .andExpect(status().isCreated());
+               .andExpect(status().isCreated());
 
         // Then
-        verify(permissionService).setupNewPermissions(argThat(dto -> dto.permissionIds().getFirst().equals(permissionId)));
+        verify(permissionService).setupNewPermissions(argThat(dto -> dto.permissionIds()
+                                                                        .getFirst()
+                                                                        .equals(permissionId)));
     }
 
     @Test
@@ -303,7 +304,6 @@ class PermissionControllerTest {
         when(permissionService.revokePermission(any()))
                 .thenThrow(new InboundDataSourceInUseException(
                         permissionId,
-                        dataSourceId,
                         List.of(blockingPermissionId1, blockingPermissionId2)
                 ));
 

--- a/aiida/src/test/java/energy/eddie/aiida/web/PermissionControllerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/web/PermissionControllerTest.java
@@ -118,6 +118,18 @@ class PermissionControllerTest {
 
     @Test
     @WithMockUser
+    void getActiveInboundPermissions_returnsPermissionsWithDataSource() throws Exception {
+        when(permissionService.getActiveInboundPermissions()).thenReturn(List.of(mockPermission));
+
+        mockMvc.perform(get("/permissions/inbound/active"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.length()").value(1));
+
+        verify(permissionService).getActiveInboundPermissions();
+    }
+
+    @Test
+    @WithMockUser
     void givenInvalidMediaType_permissionRequest_returnsUnsupportedMediaType() throws Exception {
         mockMvc.perform(post("/permissions").with(csrf()).contentType(MediaType.APPLICATION_CBOR))
                .andExpect(status().isUnsupportedMediaType());

--- a/aiida/src/test/java/energy/eddie/aiida/web/PermissionControllerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/web/PermissionControllerTest.java
@@ -5,6 +5,9 @@ package energy.eddie.aiida.web;
 
 import energy.eddie.aiida.ObjectMapperCreatorUtil;
 import energy.eddie.aiida.errors.GlobalExceptionHandler;
+import energy.eddie.aiida.errors.datasource.DataSourceNotFoundException;
+import energy.eddie.aiida.errors.datasource.IncompatibleDataSourceException;
+import energy.eddie.aiida.errors.permission.InboundDataSourceInUseException;
 import energy.eddie.aiida.errors.permission.MissingInboundMessageFormatException;
 import energy.eddie.aiida.models.permission.InboundMessageFormat;
 import energy.eddie.aiida.models.permission.Permission;
@@ -282,6 +285,27 @@ class PermissionControllerTest {
 
     @Test
     @WithMockUser
+    void givenInboundDataSourceInUseDuringRevoke_updatePermission_returnsConflict() throws Exception {
+        var blockingPermissionId1 = UUID.fromString("a57a9f3d-2b5a-4b84-a32c-51bfa4b865c1");
+        var blockingPermissionId2 = UUID.fromString("6dbc4ec9-4f2f-4aa7-b016-36c28945a6e4");
+        when(permissionService.revokePermission(any()))
+                .thenThrow(new InboundDataSourceInUseException(
+                        permissionId,
+                        dataSourceId,
+                        List.of(blockingPermissionId1, blockingPermissionId2)
+                ));
+
+        mockMvc.perform(patch("/permissions/{permissionId}", permissionId).with(csrf())
+                                                                          .contentType(MediaType.APPLICATION_JSON)
+                                                                          .content("{\"operation\": \"REVOKE\"}"))
+               .andExpect(status().isConflict())
+               .andExpect(jsonPath(ERRORS_JSON_PATH, iterableWithSize(1)))
+               .andExpect(jsonPath(ERRORS_JSON_PATH + "[0].message", containsString(blockingPermissionId1.toString())))
+               .andExpect(jsonPath(ERRORS_JSON_PATH + "[0].message", containsString(blockingPermissionId2.toString())));
+    }
+
+    @Test
+    @WithMockUser
     void givenUpdateInboundMessageFormat_updatePermission_callsService() throws Exception {
         // Given
         var requestJson = "{\"operation\": \"UPDATE_INBOUND_MESSAGE_FORMAT\", \"inboundMessageFormat\": \"OPENADR_3_1\"}";
@@ -311,6 +335,36 @@ class PermissionControllerTest {
                .andExpect(jsonPath(ERRORS_JSON_PATH, iterableWithSize(1)))
                .andExpect(jsonPath(ERRORS_JSON_PATH + "[0].message",
                                    is("inboundMessageFormat must not be null when operation is UPDATE_INBOUND_MESSAGE_FORMAT.")));
+    }
+
+    @Test
+    @WithMockUser
+    void givenIncompatibleDataSource_updatePermission_returnsBadRequest() throws Exception {
+        when(permissionService.acceptPermission(permissionId, dataSourceId, null))
+                .thenThrow(new IncompatibleDataSourceException("Data source is incompatible."));
+
+        mockMvc.perform(patch("/permissions/{permissionId}", permissionId)
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"operation\": \"ACCEPT\", \"dataSourceId\": \"" + dataSourceId + "\"}"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath(ERRORS_JSON_PATH, iterableWithSize(1)))
+               .andExpect(jsonPath(ERRORS_JSON_PATH + "[0].message", containsString("incompatible")));
+    }
+
+    @Test
+    @WithMockUser
+    void givenDataSourceNotFound_updatePermission_returnsNotFound() throws Exception {
+        when(permissionService.acceptPermission(permissionId, dataSourceId, null))
+                .thenThrow(new DataSourceNotFoundException(dataSourceId));
+
+        mockMvc.perform(patch("/permissions/{permissionId}", permissionId)
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"operation\": \"ACCEPT\", \"dataSourceId\": \"" + dataSourceId + "\"}"))
+               .andExpect(status().isNotFound())
+               .andExpect(jsonPath(ERRORS_JSON_PATH, iterableWithSize(1)))
+               .andExpect(jsonPath(ERRORS_JSON_PATH + "[0].message", containsString(dataSourceId.toString())));
     }
 
     private List<Permission> sampleDataForGetAllPermissionsTest() {

--- a/aiida/ui/src/api.ts
+++ b/aiida/ui/src/api.ts
@@ -101,12 +101,12 @@ export function getPermissions(): Promise<AiidaPermission[]> {
   return fetch('/permissions')
 }
 
-export function getDataSources(): Promise<AiidaDataSource[]> {
-  return fetch('/datasources/outbound')
+export function getActiveInboundPermissions(): Promise<AiidaPermission[]> {
+  return fetch('/permissions/inbound/active')
 }
 
-export function getInboundDataSources(): Promise<AiidaDataSource[]> {
-  return fetch('/datasources/inbound')
+export function getDataSources(): Promise<AiidaDataSource[]> {
+  return fetch('/datasources/outbound')
 }
 
 export function getDataSourceTypes(): Promise<AiidaDataSourceType[]> {

--- a/aiida/ui/src/api.ts
+++ b/aiida/ui/src/api.ts
@@ -105,6 +105,10 @@ export function getDataSources(): Promise<AiidaDataSource[]> {
   return fetch('/datasources/outbound')
 }
 
+export function getInboundDataSources(): Promise<AiidaDataSource[]> {
+  return fetch('/datasources/inbound')
+}
+
 export function getDataSourceTypes(): Promise<AiidaDataSourceType[]> {
   return fetch('/datasources/outbound/types')
 }

--- a/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
+++ b/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
@@ -13,8 +13,10 @@ import { acceptPermission, getInboundDataSources, rejectPermission } from '@/api
 import { usePermissionDialog } from '@/composables/permission-dialog'
 import CustomSelect from '../CustomSelect.vue'
 import { dataSources, fetchDataSources } from '@/stores/dataSources'
-import type { AiidaDataSource } from '@/types'
+import type { AiidaDataSource, AiidaSchema } from '@/types'
 import { useI18n } from 'vue-i18n'
+
+const inboundSchemas: Set<AiidaSchema> = new Set(['MIN-MAX-ENVELOPE-CIM-V1-12', 'OPAQUE'])
 
 const { permission, open, resolveDialog } = usePermissionDialog()
 const { t } = useI18n()
@@ -53,11 +55,20 @@ const handleModalClose = () => {
 
 const dataSourceOptions = computed(() => {
   const requestedSchemas = permission.value?.dataNeed.schemas ?? []
-  const filteredInboundDataSources = inboundDataSources.value.filter((dataSource) =>
-    requestedSchemas.some((schema) => dataSource.schemas?.includes(schema)),
-  )
+  const matches: AiidaDataSource[] = []
 
-  return [...dataSources.value, ...filteredInboundDataSources].map(({ id, name }) => ({
+  if (requestedSchemas.some((requestedSchema) => inboundSchemas.has(requestedSchema))) {
+    const inboundMatches = inboundDataSources.value.filter((dataSource) =>
+      requestedSchemas.some((requestedSchema) => dataSource.schemas?.includes(requestedSchema)),
+    )
+    matches.push(...inboundMatches)
+  }
+
+  if (requestedSchemas.some((requestedSchema) => !inboundSchemas.has(requestedSchema))) {
+    matches.push(...dataSources.value)
+  }
+
+  return matches.map(({ id, name }) => ({
     label: name,
     value: id,
   }))

--- a/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
+++ b/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
@@ -9,10 +9,11 @@ import ModalDialog from '@/components/ModalDialog.vue'
 import Button from '@/components/Button.vue'
 import { computed, ref, watch } from 'vue'
 import PermissionDetails from '@/components/PermissionDetails.vue'
-import { acceptPermission, rejectPermission } from '@/api'
+import { acceptPermission, getInboundDataSources, rejectPermission } from '@/api'
 import { usePermissionDialog } from '@/composables/permission-dialog'
 import CustomSelect from '../CustomSelect.vue'
 import { dataSources, fetchDataSources } from '@/stores/dataSources'
+import type { AiidaDataSource } from '@/types'
 import { useI18n } from 'vue-i18n'
 
 const { permission, open, resolveDialog } = usePermissionDialog()
@@ -20,12 +21,16 @@ const { t } = useI18n()
 const modal = ref<HTMLDialogElement>()
 const loading = ref(false)
 const selectedDataSource = ref<string>('')
+const inboundDataSources = ref<AiidaDataSource[]>([])
 const emit = defineEmits(['update'])
 
 watch([open], async () => {
   if (open.value) {
+    selectedDataSource.value = ''
     modal.value?.showModal()
+
     await fetchDataSources()
+    inboundDataSources.value = await getInboundDataSources()
   }
 })
 
@@ -47,12 +52,15 @@ const handleModalClose = () => {
 }
 
 const dataSourceOptions = computed(() => {
-  return dataSources.value.map((datasource) => {
-    return {
-      label: datasource.name,
-      value: datasource.id,
-    }
-  })
+  const requestedSchemas = permission.value?.dataNeed.schemas ?? []
+  const filteredInboundDataSources = inboundDataSources.value.filter((dataSource) =>
+    requestedSchemas.some((schema) => dataSource.schemas?.includes(schema)),
+  )
+
+  return [...dataSources.value, ...filteredInboundDataSources].map(({ id, name }) => ({
+    label: name,
+    value: id,
+  }))
 })
 </script>
 

--- a/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
+++ b/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
@@ -9,11 +9,11 @@ import ModalDialog from '@/components/ModalDialog.vue'
 import Button from '@/components/Button.vue'
 import { computed, ref, watch } from 'vue'
 import PermissionDetails from '@/components/PermissionDetails.vue'
-import { acceptPermission, getInboundDataSources, rejectPermission } from '@/api'
+import { acceptPermission, getActiveInboundPermissions, rejectPermission } from '@/api'
 import { usePermissionDialog } from '@/composables/permission-dialog'
 import CustomSelect from '../CustomSelect.vue'
 import { dataSources, fetchDataSources } from '@/stores/dataSources'
-import type { AiidaDataSource, AiidaSchema } from '@/types'
+import type { AiidaPermission, AiidaSchema } from '@/types'
 import { useI18n } from 'vue-i18n'
 
 const inboundSchemas: Set<AiidaSchema> = new Set(['MIN-MAX-ENVELOPE-CIM-V1-12', 'OPAQUE'])
@@ -23,7 +23,7 @@ const { t } = useI18n()
 const modal = ref<HTMLDialogElement>()
 const loading = ref(false)
 const selectedDataSource = ref<string>('')
-const inboundDataSources = ref<AiidaDataSource[]>([])
+const inboundPermissions = ref<AiidaPermission[]>([])
 const emit = defineEmits(['update'])
 
 watch([open], async () => {
@@ -32,7 +32,7 @@ watch([open], async () => {
     modal.value?.showModal()
 
     await fetchDataSources()
-    inboundDataSources.value = await getInboundDataSources()
+    inboundPermissions.value = await getActiveInboundPermissions()
   }
 })
 
@@ -55,23 +55,31 @@ const handleModalClose = () => {
 
 const dataSourceOptions = computed(() => {
   const requestedSchemas = permission.value?.dataNeed.schemas ?? []
-  const matches: AiidaDataSource[] = []
+  const matches: { label: string; value: string }[] = []
 
+  // Request includes inbound schemas
   if (requestedSchemas.some((requestedSchema) => inboundSchemas.has(requestedSchema))) {
-    const inboundMatches = inboundDataSources.value.filter((dataSource) =>
-      requestedSchemas.some((requestedSchema) => dataSource.schemas?.includes(requestedSchema)),
-    )
-    matches.push(...inboundMatches)
+    for (const { dataSource } of inboundPermissions.value) {
+      if (
+        dataSource && // For TypeScript, even though it should always be set here
+        requestedSchemas.some((requestedSchema) => dataSource.schemas?.includes(requestedSchema))
+      ) {
+        matches.push({ label: dataSource.name, value: dataSource.id })
+      }
+    }
   }
 
+  // Request includes outbound schemas
   if (requestedSchemas.some((requestedSchema) => !inboundSchemas.has(requestedSchema))) {
-    matches.push(...dataSources.value)
+    matches.push(
+      ...dataSources.value.map(({ id, name }) => ({
+        label: name,
+        value: id,
+      })),
+    )
   }
 
-  return matches.map(({ id, name }) => ({
-    label: name,
-    value: id,
-  }))
+  return matches
 })
 </script>
 

--- a/aiida/ui/src/types.d.ts
+++ b/aiida/ui/src/types.d.ts
@@ -1,13 +1,21 @@
 // SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
+export type AiidaSchema =
+  | 'SMART-METER-P1-RAW'
+  | 'SMART-METER-P1-CIM-V1-04'
+  | 'SMART-METER-P1-CIM-V1-12'
+  | 'OPAQUE'
+  | 'ACKNOWLEDGEMENT-CIM-V1-12'
+  | 'MIN-MAX-ENVELOPE-CIM-V1-12'
+
 export type AiidaDataNeed = {
   dataNeedId: string
   name: string
   purpose: string
   policyLink: string
   transmissionSchedule: string
-  schemas: string[]
+  schemas: AiidaSchema[]
   allowedPermissionCommands: string[]
   acknowledgementRequired: boolean
   asset: string

--- a/aiida/ui/src/types.d.ts
+++ b/aiida/ui/src/types.d.ts
@@ -29,6 +29,7 @@ export type AiidaDataSource = {
   operatorId?: string
   //DatasourceType = INBOUND
   accessCode?: string
+  schemas?: string[]
   //DatasourceType = MQTT
   internalHost?: string
   externalHost?: string

--- a/core/src/main/js/data-need-summary.js
+++ b/core/src/main/js/data-need-summary.js
@@ -37,6 +37,7 @@ class DataNeedSummary extends HTMLElement {
     const dataNeed = await getDataNeedAttributes(dataNeedId);
 
     const {
+      name,
       type,
       purpose,
       policyLink,
@@ -72,6 +73,8 @@ class DataNeedSummary extends HTMLElement {
 
       <sl-alert open>
         <dl>
+          <dt>Name</dt>
+          <dd>${name}</dd>
           <dt>Type of data</dt>
           <dd>
             <sl-tooltip content="${details}">
@@ -133,7 +136,7 @@ class DataNeedSummary extends HTMLElement {
           <!-- For AIIDA data needs -->
           ${schemas
             ? /* HTML */ `
-                <dt>Schemas:</dt>
+                <dt>Schemas</dt>
                 <dd>${schemas.join(", ")}</dd>
               `
             : ""}
@@ -150,7 +153,7 @@ class DataNeedSummary extends HTMLElement {
           ${dataTags
             ? /* HTML */ `
                 <dt>OBIS Points</dt>
-                <dd>${dataTags.join(", ")}</dd>
+                <dd>${dataTags.join(", ") || "None"}</dd>
               `
             : ""}
 

--- a/data-needs/data-needs.json
+++ b/data-needs/data-needs.json
@@ -96,6 +96,27 @@
     "dataTags": []
   },
   {
+    "type": "outbound-aiida",
+    "id": "5de2a77d-1dd4-458d-b700-a84884dd04c6",
+    "name": "Forward inbound opaque and min-max envelopes",
+    "description": "Forwarded reference energy curve min-max operating envelopes for flexible connection agreements",
+    "purpose": "purpose",
+    "policyLink": "https://example.com/toc",
+    "duration": {
+      "type": "relativeDuration",
+      "start": "P0D",
+      "end": "P10D"
+    },
+    "transmissionSchedule": "*/5 * * * * *",
+    "acknowledgementRequired": false,
+    "schemas": [
+      "MIN-MAX-ENVELOPE-CIM-V1-12",
+      "OPAQUE"
+    ],
+    "asset": "CONNECTION-AGREEMENT-POINT",
+    "dataTags": []
+  },
+  {
     "type": "validated",
     "id": "b35dc783-a25e-487a-a914-6064bdd7feb5",
     "name": "LAST_3_MONTHS_HOURLY_MEASUREMENTS_PER_DAY",

--- a/data-needs/data-needs.mermaid
+++ b/data-needs/data-needs.mermaid
@@ -59,7 +59,11 @@ classDiagram
     class AiidaSchema {
         <<enumeration>>
         SMART-METER-P1-RAW
-        SMART-METER-P1-CIM
+        SMART-METER-P1-CIM-V1-04
+        SMART-METER-P1-CIM-V1-12
+        OPAQUE
+        ACKNOWLEDGEMENT-CIM-V1-12
+        MIN-MAX-ENVELOPE-CIM-V1-12
     }
 
     class AiidaAsset {

--- a/data-needs/src/main/java/energy/eddie/dataneeds/needs/aiida/OutboundAiidaDataNeed.java
+++ b/data-needs/src/main/java/energy/eddie/dataneeds/needs/aiida/OutboundAiidaDataNeed.java
@@ -18,7 +18,9 @@ public class OutboundAiidaDataNeed extends AiidaDataNeed {
     public static final String DISCRIMINATOR_VALUE = "outbound-aiida";
     public static final Set<AiidaSchema> SUPPORTED_SCHEMAS = Set.of(AiidaSchema.SMART_METER_P1_RAW,
                                                                       AiidaSchema.SMART_METER_P1_CIM_V1_04,
-                                                                      AiidaSchema.SMART_METER_P1_CIM_V1_12);
+                                                                      AiidaSchema.SMART_METER_P1_CIM_V1_12,
+                                                                      AiidaSchema.OPAQUE,
+                                                                      AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12);
 
     @SuppressWarnings("NullAway.Init")
     public OutboundAiidaDataNeed() {


### PR DESCRIPTION
This PR introduces the following changes towards implementing the forwarding of inbound messages in AIIDA for #2394.
1. Eligible parties may request inbound schemas in outbound data needs.
2. Customers may select inbound data sources (presented as permissions) for outbound permissions.
3. Inbound records are relayed to the MQTT topic of the outbound permission and schema.

The changes only implement the AIIDA side: requesting, selection, and forwarding.
I want to split the EDDIE side into its own PR to keep the total number of changes manageable.

A couple assumptions were made when working on these features, and some questions arose that I would like to list here.

## Assumptions

 - Presence of an inbound schema means a forwarding data need requiring the selection of an inbound data source
 - Allow only the selection of data sources able to produce one of the requested schemas
 - Only one data source can be selected per permission
 - EP receiving the forwarded messages does not need the original metadata
	 - EP would not request forwarded messages if they were sending the messages themselves. Therefore, metadata can be replaced when forwarded to match the forwarding permission.


## Questions

- [x] Allow adding data needs with both inbound and outbound schemas or fail creation?
- [x] Should the data source be able to forward one requested schema or all?
	- Outbound schemas → select outbound data source
	- Inbound schemas → select inbound data source that can forward it
	- Mix of inbound and outbound → select either inbound or outbound
	- Both inbound and outbound → select one of each
- [x] Throw when trying to set a data source with the wrong asset type, do we care?
- [x] Allow the user to name their permissions? Data need name as default.
	- Most relevant for inbound, but might also be useful for outbound permissions.
- [x] How to handle revoke inbound permission?
	- Revoke outbound permissions using the inbound data source as well, or
	- only allow revoke if no outbound permissions use its data source (current implementation)?

## Screencasts

Selecting an inbound data source for an outbound permission

https://github.com/user-attachments/assets/a48e2670-f2b5-4a24-a704-7f38ba0e17a5

Handling revocation

https://github.com/user-attachments/assets/5bceea29-da9c-48f9-a797-589680d5a775

Downloading the latest forwarded record

https://github.com/user-attachments/assets/5dff87c2-e384-4b68-8d54-84e53af844bd


