### PR TITLE
docs: Update the readme to include the consortium

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,135 +2,132 @@
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11443/badge)](https://www.bestpractices.dev/en/projects/11443/passing)
 
-[EDDIE](https://eddie.energy) provides a unified interface for requesting energy data from various MDAs (Metered Data Administrators) throughout
-the European Union.
-It abstracts the complex and diverse processes required by the different MDAs and provides easy access to energy data.
+[EDDIE](https://eddie.energy/) is an open-source European energy-data initiative built through cooperation between research organisations, universities, energy-sector specialists, technology companies and individual contributors.
 
-This repository is home to both the EDDIE Framework and AIIDA.
-AIIDA lives in the `aiida` folder and has its own [README](aiida/README.md).
+**EDDIE makes it possible for energy-data-driven services to connect to cross-border data-exchange environments across the EU—and beyond—in a matter of minutes.** Final customers benefit from a standardised and trusted workflow that enables them to participate in flexibility services, energy sharing, energy-efficiency schemes and many other data-driven applications.
+
+> [!IMPORTANT]
+> **Open source:** The EDDIE Framework and AIIDA open-source core components are released under the [Apache License 2.0](https://github.com/eddie-energy/eddie/blob/main/LICENSE), supporting open use, modification and redistribution under its terms. Third-party assets, demonstrators, branding and domains may be subject to separate terms.
+
+EDDIE’s overarching technical and interoperability architecture was developed by <a href="https://entarc.eu/" target="_blank" rel="noopener noreferrer">EntArc.eu</a> and <a href="https://www.digital4grids.com/" target="_blank" rel="noopener noreferrer">Digital4Grids</a>. Component design and implementation have been collaborative efforts across the consortium. During the Horizon Europe project, <a href="https://fh-ooe.at/" target="_blank" rel="noopener noreferrer">FH Upper Austria</a> provided the principal software-engineering capacity, complemented by implementation, data-modelling, standardisation, research and validation work from other consortium partners and community contributors.
+
+## Start with the EDDIE tutorial
+
+Follow the official quickstart to launch the EDDIE Framework, explore the demonstration environment and understand the basic operator workflow.
+
+### [Open the EDDIE tutorial →](https://architecture.eddie.energy/framework/1-running/OPERATION.html#quickstart)
 
 > [!NOTE]
-> Feedback and Questions create either an issue or direct at <georg.hartner@eddie.energy> and <florian.weingartshofer@fh-hagenberg.at>
+> For feedback and questions, [create an issue](https://github.com/eddie-energy/eddie/issues/new/choose) or contact [georg.hartner@eddie.energy](mailto:georg.hartner@eddie.energy) and [florian.weingartshofer@fh-hagenberg.at](mailto:florian.weingartshofer@fh-hagenberg.at).
 
 ## Getting started
 
-The EDDIE Framework [documentation](https://architecture.eddie.energy/framework/) is a great place to start for both operators and developers.
-It provides different entry points for:
+The [EDDIE Framework documentation](https://architecture.eddie.energy/framework/) is a great place to start for both operators and developers. It provides different entry points for:
 
 - [Running the EDDIE Framework](https://architecture.eddie.energy/framework/1-running/OPERATION.html)
 - [Integrating EDDIE into your application](https://architecture.eddie.energy/framework/2-integrating/integrating.html)
 - [Extending or contributing to this repository](https://architecture.eddie.energy/framework/3-extending/tech-stack.html)
 
-To learn more about the architecture of the EDDIE project,
-you can visit our [architecture documentation](https://architecture.eddie.energy/architecture/).
+To learn more about the architecture of the EDDIE project, visit the [architecture documentation](https://architecture.eddie.energy/architecture/).
 
 ## Contributing
 
-If you want to contribute to this repository, please take a look at our [contributing guide](CONTRIBUTING.md).
+If you want to contribute to this repository, please take a look at the [contributing guide](https://github.com/eddie-energy/eddie/blob/main/CONTRIBUTING.md).
 
-## A quick overview of how EDDIE works
+## EDDIE project consortium
 
-![Simple diagram showing how the EDDIE Framework works](/docs/images/eddie-simple.svg)
+EDDIE was established and developed through the Horizon Europe project, which ran from **January 2023 to June 2026** under Grant Agreement No. 101069510. The consortium brought together the following organisations before the project’s transition into a sustainable open-source community:
 
-The entry point on your website is the _EDDIE Button_.
+<table>
+  <tr>
+    <td><a href="https://entarc.eu/"><img src="https://eddie.energy/assets/images/2/partner_ambassadors_EDDIE_ENTARC-543896f6.jpg" alt="EntArc.eu" width="180"><br><strong>EntArc.eu</strong></a></td>
+    <td><a href="https://www.digital4grids.com/"><img src="https://eddie.energy/assets/images/e/partner_ambassadors_EDDIE_DIGITAL4GRIDS-a6e9eabd.jpg" alt="Digital4Grids" width="180"><br><strong>Digital4Grids</strong></a></td>
+    <td><a href="https://fh-ooe.at/"><img src="https://eddie.energy/assets/images/6/partner_ambassadors_EDDIE_FHOOE-cbbd70e8.jpg" alt="FH Upper Austria" width="180"><br><strong>FH Upper Austria</strong></a></td>
+    <td><a href="https://www.univie.ac.at/"><img src="https://eddie.energy/assets/images/1/partner_ambassadors_EDDIE_UNIVERSITAETWIEN-f2bc64b8.jpg" alt="University of Vienna" width="180"><br><strong>University of Vienna</strong></a></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.ait.ac.at/"><img src="https://eddie.energy/assets/images/0/partner_ambassadors_EDDIE_AIT-1d19734f.jpg" alt="AIT Austrian Institute of Technology" width="180"><br><strong>AIT Austrian Institute of Technology</strong></a></td>
+    <td><a href="https://www.cbs.dk/"><img src="https://eddie.energy/assets/images/6/partner_ambassadors_EDDIE_CBS-fb34327f.jpg" alt="Copenhagen Business School" width="180"><br><strong>Copenhagen Business School</strong></a></td>
+    <td><a href="https://www.eui.eu/en/home"><img src="https://eddie.energy/assets/images/0/partner_ambassadors_EDDIE_EUI-4fdc18ca.jpg" alt="European University Institute" width="180"><br><strong>European University Institute</strong></a></td>
+    <td><a href="https://lisboncouncil.net/"><img src="https://eddie.energy/assets/images/7/partner_ambassadors_EDDIE_THELISBONCOUNCIL-9b154c58.jpg" alt="The Lisbon Council" width="180"><br><strong>The Lisbon Council</strong></a></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.ponton.de/"><img src="https://eddie.energy/assets/images/b/partner_ambassadors_EDDIE_PONTON-259b68bb.jpg" alt="PONTON" width="180"><br><strong>PONTON</strong></a></td>
+    <td><a href="https://aelec.es/"><img src="https://eddie.energy/assets/images/b/partner_ambassadors_EDDIE_AELEC-478f120a.jpg" alt="aelēc" width="180"><br><strong>aelēc</strong></a></td>
+    <td><a href="https://www.eda.at/"><img src="https://eddie.energy/assets/images/b/partner_ambassadors_EDDIE_EDA-1f614f73.jpg" alt="EDA" width="180"><br><strong>EDA</strong></a></td>
+    <td><a href="https://oetzi.energy/"><img src="https://eddie.energy/assets/images/8/partner_ambassadors_EDDIE_OETZI-1f11a4bd.jpg" alt="Südtiroler Energieverband and Ötzi Strom" width="180"><br><strong>Südtiroler Energieverband / Ötzi Strom</strong></a></td>
+  </tr>
+  <tr>
+    <td><a href="https://www.flexidao.com/"><img src="https://eddie.energy/assets/images/7/partner_ambassadors_EDDIE_FLEXIDAO-0e0186f0.jpg" alt="FlexiDAO" width="180"><br><strong>FlexiDAO</strong></a></td>
+    <td><a href="https://easee-gas.eu/"><img src="https://eddie.energy/assets/images/8/partner_ambassadors_EDDIE_EASEEGAS-3c87154e.jpg" alt="EASEE-gas" width="180"><br><strong>EASEE-gas</strong></a></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
 
-![Visual representation of the EDDIE button](/docs/images/eddie-button.svg)
+## Open-source governance
 
-This button is configured with a [data need](https://architecture.eddie.energy/framework/2-integrating/data-needs.html) describing the data request.
-When the customer clicks the button, a dialog will guide them through the permission process.
-The customer will usually select their country and data administrator, and input additional data depending on their regional implementation.
+Following completion of the Horizon Europe project, EDDIE is transitioning from consortium-led delivery to transparent, vendor-neutral and contribution-driven open-source stewardship.
 
-![Showcase of the EDDIE dialog](/docs/images/eddie-dialog.webp)
+> [!NOTE]
+> **Governance status:** This section describes EDDIE’s interim post-project governance. It is based on the transition framework presented to the Extraordinary General Assembly on 15 June 2026 and remains subject to completion of the Memorandum of Cooperation and alignment with the selected long-term open-source host.
 
-Any [status messages](https://architecture.eddie.energy/framework/2-integrating/messages/cim/permission-market-documents.html) as well as the [requested data](https://architecture.eddie.energy/framework/2-integrating/messages/cim/validated-historical-data-market-documents.html) are published to configured [outbound connectors](https://architecture.eddie.energy/framework/1-running/outbound-connectors/outbound-connectors.html) (like [Kafka](https://architecture.eddie.energy/framework/1-running/outbound-connectors/outbound-connector-kafka.html)) to be retrieved by your application.
+During this transition, the **EDDIE Open Source Transition Board (EOSTB)** provides overall stewardship. Its purpose is to preserve project continuity while establishing a durable community governance structure. Until the transition to a long-term host is completed, [FH Upper Austria](https://fh-ooe.at/), the [University of Vienna](https://www.univie.ac.at/), [EntArc.eu](https://entarc.eu/) and [Digital4Grids](https://www.digital4grids.com/) jointly steward the onboarding process and the EDDIE GitHub organisation under shared governance.
 
-## Running the EDDIE Framework
+| Role                                                                      | Responsibilities                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|---------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **EDDIE Open Source Transition Board (EOSTB)**                            | Acts as the temporary coordination and decision-making body for the open-source transition; safeguards EDDIE’s mission and independence; and oversees repositories, infrastructure, intellectual property, project assets and host onboarding. The EOSTB is chaired by **Georg Hartner**, Technical Coordinator, with **Laurent Schmitt**, Business Coordinator, as Deputy Chair.                                                                                                                                        |
+| **Technical Coordinator, Product Owner, EOSTB Chair and primary contact** | **Georg Hartner** coordinates the overall technical direction, architecture and cross-component roadmap; provides product ownership by aligning priorities, user needs and release objectives; leads technical and transition coordination; facilitates decisions between maintainers and working groups; coordinates security or interoperability escalations; and represents technical matters to the Transition Board and prospective host. Contact: [georg.hartner@eddie.energy](mailto:georg.hartner@eddie.energy). |
+| **Administrative and Scientific Coordinator / General Assembly Chair**    | **Oliver Hödl** provides scientific and academic coordination, strategic institutional alignment and General Assembly leadership. Contact: [oliver.hoedl@eddie.energy](mailto:oliver.hoedl@eddie.energy).                                                                                                                                                                                                                                                                                                                |
+| **Development Coordinator and maintainer contact**                        | **Marc Kurz** coordinates development processes, coding guidelines, quality assurance, testing, release management, CI/CD governance and implementation alignment. Maintainers take responsibility for defined components, review contributions, prepare releases and mentor contributors. Contact: [marc.kurz@fh-hagenberg.at](mailto:marc.kurz@fh-hagenberg.at).                                                                                                                                                       |
+| **Committers**                                                            | Regular contributors trusted to work directly within defined repository areas while following the project’s review, testing and release requirements.                                                                                                                                                                                                                                                                                                                                                                    |
+| **Contributors**                                                          | Improve EDDIE through code, documentation, testing, architecture, data models, connectors, standards work, issue reports, security reviews, translations or community support.                                                                                                                                                                                                                                                                                                                                           |
+| **Working groups**                                                        | Open, task-oriented groups for subjects such as architecture, regional connectors, AIIDA, data models, security, documentation, releases and community development.                                                                                                                                                                                                                                                                                                                                                      |
+| **Business Coordinator and EOSTB Deputy Chair**                           | **Laurent Schmitt** coordinates partner engagement, use-case alignment and ecosystem development through [Digital4Grids](https://www.digital4grids.com/), and works jointly with the Technical Coordinator on community building. Contact: [laurent.schmitt@digital4grids.com](mailto:laurent.schmitt@digital4grids.com).                                                                                                                                                                                                |
 
-The recommended way of running the EDDIE Framework is using [Docker](https://www.docker.com/) containers.
-Instructions are found in the [operation manual](https://architecture.eddie.energy/framework/1-running/OPERATION.html).
+The intended decision model is open discussion and consensus wherever possible:
 
-It is also possible to run the EDDIE Framework from source.
-This requires [JDK 21](https://www.jetbrains.com/help/idea/sdk.html#set-up-jdk) to be installed.
-The following instructions can be used to set up a local instance including our [example app](docs/1-running/example-app.md).
+1. Technical proposals are discussed through public issues, pull requests or lightweight requests for comments.
+2. Maintainers decide routine matters within their areas of responsibility.
+3. Cross-component decisions are coordinated by the Technical Coordinator together with the affected maintainers.
+4. Matters that cannot be resolved technically, or that affect the project’s mission, governance, ownership or neutrality, are referred to the Transition Board.
+5. Material decisions and their reasoning should be documented publicly.
 
-**Steps:**
+The final governance charter will define appointment, voting, recusal and role-transition procedures. Organisational affiliation alone does not grant technical authority: responsibility is based on sustained contribution, expertise, constructive participation and the trust of the project community.
 
-1. Clone the repository
-2. Start PostgreSQL and Apache Kafka: `docker compose -f ./env/docker-compose.yml up -d db kafka`
-3. Generate a secret for signing JWTs with `openssl rand -base64 32`
-4. Set the generated secret in `core/src/main/resources/application.properties`.
-   For example `eddie.jwt.hmac.secret=Y+nmICKhBcl4QbSItrf/IS9sVpUv4RMpiBtBPz0KYbM=`.
-5. Start the EDDIE Framework using Gradle: `./gradlew run-core`
-6. Start the example app: `./gradlew run-example-app`
-7. Open the example app on http://localhost:8081/login (_use any email/password_)
+## Development and technical contribution overview
 
-## Building Docker images locally
+EDDIE recognises different forms of technical contribution. Direct source-code contributions are distinguished from architecture, data modelling, standardisation and domain implementation work.
 
-Instructions on how to run the Docker images locally exist in [env/README.md](env/README.md).
-The following instructions can be used to perform a local test run with compiling the software, building, and starting a local Docker environment.
+### Founding, architecture and technical coordination
 
-1. Build the EDDIE Framework using Gradle:
+EDDIE was founded in 2020 by **Oliver Hödl** and **Georg Hartner**, growing from their shared work on European energy-data interoperability into the European Distributed Data Infrastructure for Energy.
 
-   ```shell
-   ./gradlew clean installDist
-   ```
+- **Oliver Hödl** — co-founder; scientific and project development at the <a href="https://www.univie.ac.at/" target="_blank" rel="noopener noreferrer">University of Vienna</a>.
+- **Georg Hartner** — co-founder, Technical Coordinator, Product Owner and primary technical contact; interoperability and overarching architecture through <a href="https://entarc.eu/" target="_blank" rel="noopener noreferrer">EntArc.eu</a>.
+- **Laurent Schmitt** — energy-system architecture, European interoperability and data-space expertise through <a href="https://www.digital4grids.com/" target="_blank" rel="noopener noreferrer">Digital4Grids</a>.
+- **Wout van Voornveld** — lead data architecture, Common Information Model and electricity/gas interoperability through <a href="https://easee-gas.eu/" target="_blank" rel="noopener noreferrer">EASEE-gas</a>.
+- **Christoph Schaffer** — Head of the Department for Smart and Interconnected Living (SAIL) at <a href="https://fh-ooe.at/" target="_blank" rel="noopener noreferrer">FH Upper Austria</a>; departmental oversight and institutional support for EDDIE’s software-development activities.
 
-2. Build the Docker containers:
+### Software-development coordination
 
-   ```shell
-   docker compose -f ./env/docker-compose.yml build
-   ```
+- **Marc Kurz** — coordination of the EDDIE software-development work during the Horizon Europe project at [FH Upper Austria](https://fh-ooe.at/).
+- **Nathaniel Boisgard** — Operationalisation Lead at [FlexiData GmbH](https://firmen.wko.at/flexidata-gmbh/wien/?firmaid=60b28c6c-553d-4cc6-86df-915bbfbf8db9).
+- **Florian Weingartshofer** — principal repository contributor and maintainer.
+- **Henner Carl** — software and interoperability contributions through [PONTON](https://www.ponton.de/).
+- **Benjamin Ellmer** — software engineering and implementation at [FH Upper Austria](https://fh-ooe.at/).
+- **Markus Reichl** — software engineering and implementation at [FH Upper Austria](https://fh-ooe.at/).
 
-3. Start the containers with Docker Compose.
+### Software and implementation contributors
 
-   ```shell
-   docker compose -f ./env/docker-compose.yml up -d
-   ```
+Alexander Gaertner, Arthur Grabmair, Auriane Dupin, Aya Khaled, Benjamin Ellmer, Fabian Haas, Florian Auzinger, Florian Weingartshofer, Henner Carl, Kerstin Hoebart, Manuel Seifriedsberger, Manuel Zatschkowitsch, Markus Reichl, Michael Zauner, Rainer Danner, Simon Mayr, Stefan Penzinger, Thomas Staltner, Thomas Wagner and Tobias Fischer.
 
-4. A demo button should be available on http://localhost:8080/demo
+This list provides a human-readable overview and is not intended to replace the repository history. The continuously updated record of code contributions is available in the <a href="https://github.com/eddie-energy/eddie/graphs/contributors" target="_blank" rel="noopener noreferrer">GitHub contributor graph</a>.
 
-## Configuration
+<a href="https://github.com/eddie-energy/eddie/graphs/contributors" target="_blank" rel="noopener noreferrer"><img src="https://contrib.rocks/image?repo=eddie-energy/eddie" alt="EDDIE repository contributors"></a>
 
-While Docker Compose and local configurations should run out of the box,
-actual deployments of the EDDIE Framework will require further configuration.
-Please refer to the [Configuration](https://architecture.eddie.energy/framework/1-running/OPERATION.html#configuration) of the operation manual.
+<small>Made with <a href="https://contrib.rocks" target="_blank" rel="noopener noreferrer">contrib.rocks</a>.</small>
 
-## Contributors
+Contributions to the EDDIE Framework and AIIDA open-source core are reviewed according to the project’s contribution guidelines, development practices and the requirements of the <a href="https://github.com/eddie-energy/eddie/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>. Third-party assets and separately maintained demonstrators may use other compatible terms. New contributors are welcome regardless of organisational affiliation.
 
-<a href="https://github.com/eddie-energy/eddie/graphs/contributors">
-  <img alt="Wall of Contributors" src="https://contrib.rocks/image?repo=eddie-energy/eddie" />
-</a>
-
-Made with [contrib.rocks](https://contrib.rocks).
-
-### EDDIE Development Team
-
-- Alexander Gaertner <alexander.gaertner@fh-hagenberg.at>
-- Arthur Grabmair <100279418+yungAnsem@users.noreply.github.com>
-- Auriane Dupin <144226487+AduDeVinci@users.noreply.github.com>
-- Aya Khaled <ayak.youssef@gmail.com>
-- Benjamin Ellmer <benjamin.ellmer@fh-hagenberg.at>
-- Fabian Haas <fabian.h.haas@gmail.com>
-- Florian Auzinger <florian.auzi0204@gmail.com>
-- Florian Weingartshofer <florian@flwr.dev>
-- Henner Carl <carl@ponton.de>
-- Kerstin Hoebart <kerstin.hoebart@fh-hagenberg.at>
-- Manuel Seifriedsberger <p43057@fhooe.at>
-- Manuel Zatschkowitsch <manuel.zatschkowitsch@gmail.com>
-- Markus Reichl <markus@re1.at>
-- Michael Zauner <mi.zauner.dev@proton.me>
-- Rainer Danner <rainer.danner@fh-hagenberg.at>
-- Simon Mayr <simon.mayr@fh-hagenberg.at>
-- Stefan Penzinger <Stefan.Penzinger@fh-hagenberg.at>
-- Thomas Staltner <thomas.staltner@fh-hagenberg.at>
-- Thomas Wagner <thomas.wagner@fh-hagenberg.at>
-- Tobias Fischer <tobias@tformatix.at>
-
-### Organizational Team
-
-- Christoph Schaffer <christoph.schaffer@fh-hagenberg.at>
-- Georg Hartner <georg.hartner@eddie.energy>
-- Marc Kurz <marc.kurz@fh-hagenberg.at>
-- Oliver Hoedl <oliver.hoedl@fh-hagenberg.at>
-- Shievam Kashyap <shievam.kashyap@fh-hagenberg.at>
-- Stefan Gruenberger <stefan.gruenberger@fh-hagenberg.at>
+> **Acknowledgement.** EDDIE received co-funding from the European Union’s Horizon Europe Innovation Actions under Grant Agreement No. 101069510. The project ran from January 2023 to June 2026. The views and opinions expressed in this repository are those of its contributors and do not necessarily reflect those of the European Union.


### PR DESCRIPTION
<details>

<summary>Mail for context (in german)</summary>
Die Fassung berücksichtigt die in der letzten General Assembly formulierten Governance-Entscheidungen sowie die im Hinblick auf Kommunikation, Verantwortlichkeiten und die Open-Source-Transition gefassten Beschlüsse.

Mit der Überarbeitung soll insbesondere deutlicher werden, dass EDDIE eine gemeinsame Leistung des gesamten Konsortiums ist und die Verantwortung für die Projektergebnisse vom Konsortium als Ganzes getragen wird. Gleichzeitig werden die vereinbarten operativen Rollen und Ansprechpartner transparent dargestellt, ohne den gemeinschaftlichen Charakter des Projekts in den Hintergrund treten zu lassen.

Darüber hinaus müssen die im Consortium Agreement – insbesondere in dessen IP-Bestimmungen – festgehaltene Zuordnung von Urheberschaft, Beiträgen und Rechten sowie die dazu vereinbarten Kommunikationsvorgaben angemessen abgebildet bleiben. Dies betrifft insbesondere die Beiträge und Rollen von Oliver Hödl, Digital4Grids und mir. Die entsprechenden Nennungen und Architektur- beziehungsweise Gründungszuordnungen sollten daher bei der Übernahme nicht entfernt oder inhaltlich verändert werden.

Bitte prüfe vor der Übernahme noch kurz, ob die Markdown- und HTML-Elemente auf GitHub wie vorgesehen dargestellt werden. Falls keine technischen Probleme auftreten, kannst du die bestehende README damit ersetzen.

</details>