### PR TITLE
chore: Add @re1 as AIIDA code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
  
 # fh-dev is used as a fallback in case the main reviewer is unavailable
 admin-console @re1 @eddie-energy/fh-dev
-aiida @stefanpenzinger @tformatix @Maikaru-Sensei @eddie-energy/fh-dev
+aiida @re1 @stefanpenzinger @tformatix @Maikaru-Sensei @eddie-energy/fh-dev
 aiida/ui @GoodVibezOnly @re1 @eddie-energy/fh-dev
 cim @fweingartshofer @eddie-energy/fh-dev
 core/src/main/js @re1 @eddie-energy/fh-dev
@@ -11,5 +11,5 @@ e2e-tests @re1 @eddie-energy/fh-dev
 european-masterdata @re1 @eddie-energy/fh-dev
 outbound-connectors @fweingartshofer @eddie-energy/fh-dev
 region-connectors @fweingartshofer @eddie-energy/fh-dev
-region-connectors/region-connector-aiida @stefanpenzinger @tformatix @Maikaru-Sensei @eddie-energy/fh-dev
+region-connectors/region-connector-aiida @re1 @stefanpenzinger @tformatix @Maikaru-Sensei @eddie-energy/fh-dev
 region-connectors/*.js @re1 @eddie-energy/fh-dev


### PR DESCRIPTION
Suggested by @tformatix as I am now responsible for implementing flexible connection agreements into AIIDA and will probably take on more AIIDA tasks in the future.

Placed first alphabetically, not in priority.