### PR TITLE
feat(simulation-region-connector): Extend scenarios with an interaction block for termination requests

### DIFF
--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/SimulationConnector.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/SimulationConnector.java
@@ -1,14 +1,19 @@
-// SPDX-FileCopyrightText: 2023 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2023-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.regionconnector.simulation;
 
 import energy.eddie.api.v0.RegionConnector;
 import energy.eddie.api.v0.RegionConnectorMetadata;
+import energy.eddie.regionconnector.simulation.providers.DocumentStreams;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SimulationConnector implements RegionConnector {
+    private final DocumentStreams streams;
+
+    public SimulationConnector(DocumentStreams streams) {this.streams = streams;}
+
     @Override
     public RegionConnectorMetadata getMetadata() {
         return SimulationConnectorMetadata.getInstance();
@@ -16,6 +21,6 @@ public class SimulationConnector implements RegionConnector {
 
     @Override
     public void terminatePermission(String permissionId) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        streams.publish(permissionId);
     }
 }

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/SimulationConstraints.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/SimulationConstraints.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.regionconnector.simulation.engine;
@@ -16,7 +16,9 @@ class SimulationConstraints {
     private final Scenario scenario;
     private final List<StructuralConstraint> structuralConstraints = List.of(
             new PermissionProcessModelConstraint(),
-            new DataFollowsAcceptedStepOrDataConstraint()
+            new DataFollowsAcceptedStepOrDataConstraint(),
+            new TerminationFollowedByConstraint(),
+            new TerminationFollowingConstraint()
     );
     private final List<ElementConstraint> elementConstraints;
 

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/SimulationInterpret.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/SimulationInterpret.java
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2024 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.regionconnector.simulation.engine;
 
+import energy.eddie.regionconnector.simulation.engine.exceptions.ExecutionException;
 import energy.eddie.regionconnector.simulation.engine.steps.Scenario;
 import energy.eddie.regionconnector.simulation.engine.steps.Step;
 import org.slf4j.Logger;
@@ -26,6 +27,15 @@ class SimulationInterpret {
 
     void run() {
         LOGGER.info("Starting simulation scenario {}", scenario.name());
+        try {
+            executionLoop();
+            LOGGER.info("Finishing simulation scenario {}", scenario.name());
+        } catch (ExecutionException e) {
+            LOGGER.info("Simulation was stopped by unsuccessful step", e);
+        }
+    }
+
+    private void executionLoop() throws ExecutionException {
         final Deque<Step> stack = new ArrayDeque<>();
         stack.push(scenario);
         var stepCounter = 0;
@@ -41,8 +51,7 @@ class SimulationInterpret {
             }
         }
         var end = System.nanoTime();
-        LOGGER.info("Finishing simulation scenario {}", scenario.name());
-        LOGGER.atInfo()
+        LOGGER.atDebug()
               .addArgument(stepCounter)
               .addArgument(() -> Duration.of(end - start, ChronoUnit.NANOS).toString())
               .log("Simulation included {} steps and has been running for {}");

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/constraints/TerminationFollowedByConstraint.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/constraints/TerminationFollowedByConstraint.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.constraints;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintOk;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintResult;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintViolation;
+import energy.eddie.regionconnector.simulation.engine.steps.Model;
+import energy.eddie.regionconnector.simulation.engine.steps.StatusChangeStep;
+import energy.eddie.regionconnector.simulation.engine.steps.TerminationInteractionStep;
+
+public class TerminationFollowedByConstraint implements StructuralConstraint {
+    @Override
+    public ConstraintResult violatesConstraint(Model current, Model next) {
+        if (!(current instanceof TerminationInteractionStep) || next == null) {
+            return new ConstraintOk();
+        }
+        if (!(next instanceof StatusChangeStep statusChangeStep)) {
+            return new ConstraintViolation("TerminationInteractionStep must be followed by a StatusChangeStep");
+        }
+        if (statusChangeStep.status() != PermissionProcessStatus.REQUIRES_EXTERNAL_TERMINATION) {
+            return new ConstraintViolation("StatusChangeStep must have REQUIRES_EXTERNAL_TERMINATION status");
+        }
+        return new ConstraintOk();
+    }
+}

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/constraints/TerminationFollowingConstraint.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/constraints/TerminationFollowingConstraint.java
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.constraints;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintOk;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintResult;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintViolation;
+import energy.eddie.regionconnector.simulation.engine.steps.Model;
+import energy.eddie.regionconnector.simulation.engine.steps.StatusChangeStep;
+import energy.eddie.regionconnector.simulation.engine.steps.TerminationInteractionStep;
+
+public class TerminationFollowingConstraint implements StructuralConstraint {
+    @Override
+    public ConstraintResult violatesConstraint(Model current, Model next) {
+        if (!(next instanceof TerminationInteractionStep)) {
+            return new ConstraintOk();
+        }
+        if (current instanceof TerminationInteractionStep) {
+            return new ConstraintViolation(
+                    "TerminationInteractionStep must not be followed by another TerminationInteractionStep");
+        }
+        if (!(current instanceof StatusChangeStep statusChangeStep)) {
+            return new ConstraintOk();
+        }
+        if (statusChangeStep.status() != PermissionProcessStatus.ACCEPTED) {
+            return new ConstraintViolation("TerminationInteractionStep must follow an ACCEPTED StatusChangeStep");
+        }
+        return new ConstraintOk();
+    }
+}

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/exceptions/ExecutionException.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/exceptions/ExecutionException.java
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.exceptions;
+
+public class ExecutionException extends Exception {
+    public ExecutionException(String message) {
+        super(message);
+    }
+}

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/Model.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/Model.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.regionconnector.simulation.engine.steps;
@@ -20,7 +20,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = Scenario.class, name = Scenario.DISCRIMINATOR_VALUE),
         @JsonSubTypes.Type(value = StatusChangeStep.class, name = StatusChangeStep.DISCRIMINATOR_VALUE),
-        @JsonSubTypes.Type(value = ValidatedHistoricalDataStep.class, name = ValidatedHistoricalDataStep.DISCRIMINATOR_VALUE)
+        @JsonSubTypes.Type(value = ValidatedHistoricalDataStep.class, name = ValidatedHistoricalDataStep.DISCRIMINATOR_VALUE),
+        @JsonSubTypes.Type(value = TerminationInteractionStep.class, name = TerminationInteractionStep.DISCRIMINATOR_VALUE)
 })
 public abstract class Model implements Step {
     protected final String type;

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/Step.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/Step.java
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2024 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.regionconnector.simulation.engine.steps;
 
 import energy.eddie.regionconnector.simulation.engine.SimulationContext;
+import energy.eddie.regionconnector.simulation.engine.exceptions.ExecutionException;
 
 import java.util.SequencedCollection;
 
@@ -19,5 +20,5 @@ public interface Step {
      * @param ctx context that might be needed by the step
      * @return next steps to be executed
      */
-    SequencedCollection<Step> execute(SimulationContext ctx);
+    SequencedCollection<Step> execute(SimulationContext ctx) throws ExecutionException;
 }

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/TerminationInteractionStep.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/TerminationInteractionStep.java
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.steps;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import energy.eddie.regionconnector.simulation.engine.SimulationContext;
+import energy.eddie.regionconnector.simulation.engine.steps.runtime.WaitForTerminationStep;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.SequencedCollection;
+
+public class TerminationInteractionStep extends Model {
+    public static final String DISCRIMINATOR_VALUE = "TerminationInteractionStep";
+    private final Duration waitFor;
+
+    @JsonCreator
+    public TerminationInteractionStep(@JsonProperty("waitFor") Duration waitFor) {
+        super(DISCRIMINATOR_VALUE);
+        this.waitFor = waitFor;
+    }
+
+    @Override
+    public SequencedCollection<Step> execute(SimulationContext ctx) {
+        return List.of(
+                new WaitForTerminationStep(waitFor)
+        );
+    }
+}

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/runtime/WaitForTerminationStep.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/runtime/WaitForTerminationStep.java
@@ -5,9 +5,8 @@ package energy.eddie.regionconnector.simulation.engine.steps.runtime;
 
 import energy.eddie.cim.agnostic.PermissionProcessStatus;
 import energy.eddie.regionconnector.simulation.engine.SimulationContext;
+import energy.eddie.regionconnector.simulation.engine.exceptions.ExecutionException;
 import energy.eddie.regionconnector.simulation.engine.steps.Step;
-import org.jspecify.annotations.NonNull;
-import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.util.List;
@@ -21,23 +20,19 @@ public class WaitForTerminationStep implements Step {
     }
 
     @Override
-    public SequencedCollection<Step> execute(SimulationContext ctx) {
+    public SequencedCollection<Step> execute(SimulationContext ctx) throws ExecutionException {
         try {
-            return ctx.documentStreams().getTerminationStream()
-                      .any(permissionId -> permissionId.equals(ctx.permissionId()))
-                      .timeout(waitFor)
-                      .onErrorResume(throwable -> Mono.just(false))
-                      .map(WaitForTerminationStep::onTermination)
-                      .blockOptional()
-                      .orElseGet(List::of);
-        } catch (IllegalStateException e) {
-            return List.of();
+            var res = ctx.documentStreams()
+                         .getTerminationStream()
+                         .any(permissionId -> permissionId.equals(ctx.permissionId()))
+                         .timeout(waitFor)
+                         .block();
+            if (Boolean.TRUE.equals(res)) {
+                return List.of(new StatusEmissionStep(PermissionProcessStatus.TERMINATED));
+            }
+        } catch (RuntimeException ignored) {
+            // No Op
         }
-    }
-
-    private static @NonNull SequencedCollection<Step> onTermination(boolean present) {
-        return present
-                ? List.of(new StatusEmissionStep(PermissionProcessStatus.TERMINATED))
-                : List.of();
+        throw new ExecutionException("Never received termination request from eligible party for permission request " + ctx.permissionId());
     }
 }

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/runtime/WaitForTerminationStep.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/engine/steps/runtime/WaitForTerminationStep.java
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.steps.runtime;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.regionconnector.simulation.engine.SimulationContext;
+import energy.eddie.regionconnector.simulation.engine.steps.Step;
+import org.jspecify.annotations.NonNull;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.SequencedCollection;
+
+public class WaitForTerminationStep implements Step {
+    private final Duration waitFor;
+
+    public WaitForTerminationStep(Duration waitFor) {
+        this.waitFor = waitFor;
+    }
+
+    @Override
+    public SequencedCollection<Step> execute(SimulationContext ctx) {
+        try {
+            return ctx.documentStreams().getTerminationStream()
+                      .any(permissionId -> permissionId.equals(ctx.permissionId()))
+                      .timeout(waitFor)
+                      .onErrorResume(throwable -> Mono.just(false))
+                      .map(WaitForTerminationStep::onTermination)
+                      .blockOptional()
+                      .orElseGet(List::of);
+        } catch (IllegalStateException e) {
+            return List.of();
+        }
+    }
+
+    private static @NonNull SequencedCollection<Step> onTermination(boolean present) {
+        return present
+                ? List.of(new StatusEmissionStep(PermissionProcessStatus.TERMINATED))
+                : List.of();
+    }
+}

--- a/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/providers/DocumentStreams.java
+++ b/region-connectors/region-connector-simulation/src/main/java/energy/eddie/regionconnector/simulation/providers/DocumentStreams.java
@@ -30,6 +30,7 @@ public class DocumentStreams implements AutoCloseable {
     private final Sinks.Many<SimulatedMeterReading> vhdSink = Sinks.many().multicast().onBackpressureBuffer();
     private final Sinks.Many<ConnectionStatusMessage> csmSink = Sinks.many().multicast().onBackpressureBuffer();
     private final Sinks.Many<PermissionEnvelope> pmdSink = Sinks.many().multicast().onBackpressureBuffer();
+    private final Sinks.Many<String> terminationSink = Sinks.many().multicast().onBackpressureBuffer();
     private final CommonInformationModelConfiguration cimConfig;
     private final ObjectMapper objectMapper;
     private final Sinks.Many<RequestPermissionEnvelope> rpmdSink = Sinks.many().multicast().onBackpressureBuffer();
@@ -59,6 +60,10 @@ public class DocumentStreams implements AutoCloseable {
         rpmdSink.tryEmitNext(permissionMarketDocument);
     }
 
+    public synchronized void publish(String permissionToBeTerminated) {
+        terminationSink.tryEmitNext(permissionToBeTerminated);
+    }
+
     @MessageStream(ValidatedHistoricalDataEnvelope.class)
     public Flux<ValidatedHistoricalDataEnvelope> getValidatedHistoricalDataMarketDocumentsStream() {
         return getSimulatedMeterReadingStream()
@@ -71,6 +76,7 @@ public class DocumentStreams implements AutoCloseable {
         vhdSink.tryEmitComplete();
         pmdSink.tryEmitComplete();
         csmSink.tryEmitComplete();
+        terminationSink.tryEmitComplete();
     }
 
     @MessageStream(ConnectionStatusMessage.class)
@@ -87,6 +93,7 @@ public class DocumentStreams implements AutoCloseable {
     public Flux<RequestPermissionEnvelope> getRequestPermissionMarketDocumentStream() {
         return rpmdSink.asFlux();
     }
+
     @MessageStream(RawDataMessage.class)
     public Flux<RawDataMessage> getRawDataMessageStream() {
         return getSimulatedMeterReadingStream()
@@ -101,5 +108,9 @@ public class DocumentStreams implements AutoCloseable {
 
     public Flux<SimulatedMeterReading> getSimulatedMeterReadingStream() {
         return vhdSink.asFlux();
+    }
+
+    public Flux<String> getTerminationStream() {
+        return terminationSink.asFlux();
     }
 }

--- a/region-connectors/region-connector-simulation/src/main/resources/scenarios/eligible-party-terminating-permission-request-scenario.json
+++ b/region-connectors/region-connector-simulation/src/main/resources/scenarios/eligible-party-terminating-permission-request-scenario.json
@@ -1,0 +1,40 @@
+{
+  "type": "Scenario",
+  "name": "Eligible Party Terminating Permission Request Scenario",
+  "steps": [
+    {
+      "type": "StatusChangeStep",
+      "status": "CREATED",
+      "delayInSeconds": 0
+    },
+    {
+      "type": "StatusChangeStep",
+      "status": "VALIDATED",
+      "delayInSeconds": 0
+    },
+    {
+      "type": "StatusChangeStep",
+      "status": "SENT_TO_PERMISSION_ADMINISTRATOR",
+      "delayInSeconds": 0
+    },
+    {
+      "type": "StatusChangeStep",
+      "status": "ACCEPTED",
+      "delayInSeconds": 0
+    },
+    {
+      "type": "TerminationInteractionStep",
+      "waitFor": "PT5M"
+    },
+    {
+      "type": "StatusChangeStep",
+      "status": "REQUIRES_EXTERNAL_TERMINATION",
+      "delayInSeconds": 10
+    },
+    {
+      "type": "StatusChangeStep",
+      "status": "EXTERNALLY_TERMINATED",
+      "delayInSeconds": 0
+    }
+  ]
+}

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/SimulationConnectorTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/SimulationConnectorTest.java
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation;
+
+import energy.eddie.api.cim.config.PlainCommonInformationModelConfiguration;
+import energy.eddie.cim.v0_82.vhd.CodingSchemeTypeList;
+import energy.eddie.regionconnector.simulation.providers.DocumentStreams;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+import tools.jackson.databind.ObjectMapper;
+
+class SimulationConnectorTest {
+
+    @Test
+    void testTerminatePermission() {
+        // Given
+        var cimConfig = new PlainCommonInformationModelConfiguration(CodingSchemeTypeList.AUSTRIA_NATIONAL_CODING_SCHEME,
+                                                                     "ep-id");
+        var streams = new DocumentStreams(cimConfig, new ObjectMapper());
+        var simulationConnector = new SimulationConnector(streams);
+        var testPermissionId = "test-permission-id";
+
+        // When
+        simulationConnector.terminatePermission(testPermissionId);
+
+        // Then
+        StepVerifier.create(streams.getTerminationStream())
+                    .expectNext(testPermissionId)
+                    .then(streams::close)
+                    .verifyComplete();
+    }
+}

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/PredefinedScenariosTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/PredefinedScenariosTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.regionconnector.simulation.engine;
@@ -18,6 +18,7 @@ class PredefinedScenariosTest {
         // Given
         var uri = "classpath:/scenarios/*.json";
         var expected = Set.of(
+                "Eligible Party Terminating Permission Request Scenario",
                 "External Termination Scenario",
                 "Validated Historical Data Scenario",
                 "Failed To Externally Terminate Scenario",

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/SimulationInterpretTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/SimulationInterpretTest.java
@@ -4,13 +4,13 @@
 package energy.eddie.regionconnector.simulation.engine;
 
 import energy.eddie.cim.agnostic.PermissionProcessStatus;
-import energy.eddie.regionconnector.simulation.engine.steps.Scenario;
-import energy.eddie.regionconnector.simulation.engine.steps.StatusChangeStep;
-import energy.eddie.regionconnector.simulation.engine.steps.TestSimulationContext;
+import energy.eddie.regionconnector.simulation.engine.exceptions.ExecutionException;
+import energy.eddie.regionconnector.simulation.engine.steps.*;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import java.util.List;
+import java.util.SequencedCollection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -40,6 +40,31 @@ class SimulationInterpretTest {
                             PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR,
                             csm.status()
                     ))
+                    .verifyComplete();
+    }
+
+    @Test
+    void testRunWithExecutionException_stopsExecution() {
+        // Given
+        var ctx = TestSimulationContext.create();
+        var streams = ctx.documentStreams();
+        var scenario = new Scenario("Test", List.of(
+                new Model("TestModel") {
+                    @Override
+                    public SequencedCollection<Step> execute(SimulationContext ctx) throws ExecutionException {
+                        throw new ExecutionException("Test Exception");
+                    }
+                },
+                new StatusChangeStep(PermissionProcessStatus.CREATED)
+        ));
+        var interpret = new SimulationInterpret(scenario, ctx);
+
+        // When
+        interpret.run();
+
+        // Then
+        StepVerifier.create(streams.getConnectionStatusMessageStream())
+                    .then(streams::close)
                     .verifyComplete();
     }
 }

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/constraints/TerminationFollowedByConstraintTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/constraints/TerminationFollowedByConstraintTest.java
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.constraints;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintOk;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintResult;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintViolation;
+import energy.eddie.regionconnector.simulation.engine.steps.Model;
+import energy.eddie.regionconnector.simulation.engine.steps.StatusChangeStep;
+import energy.eddie.regionconnector.simulation.engine.steps.TerminationInteractionStep;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TerminationFollowedByConstraintTest {
+
+    @Test
+    void shouldReturnOkWhenCurrentIsNotTerminationInteractionStep() {
+        // Given
+        Model current = new StatusChangeStep(PermissionProcessStatus.VALIDATED);
+        Model next = new StatusChangeStep(PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR);
+
+        var constraint = new TerminationFollowedByConstraint();
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(current, next);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintOk.class);
+    }
+
+    @Test
+    void shouldReturnOkWhenNextIsNull() {
+        // Given
+        Model current = new TerminationInteractionStep(Duration.ofSeconds(10));
+        var constraint = new TerminationFollowedByConstraint();
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(current, null);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintOk.class);
+    }
+
+    @Test
+    void shouldReturnViolationWhenNextIsNotStatusChangeStep() {
+        // Given
+        Model current = new TerminationInteractionStep(Duration.ofSeconds(10));
+        Model next = new TerminationInteractionStep(Duration.ofSeconds(10));
+
+        var constraint = new TerminationFollowedByConstraint();
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(current, next);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintViolation.class);
+    }
+
+    @Test
+    void shouldReturnViolationWhenNextStatusIsNotRequiresExternalTermination() {
+        // Given
+        Model current = new TerminationInteractionStep(Duration.ofSeconds(10));
+        Model next = new StatusChangeStep(PermissionProcessStatus.ACCEPTED);
+        var constraint = new TerminationFollowedByConstraint();
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(current, next);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintViolation.class);
+    }
+
+    @Test
+    void shouldReturnOkWhenNextStatusIsRequiresExternalTermination() {
+        // Given
+        Model current = new TerminationInteractionStep(Duration.ofSeconds(10));
+        Model next = new StatusChangeStep(PermissionProcessStatus.REQUIRES_EXTERNAL_TERMINATION);
+        var constraint = new TerminationFollowedByConstraint();
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(current, next);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintOk.class);
+    }
+}

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/constraints/TerminationFollowingConstraintTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/constraints/TerminationFollowingConstraintTest.java
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.constraints;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.regionconnector.simulation.dtos.SimulatedValidatedHistoricalData;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintOk;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintResult;
+import energy.eddie.regionconnector.simulation.engine.constraints.results.ConstraintViolation;
+import energy.eddie.regionconnector.simulation.engine.steps.Model;
+import energy.eddie.regionconnector.simulation.engine.steps.StatusChangeStep;
+import energy.eddie.regionconnector.simulation.engine.steps.TerminationInteractionStep;
+import energy.eddie.regionconnector.simulation.engine.steps.ValidatedHistoricalDataStep;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TerminationFollowingConstraintTest {
+
+    @Test
+    void shouldReturnConstraintViolationForSuccessiveTerminationSteps() {
+        // Given
+        var constraint = new TerminationFollowingConstraint();
+        Model model1 = new TerminationInteractionStep(Duration.ofSeconds(5));
+        Model model2 = new TerminationInteractionStep(Duration.ofSeconds(10));
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(model1, model2);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintViolation.class);
+    }
+
+    @Test
+    void shouldReturnConstraintViolationForNonAcceptedStatus() {
+        // Given
+        var constraint = new TerminationFollowingConstraint();
+        Model statusStep = new StatusChangeStep(PermissionProcessStatus.VALIDATED);
+        Model terminationStep = new TerminationInteractionStep(Duration.ofSeconds(15));
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(statusStep, terminationStep);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintViolation.class);
+    }
+
+    @Test
+    void shouldReturnConstraintOkForAcceptedStatus() {
+        // Given
+        var constraint = new TerminationFollowingConstraint();
+        Model acceptedStatusStep = new StatusChangeStep(PermissionProcessStatus.ACCEPTED);
+        Model terminationStep = new TerminationInteractionStep(Duration.ofSeconds(10));
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(acceptedStatusStep, terminationStep);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintOk.class);
+    }
+
+    @Test
+    void shouldReturnConstraintOkForUnrelatedModels() {
+        // Given
+        var constraint = new TerminationFollowingConstraint();
+        Model unrelatedModel1 = new StatusChangeStep(PermissionProcessStatus.ACCEPTED);
+        Model unrelatedModel2 = new StatusChangeStep(PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR);
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(unrelatedModel1, unrelatedModel2);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintOk.class);
+    }
+
+    @Test
+    void shouldReturnConstraintOkForUnrelatedPreviousStep() {
+        // Given
+        var constraint = new TerminationFollowingConstraint();
+        Model previous = new ValidatedHistoricalDataStep(
+                new SimulatedValidatedHistoricalData(
+                        "",
+                        ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                        "",
+                        List.of()
+                )
+        );
+        Model next = new TerminationInteractionStep(Duration.ofSeconds(10));
+
+        // When
+        ConstraintResult result = constraint.violatesConstraint(previous, next);
+
+        // Then
+        assertThat(result).isInstanceOf(ConstraintOk.class);
+    }
+}

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/steps/TerminationInteractionStepTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/steps/TerminationInteractionStepTest.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.steps;
+
+import energy.eddie.regionconnector.simulation.engine.steps.runtime.WaitForTerminationStep;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TerminationInteractionStepTest {
+    @Test
+    void shouldReturnListWithWaitForTerminationStep() {
+        // Given
+        var step = new TerminationInteractionStep(Duration.ofSeconds(10));
+        var ctx = TestSimulationContext.create();
+
+        // When
+        var res = step.execute(ctx);
+
+        // Then
+        assertThat(res)
+                .singleElement()
+                .isInstanceOf(WaitForTerminationStep.class);
+    }
+}

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/steps/runtime/WaitForTerminationStepTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/steps/runtime/WaitForTerminationStepTest.java
@@ -3,6 +3,7 @@
 
 package energy.eddie.regionconnector.simulation.engine.steps.runtime;
 
