### PR TITLE
fix(eddie-button): Fix unset button version

### DIFF
--- a/core/src/main/js/eddie-connect-button.js
+++ b/core/src/main/js/eddie-connect-button.js
@@ -35,6 +35,8 @@ import { dataNeedDescription } from "./data-need-util.js";
 
 setBasePath("https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.15.0/cdn");
 
+const EDDIE_VERSION = __EDDIE_VERSION__;
+
 const COUNTRY_NAMES = new Intl.DisplayNames(["en"], { type: "region" });
 
 const SPECIAL_PERMISSION_ADMINISTRATORS = {
@@ -1073,7 +1075,7 @@ class EddieConnectButton extends LitElement {
         <div slot="footer" class="footer">
           ${this._hasCustomLogo ? html`${unsafeSVG(headerImage)}` : ""}
           <div class="version-indicator">
-            <i>EDDIE Version: __EDDIE_VERSION__</i>
+            <i>EDDIE Version: ${EDDIE_VERSION}</i>
           </div>
         </div>
       </sl-dialog>


### PR DESCRIPTION
I assume some version bump on Vite changed how it replaces constants so it does not work directly in strings anymore.

Note that the displayed version is not actually the EDDIE version anymore. We changed to semantic versioning a while ago but never added the version information to the repository. Only want this PR to not show the placeholder. Creating a separate issue for tracking the current version, as this will also be needed for tracing in messages.

Before

<img width="293" height="43" alt="image" src="https://github.com/user-attachments/assets/55b170dd-e601-43fb-8c2b-c5912869bf2e" />

After

<img width="216" height="43" alt="image" src="https://github.com/user-attachments/assets/0cdf6a21-631a-441a-9a61-b5b901e79849" />