### PR TITLE
fix(core): Fix bug where management APIs could be accessed from the public port when context-path is given

### DIFF
--- a/core/src/main/java/energy/eddie/core/ManagementApiConfig.java
+++ b/core/src/main/java/energy/eddie/core/ManagementApiConfig.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2023-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.core;
@@ -11,8 +11,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import org.apache.catalina.connector.Connector;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.tomcat.TomcatWebServerFactory;
 import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.servlet.ServletWebServerFactory;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -57,7 +59,7 @@ public class ManagementApiConfig {
 
     @Bean
     public ServletWebServerFactory servletContainer() {
-        Connector connector = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
+        Connector connector = new Connector(TomcatWebServerFactory.DEFAULT_PROTOCOL);
         connector.setScheme("http");
         connector.setPort(managementPort);
 
@@ -82,12 +84,14 @@ public class ManagementApiConfig {
                 FilterChain chain
         ) throws IOException, ServletException {
             var httpRequest = (HttpServletRequest) request;
+            var contextPath = contextPath(httpRequest);
             var isRequestOnManagementPort = httpRequest.getLocalPort() == managementPort;
             var requestURI = httpRequest.getRequestURI();
-            var isRequestOnManagementUrl = requestURI.startsWith(CoreSpringConfig.DATA_NEEDS_URL_MAPPING_PREFIX + managementUrlPrefix)
-                                           || requestURI.startsWith("/outbound-connectors")
-                                           || requestURI.startsWith(managementUrlPrefix)
-                                           || requestURI.matches("/region-connectors/[\\w\\-]+%s/.*".formatted(managementUrlPrefix));
+            var isRequestOnManagementUrl = requestURI.startsWith(contextPath + CoreSpringConfig.DATA_NEEDS_URL_MAPPING_PREFIX + managementUrlPrefix)
+                                           || requestURI.startsWith(contextPath + "/outbound-connectors")
+                                           || requestURI.startsWith(contextPath + managementUrlPrefix)
+                                           || requestURI.matches(contextPath + "/region-connectors/[\\w\\-]+%s/.*".formatted(
+                    managementUrlPrefix));
             IEF_LOGGER.debug("{} requested on port {}, managementPort: {}, managementUrl: {}",
                              requestURI,
                              request.getLocalPort(),
@@ -100,6 +104,19 @@ public class ManagementApiConfig {
             } else {
                 ((HttpServletResponse) response).sendError(HttpServletResponse.SC_NOT_FOUND);
             }
+        }
+
+        @SuppressWarnings("java:S1075")
+        private static @NonNull String contextPath(HttpServletRequest httpRequest) {
+            var contextPath = httpRequest.getContextPath();
+            if (contextPath == null || contextPath.isBlank()) {
+                contextPath = "";
+            } else {
+                contextPath = contextPath.startsWith("/") ? contextPath : "/" + contextPath;
+                contextPath = contextPath.endsWith("/") ? contextPath.substring(0,
+                                                                                contextPath.length() - 1) : contextPath;
+            }
+            return contextPath;
         }
     }
 }

--- a/core/src/test/java/energy/eddie/core/ManagementApiConfigTest.java
+++ b/core/src/test/java/energy/eddie/core/ManagementApiConfigTest.java
@@ -7,16 +7,22 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.testcontainers.shaded.com.google.common.collect.Sets;
 
 import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SuppressWarnings("DataFlowIssue")
 class ManagementApiConfigInternalEndpointsFilterTest {
     @ParameterizedTest
     @ValueSource(strings = {"/management", "/outbound-connectors", "/data-needs/management", "/region-connectors/any-region-connector/management/any/other"})
@@ -25,6 +31,32 @@ class ManagementApiConfigInternalEndpointsFilterTest {
         var req = new MockHttpServletRequest();
         req.setRequestURI(reqUri);
         req.setLocalPort(9090);
+        var resp = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+        var config = new ManagementApiConfig(9090, "management");
+        var filter = config.trustedEndpointsFilter().getFilter();
+
+        // When
+        filter.doFilter(req, resp, chain);
+
+        // Then
+        assertAll(
+                () -> assertEquals(req, chain.getRequest()),
+                () -> assertEquals(resp, chain.getResponse())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testDoFilter_forManagementPortOnManagementUrlWithContextPath_continuesFilterChain(
+            String reqUri,
+            String contextPath
+    ) throws ServletException, IOException {
+        // Given
+        var req = new MockHttpServletRequest();
+        req.setRequestURI(reqUri);
+        req.setLocalPort(9090);
+        req.setContextPath(contextPath);
         var resp = new MockHttpServletResponse();
         var chain = new MockFilterChain();
         var config = new ManagementApiConfig(9090, "management");
@@ -95,5 +127,21 @@ class ManagementApiConfigInternalEndpointsFilterTest {
 
         // Then
         assertEquals(HttpServletResponse.SC_NOT_FOUND, resp.getStatus());
+    }
+
+    private static Stream<Arguments> testDoFilter_forManagementPortOnManagementUrlWithContextPath_continuesFilterChain() {
+        var endpoints = Set.of("/eddie/management",
+                               "/eddie/outbound-connectors",
+                               "/eddie/data-needs/management",
+                               "/eddie/region-connectors/any-region-connector/management/any/other");
+        var contextPaths = Set.of("/eddie", "/eddie/", "eddie/");
+        return cartesianProduct(endpoints, contextPaths);
+    }
+
+    @SafeVarargs
+    private static Stream<Arguments> cartesianProduct(Set<String>... sets) {
+        return Sets.cartesianProduct(sets)
+                   .stream()
+                   .map(s -> Arguments.of(s.toArray(Object[]::new)));
     }
 }


### PR DESCRIPTION
Fix a bug where if the context path is set via `server.servlet.context-path`, the `InternalEndpointsFilter` would not match any management paths and would make all of them available via the public port instead of the management port. The reason for this is that the `InternalEndpointsFilter` does not take the context path into account when matching paths.