+import energy.eddie.regionconnector.simulation.engine.exceptions.ExecutionException;
 import energy.eddie.regionconnector.simulation.engine.steps.TestSimulationContext;
 import org.junit.jupiter.api.Test;
 
@@ -10,40 +11,35 @@ import java.time.Duration;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class WaitForTerminationStepTest {
 
     @Test
-    void shouldReturnAnEmptyListIfNoTerminationIsSent() {
+    void shouldThrowNoTerminationIsSent() {
         // Given
         var step = new WaitForTerminationStep(Duration.ofSeconds(0));
         var ctx = TestSimulationContext.create();
 
-        // When
-        var res = step.execute(ctx);
-
-        // Then
-        assertThat(res).isEmpty();
+        // When & Then
+        assertThatThrownBy(() -> step.execute(ctx)).isInstanceOf(ExecutionException.class);
     }
 
     @Test
-    void shouldReturnAnEmptyListIfNoMatchingTerminationIsSent() {
+    void shouldThrowIfNoMatchingTerminationIsSent() {
         // Given
         var step = new WaitForTerminationStep(Duration.ofSeconds(0));
         var ctx = TestSimulationContext.create();
 
-        // When
+        // When & Then
         ctx.documentStreams().publish(UUID.randomUUID().toString());
-        var res = step.execute(ctx);
-
-        // Then
-        assertThat(res).isEmpty();
+        assertThatThrownBy(() -> step.execute(ctx)).isInstanceOf(ExecutionException.class);
     }
 
     @Test
-    void shouldReturnListWithStatusEmissionIfTerminationMatches() {
+    void shouldReturnListWithStatusEmissionIfTerminationMatches() throws ExecutionException {
         // Given
-        var step = new WaitForTerminationStep(Duration.ofSeconds(0));
+        var step = new WaitForTerminationStep(Duration.ofSeconds(1));
         var ctx = TestSimulationContext.create();
 
         // When

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/steps/runtime/WaitForTerminationStepTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/engine/steps/runtime/WaitForTerminationStepTest.java
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.simulation.engine.steps.runtime;
+
+import energy.eddie.regionconnector.simulation.engine.steps.TestSimulationContext;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WaitForTerminationStepTest {
+
+    @Test
+    void shouldReturnAnEmptyListIfNoTerminationIsSent() {
+        // Given
+        var step = new WaitForTerminationStep(Duration.ofSeconds(0));
+        var ctx = TestSimulationContext.create();
+
+        // When
+        var res = step.execute(ctx);
+
+        // Then
+        assertThat(res).isEmpty();
+    }
+
+    @Test
+    void shouldReturnAnEmptyListIfNoMatchingTerminationIsSent() {
+        // Given
+        var step = new WaitForTerminationStep(Duration.ofSeconds(0));
+        var ctx = TestSimulationContext.create();
+
+        // When
+        ctx.documentStreams().publish(UUID.randomUUID().toString());
+        var res = step.execute(ctx);
+
+        // Then
+        assertThat(res).isEmpty();
+    }
+
+    @Test
+    void shouldReturnListWithStatusEmissionIfTerminationMatches() {
+        // Given
+        var step = new WaitForTerminationStep(Duration.ofSeconds(0));
+        var ctx = TestSimulationContext.create();
+
+        // When
+        ctx.documentStreams().publish(ctx.permissionId());
+        var res = step.execute(ctx);
+
+        // Then
+        assertThat(res)
+                .singleElement()
+                .isInstanceOf(StatusEmissionStep.class);
+    }
+}

--- a/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/web/ScenarioControllerTest.java
+++ b/region-connectors/region-connector-simulation/src/test/java/energy/eddie/regionconnector/simulation/web/ScenarioControllerTest.java
@@ -31,7 +31,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import tools.jackson.databind.ObjectMapper;
 
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -74,6 +73,7 @@ class ScenarioControllerTest {
                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                .andExpect(content().json("""
                                                  [
+                                                   "Eligible Party Terminating Permission Request Scenario",
                                                    "External Termination Scenario",
                                                    "Failed To Externally Terminate Scenario",
                                                    "Validated Historical Data Scenario",
@@ -96,7 +96,7 @@ class ScenarioControllerTest {
                         new StatusChangeStep(PermissionProcessStatus.ACCEPTED),
                         new ValidatedHistoricalDataStep(
                                 new SimulatedValidatedHistoricalData("mid",
-                                                                     ZonedDateTime.now(ZoneOffset.UTC),
+                                                                     ZonedDateTime.parse("2026-01-01T00:00:00Z"),
                                                                      Granularity.PT15M.name(),
                                                                      List.of(
                                                                              new Measurement(10.0,


### PR DESCRIPTION
The simulation-region-connector now supports scenarios with a termination interaction step that allows scenarios to await termination requests before moving on to the next steps