### PR TITLE
fix(core): Register DE-ETA health indicator group

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -236,6 +236,7 @@ management.endpoint.health.group.region-connector-fr-enedis.include=enedisAddres
 management.endpoint.health.group.region-connector-nl-mijn-aansluiting.include=mijnAansluitingHealthIndicator
 management.endpoint.health.group.region-connector-us-green-button.include=greenButtonApiHealthIndicator
 management.endpoint.health.group.region-connector-sim.include=simulationHealthIndicator
+management.endpoint.health.group.region-connector-de-eta.include=etaPlusApiHealthIndicator
 
 # WebClient
 spring.codec.max-in-memory-size=20MB


### PR DESCRIPTION
### What this does

Adds the DE-ETA region connector to the actuator health groups in core, so it shows up under `/actuator/health` like the other connectors do.

### Why

The DE-ETA connector was registered and visible in the supported-features endpoint, but it never appeared under the `/actuator/health` groups, while Energinet, sim and the rest did. The connector already had a working `HealthIndicator` bean (`EtaPlusApiHealthIndicator`), so the bean was running fine. The problem was purely on the framework config side: the health groups are listed explicitly in `core/src/main/resources/application.properties`, and DE-ETA was missing its line, so the group was never created.

Florian confirmed this is the expected place to register a connector's health group.

The group key `region-connector-de-eta` matches the naming used by the other entries, and `etaPlusApiHealthIndicator` is the default Spring bean name of the `EtaPlusApiHealthIndicator` component.

### How to test

1. Start an instance with the DE-ETA connector enabled.
2. Call `GET /actuator/health` and confirm `region-connector-de-eta` is now listed under the groups.
3. Call `GET /actuator/health/region-connector-de-eta` and confirm it returns a status that reflects the reachability of the ETA Plus API.