### PR TITLE
feat(onenet-region-connector): Implement preliminary skeleton project

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2023-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 import energy.eddie.configureJavaCompileWithErrorProne
@@ -48,6 +48,7 @@ dependencies {
     implementation(project(":region-connectors:region-connector-us-green-button"))
     implementation(project(":region-connectors:region-connector-cds"))
     implementation(project(":region-connectors:region-connector-si-moj-elektro"))
+    implementation(project(":region-connectors:region-connector-onenet"))
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.openapi.webmvc.ui)
     implementation(libs.spring.boot.security)

--- a/core/src/main/js/styles/flags.js
+++ b/core/src/main/js/styles/flags.js
@@ -3,7 +3,20 @@
 
 import { css } from "lit";
 
-const flags = ["at", "be", "de", "dk", "es", "fi", "fr", "nl", "si", "us", "ca"];
+const flags = [
+  "at",
+  "be",
+  "de",
+  "dk",
+  "es",
+  "fi",
+  "fr",
+  "nl",
+  "si",
+  "us",
+  "ca",
+  "it",
+];
 
 export function hasFlag(country) {
   return flags.includes(country?.toLowerCase());
@@ -64,5 +77,9 @@ export const flagStyles = css`
 
   .flag-ca {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36'%3E%3Cpath fill='%23D52B1E' d='M4 5C1.791 5 0 6.791 0 9v18c0 2.209 1.791 4 4 4h6V5H4zm28 0h-6v26h6c2.209 0 4-1.791 4-4V9c0-2.209-1.791-4-4-4z'/%3E%3Cpath fill='%23EEE' d='M10 5h16v26H10z'/%3E%3Cpath fill='%23D52B1E' d='M18.615 22.113c1.198.139 2.272.264 3.469.401l-.305-1.002c-.049-.176.021-.368.159-.476l3.479-2.834-.72-.339c-.317-.113-.23-.292-.115-.722l.531-1.936-2.021.427c-.197.03-.328-.095-.358-.215l-.261-.911-1.598 1.794c-.227.288-.687.288-.544-.376l.683-3.634-.917.475c-.257.144-.514.168-.657-.089l-1.265-2.366v.059-.059l-1.265 2.366c-.144.257-.401.233-.658.089l-.916-.475.683 3.634c.144.664-.317.664-.544.376l-1.598-1.793-.26.911c-.03.12-.162.245-.359.215l-2.021-.427.531 1.936c.113.43.201.609-.116.722l-.72.339 3.479 2.834c.138.107.208.3.158.476l-.305 1.002 3.47-.401c.106 0 .176.059.175.181l-.214 3.704h.956l-.213-3.704c.002-.123.071-.182.177-.182z'/%3E%3C/svg%3E");
+  }
+
+  .flag-it {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36'%3E%3Cpath fill='%23CE2B37' d='M36 27c0 2.209-1.791 4-4 4h-8V5h8c2.209 0 4 1.791 4 4v18z'/%3E%3Cpath fill='%23009246' d='M4 5C1.791 5 0 6.791 0 9v18c0 2.209 1.791 4 4 4h8V5H4z'/%3E%3Cpath fill='%23EEE' d='M12 5h12v26H12z'/%3E%3C/svg%3E");
   }
 `;

--- a/european-masterdata/src/main/resources/metered-data-administrators.json
+++ b/european-masterdata/src/main/resources/metered-data-administrators.json
@@ -2006,5 +2006,13 @@
     "websiteUrl": "https://www.etaplus.energy/",
     "officialContact": "info@etaplus.energy",
     "permissionAdministrator": "ETA+"
+  },
+  {
+    "country": "it",
+    "company": "onenet",
+    "companyId": "",
+    "websiteUrl": "https://onenet-project.eu/",
+    "officialContact": "info@onenet-project.eu",
+    "permissionAdministrator": "onenet"
   }
 ]

--- a/european-masterdata/src/main/resources/permission-administrators.json
+++ b/european-masterdata/src/main/resources/permission-administrators.json
@@ -1110,5 +1110,13 @@
     "companyId": "ETA+",
     "jumpOffUrl": "https://www.etaplus.energy/",
     "regionConnector": "de-eta"
+  },
+  {
+    "country": "it",
+    "company": "onenet",
+    "name": "onenet",
+    "companyId": "onenet",
+    "jumpOffUrl": "https://onenet-project.eu/",
+    "regionConnector": "onenet"
   }
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,16 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@22.19.12)(jiti@2.6.1)
 
+  region-connectors/region-connector-onenet:
+    dependencies:
+      lit:
+        specifier: ^2.8.0
+        version: 2.8.0
+    devDependencies:
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@22.19.12)(jiti@2.6.1)
+
   region-connectors/region-connector-simulation:
     dependencies:
       lit:

--- a/region-connectors/region-connector-onenet/.gitignore
+++ b/region-connectors/region-connector-onenet/.gitignore
@@ -1,0 +1,1 @@
+src/main/resources/public

--- a/region-connectors/region-connector-onenet/build.gradle.kts
+++ b/region-connectors/region-connector-onenet/build.gradle.kts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+import energy.eddie.configureJavaCompileWithErrorProne
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+plugins {
+    id("energy.eddie.java-conventions")
+    id("energy.eddie.pnpm-build")
+
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+}
+
+group = "energy.eddie"
+version = "0.0.0"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":api"))
+    implementation(project(":region-connectors:shared"))
+    implementation(project(":data-needs"))
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.boot.starter.webclient)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.jakarta.validation.api)
+
+    runtimeOnly(libs.postgresql)
+    runtimeOnly(libs.hibernate.validator)
+
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.mockito)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.boot.starter.webmvc.test)
+    testImplementation(libs.reactor.test)
+    testImplementation(libs.okhttp3.mockwebserver)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.spring.boot.testcontainers)
+
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.flyway.core)
+    testRuntimeOnly(libs.flyway.postgresql)
+    testRuntimeOnly(libs.postgresql)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+configureJavaCompileWithErrorProne("energy.eddie.regionconnector.onenet")
+
+// disable bootJar task as it needs a main class and region connectors do not have one
+tasks.getByName<BootJar>("bootJar") {
+    enabled = false
+}
+
+tasks.getByName<Jar>("jar") {
+    enabled = true
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    finalizedBy(tasks.jacocoTestCoverageVerification)
+}

--- a/region-connectors/region-connector-onenet/package.json
+++ b/region-connectors/region-connector-onenet/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "eddie-onenet",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "lit": "^2.8.0"
+  },
+  "devDependencies": {
+    "vite": "^7.3.1"
+  }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/OneNetBeanConfig.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/OneNetBeanConfig.java
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet;
+
+import energy.eddie.api.agnostic.data.needs.DataNeedCalculationService;
+import energy.eddie.api.agnostic.process.model.events.PermissionEventRepository;
+import energy.eddie.api.cim.config.CommonInformationModelConfiguration;
+import energy.eddie.dataneeds.services.DataNeedsService;
+import energy.eddie.regionconnector.onenet.data.needs.OneNetDataNeedRuleSet;
+import energy.eddie.regionconnector.onenet.permission.request.OneNetPermissionRequest;
+import energy.eddie.regionconnector.onenet.persistence.OneNetPermissionEventRepository;
+import energy.eddie.regionconnector.onenet.persistence.OneNetPermissionRequestRepository;
+import energy.eddie.regionconnector.shared.event.sourcing.EventBus;
+import energy.eddie.regionconnector.shared.event.sourcing.EventBusImpl;
+import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
+import energy.eddie.regionconnector.shared.event.sourcing.handlers.integration.ConnectionStatusMessageHandler;
+import energy.eddie.regionconnector.shared.event.sourcing.handlers.integration.PermissionMarketDocumentMessageHandler;
+import energy.eddie.regionconnector.shared.services.data.needs.DataNeedCalculationServiceImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.function.Supplier;
+
+@Configuration
+public class OneNetBeanConfig {
+    @Bean
+    public DataNeedCalculationService dataNeedCalculationService(
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") DataNeedsService dataNeedsService,
+            OneNetDataNeedRuleSet dataNeedRuleSet,
+            OneNetRegionConnectorMetadata oneNetRegionConnectorMetadata
+    ) {
+        return new DataNeedCalculationServiceImpl(dataNeedsService, oneNetRegionConnectorMetadata, dataNeedRuleSet);
+    }
+
+    @Bean
+    public EventBus eventBus() {
+        return new EventBusImpl();
+    }
+
+    @Bean
+    public Outbox outbox(EventBus eventBus, OneNetPermissionEventRepository repository) {
+        return new Outbox(eventBus, repository);
+    }
+
+    @Bean
+    public ConnectionStatusMessageHandler<OneNetPermissionRequest> connectionStatusMessageHandler(
+            EventBus eventBus,
+            OneNetPermissionRequestRepository oneNetPermissionRequestRepository
+    ) {
+        return new ConnectionStatusMessageHandler<>(
+                eventBus,
+                oneNetPermissionRequestRepository,
+                pr -> null
+        );
+    }
+
+    @Bean
+    public PermissionMarketDocumentMessageHandler<OneNetPermissionRequest> permissionMarketDocumentMessageHandler(
+            EventBus eventBus,
+            OneNetPermissionRequestRepository oneNetPermissionRequestRepository,
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") DataNeedsService dataNeedsService,
+            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") CommonInformationModelConfiguration cimConfig,
+            OneNetRegionConnectorMetadata oneNetRegionConnectorMetadata
+    ) {
+        return new PermissionMarketDocumentMessageHandler<>(
+                eventBus,
+                oneNetPermissionRequestRepository,
+                dataNeedsService,
+                "REPLACE_ME", // TODO: Replace this with the real eligible party ID
+                cimConfig,
+                pr -> null, // TODO: Replace this with the real transmission schedule provider if one exists
+                oneNetRegionConnectorMetadata.timeZone()
+        );
+    }
+
+    @Bean
+    Supplier<PermissionEventRepository> permissionEventSupplier(OneNetPermissionEventRepository repo) {
+        return () -> repo;
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/OneNetRegionConnector.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/OneNetRegionConnector.java
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet;
+
+import energy.eddie.api.v0.RegionConnector;
+import energy.eddie.api.v0.RegionConnectorMetadata;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OneNetRegionConnector implements RegionConnector {
+    private final OneNetRegionConnectorMetadata oneNetRegionConnectorMetadata;
+
+    public OneNetRegionConnector(OneNetRegionConnectorMetadata oneNetRegionConnectorMetadata) {this.oneNetRegionConnectorMetadata = oneNetRegionConnectorMetadata;}
+
+    @Override
+    public RegionConnectorMetadata getMetadata() {
+        return oneNetRegionConnectorMetadata;
+    }
+
+    @Override
+    public void terminatePermission(String permissionId) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/OneNetRegionConnectorMetadata.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/OneNetRegionConnectorMetadata.java
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet;
+
+import energy.eddie.api.v0.RegionConnectorMetadata;
+import org.springframework.stereotype.Component;
+
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Component
+public class OneNetRegionConnectorMetadata implements RegionConnectorMetadata {
+    public static final String REGION_CONNECTOR_ID = "onenet";
+
+    @Override
+    public String id() {
+        return REGION_CONNECTOR_ID;
+    }
+
+    @Override
+    public List<String> countryCodes() {
+        // TODO: Update to correct countries that are supported by this region connector
+        // If only one country is supported, delete this method and use the countryCode method instead.
+        return List.of("IT");
+    }
+
+    @Override
+    public String countryCode() {
+        return countryCodes().getFirst();
+    }
+
+    @Override
+    public long coveredMeteringPoints() {
+        // TODO: Update to correct number of metering points
+        return 0;
+    }
+
+    @Override
+    public Period earliestStart() {
+        // TODO: Update to correct start date
+        return Period.ofYears(-3);
+    }
+
+    @Override
+    public Period latestEnd() {
+        // TODO: Update to correct end date
+        return Period.ofYears(3);
+    }
+
+    @Override
+    public ZoneId timeZone() {
+        // TODO: Update to correct time zone
+        return ZoneOffset.UTC;
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/OneNetSpringConfiguration.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/OneNetSpringConfiguration.java
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet;
+
+import energy.eddie.api.agnostic.RegionConnector;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import static energy.eddie.regionconnector.onenet.OneNetRegionConnectorMetadata.REGION_CONNECTOR_ID;
+
+@SpringBootApplication
+@RegionConnector(name = REGION_CONNECTOR_ID)
+public class OneNetSpringConfiguration {
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/data/needs/OneNetDataNeedRuleSet.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/data/needs/OneNetDataNeedRuleSet.java
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.data.needs;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.api.agnostic.data.needs.EnergyType;
+import energy.eddie.dataneeds.rules.DataNeedRule;
+import energy.eddie.dataneeds.rules.DataNeedRule.ValidatedHistoricalDataDataNeedRule;
+import energy.eddie.dataneeds.rules.DataNeedRuleSet;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class OneNetDataNeedRuleSet implements DataNeedRuleSet {
+    @Override
+    public List<DataNeedRule> dataNeedRules() {
+        // TODO: Update to match the data provided by onenet
+        return List.of(
+                new ValidatedHistoricalDataDataNeedRule(EnergyType.ELECTRICITY,
+                                                        List.of(Granularity.PT15M, Granularity.PT1H, Granularity.P1D))
+        );
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/dtos/CreatedPermissionRequest.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/dtos/CreatedPermissionRequest.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.dtos;
+
+/**
+ * This should hold all data that is required for the frontend to inform the final customer on how and where to accept or reject this permission request.
+ * TODO: Extend with all the other required attributes to allow the final customer to give consent to share their data. This will probably not be required in this case
+ *
+ * @param permissionId the final permission ID
+ */
+public record CreatedPermissionRequest(String permissionId) {}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/dtos/PermissionRequestForCreation.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/dtos/PermissionRequestForCreation.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.dtos;
+
+/**
+ * This should hold all information necessary to create a permission request and send it to the permission administrator.
+ * TODO: Extend with all the other IDs to identify a consent with the validated historical data received from onenet
+ *
+ * @param connectionId the connection ID
+ * @param dataNeedId   the data need ID
+ */
+public record PermissionRequestForCreation(String connectionId, String dataNeedId) {}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/events/CreatedEvent.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/events/CreatedEvent.java
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.permission.events;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.regionconnector.onenet.permission.request.OneNetDataSourceInformation;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Transient;
+
+import java.time.ZonedDateTime;
+
+@Entity(name = "OneNetCreatedEvent")
+@SuppressWarnings({"NullAway", "unused"})
+public class CreatedEvent extends PersistablePermissionEvent {
+    private final String connectionId;
+    private final String dataNeedId;
+    @Transient
+    private final OneNetDataSourceInformation dataSourceInformation = new OneNetDataSourceInformation();
+
+    public CreatedEvent(String permissionId, String connectionId, String dataNeedId) {
+        super(permissionId, PermissionProcessStatus.CREATED);
+        this.connectionId = connectionId;
+        this.dataNeedId = dataNeedId;
+    }
+
+    public CreatedEvent(
+            String permissionId,
+            String connectionId,
+            String dataNeedId,
+            ZonedDateTime created
+    ) {
+        super(permissionId, PermissionProcessStatus.CREATED, created);
+        this.connectionId = connectionId;
+        this.dataNeedId = dataNeedId;
+    }
+
+    protected CreatedEvent() {
+        connectionId = null;
+        dataNeedId = null;
+    }
+
+    public String connectionId() {
+        return connectionId;
+    }
+
+    public String dataNeedId() {
+        return dataNeedId;
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/events/PersistablePermissionEvent.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/events/PersistablePermissionEvent.java
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.permission.events;
+
+import energy.eddie.api.agnostic.process.model.events.PermissionEvent;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import jakarta.persistence.*;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+@Entity(name = "OneNetPersistablePermissionEvent")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@Table(schema = "onenet", name = "permission_event")
+@SuppressWarnings("NullAway") // Needed for JPA
+public abstract class PersistablePermissionEvent implements PermissionEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @SuppressWarnings("UnusedVariable")
+    private final Long id;
+
+    // Aggregate ID
+    private final String permissionId;
+    private final ZonedDateTime eventCreated;
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "text")
+    private final PermissionProcessStatus status;
+
+    protected PersistablePermissionEvent(String permissionId, PermissionProcessStatus status) {
+        this.id = null;
+        this.permissionId = permissionId;
+        this.eventCreated = ZonedDateTime.now(ZoneOffset.UTC);
+        this.status = status;
+    }
+
+    protected PersistablePermissionEvent(
+            String permissionId,
+            PermissionProcessStatus status,
+            ZonedDateTime created
+    ) {
+        this.id = null;
+        this.permissionId = permissionId;
+        this.eventCreated = created;
+        this.status = status;
+    }
+
+    protected PersistablePermissionEvent() {
+        super();
+        this.id = null;
+        this.permissionId = null;
+        this.eventCreated = null;
+        this.status = null;
+    }
+
+    @Override
+    public String permissionId() {
+        return permissionId;
+    }
+
+    @Override
+    public PermissionProcessStatus status() {
+        return status;
+    }
+
+    @Override
+    public ZonedDateTime eventCreated() {
+        return eventCreated;
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/events/SimpleEvent.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/events/SimpleEvent.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.permission.events;
+
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import jakarta.persistence.Entity;
+
+@Entity(name = "OneNetSimpleEvent")
+public class SimpleEvent extends PersistablePermissionEvent {
+    public SimpleEvent(String permissionId, PermissionProcessStatus status) {
+        super(permissionId, status);
+    }
+
+    protected SimpleEvent() {}
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/events/ValidatedEvent.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/events/ValidatedEvent.java
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.permission.events;
+
+import energy.eddie.api.agnostic.Granularity;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+import java.time.LocalDate;
+
+@Entity(name = "OneNetValidatedEvent")
+@SuppressWarnings({"unused", "NullAway"})
+public class ValidatedEvent extends PersistablePermissionEvent {
+    @Column(name = "granularity", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private final Granularity granularity;
+    @Column(name = "data_start", nullable = false)
+    private final LocalDate dataStart;
+    @Column(name = "data_end", nullable = false)
+    private final LocalDate dataEnd;
+
+    public ValidatedEvent(String permissionId, Granularity granularity, LocalDate dataStart, LocalDate dataEnd) {
+        super(permissionId, PermissionProcessStatus.VALIDATED);
+        this.granularity = granularity;
+        this.dataStart = dataStart;
+        this.dataEnd = dataEnd;
+    }
+
+    protected ValidatedEvent() {
+        super();
+        granularity = null;
+        dataStart = null;
+        dataEnd = null;
+    }
+
+    public Granularity granularity() {
+        return granularity;
+    }
+
+    public LocalDate start() {
+        return dataStart;
+    }
+
+    public LocalDate end() {
+        return dataEnd;
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/request/OneNetDataSourceInformation.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/request/OneNetDataSourceInformation.java
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.permission.request;
+
+import energy.eddie.cim.agnostic.DataSourceInformation;
+
+import static energy.eddie.regionconnector.onenet.OneNetRegionConnectorMetadata.REGION_CONNECTOR_ID;
+
+public class OneNetDataSourceInformation implements DataSourceInformation {
+    @Override
+    public String countryCode() {
+        // TODO: Replace with actual country code
+        return "it";
+    }
+
+    @Override
+    public String regionConnectorId() {
+        return REGION_CONNECTOR_ID;
+    }
+
+    @Override
+    public String meteredDataAdministratorId() {
+        // TODO: Replace with actual metered data administrator ID
+        return "onenet";
+    }
+
+    @Override
+    public String permissionAdministratorId() {
+        // TODO: Replace with actual permission administrator ID
+        return "onenet";
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/request/OneNetPermissionRequest.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/permission/request/OneNetPermissionRequest.java
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.permission.request;
+
+import energy.eddie.api.agnostic.process.model.PermissionRequest;
+import energy.eddie.cim.agnostic.DataSourceInformation;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+
+@Entity
+@Table(name = "permission_request", schema = "onenet")
+public class OneNetPermissionRequest implements PermissionRequest {
+    @Id
+    @Column(name = "permission_id")
+    private final String permissionId;
+    @Column(name = "connection_id")
+    private final String connectionId;
+    @Column(name = "data_need_id")
+    private final String dataNeedId;
+    @Column(name = "status", columnDefinition = "text")
+    @Enumerated(EnumType.STRING)
+    private final PermissionProcessStatus status;
+    @Column(name = "created")
+    private final ZonedDateTime created;
+    @Column(name = "data_start")
+    private final LocalDate dataStart;
+    @Column(name = "data_end")
+    private final LocalDate dataEnd;
+
+    OneNetPermissionRequest(
+            String permissionId,
+            String connectionId,
+            String dataNeedId,
+            PermissionProcessStatus status,
+            ZonedDateTime created,
+            LocalDate dataStart,
+            LocalDate dataEnd
+    ) {
+        this.permissionId = permissionId;
+        this.connectionId = connectionId;
+        this.dataNeedId = dataNeedId;
+        this.status = status;
+        this.created = created;
+        this.dataStart = dataStart;
+        this.dataEnd = dataEnd;
+    }
+
+    @SuppressWarnings("NullAway")
+    protected OneNetPermissionRequest() {
+        permissionId = null;
+        connectionId = null;
+        dataNeedId = null;
+        status = null;
+        created = null;
+        dataStart = null;
+        dataEnd = null;
+    }
+
+    @Override
+    public String permissionId() {
+        return permissionId;
+    }
+
+    @Override
+    public String connectionId() {
+        return connectionId;
+    }
+
+    @Override
+    public String dataNeedId() {
+        return dataNeedId;
+    }
+
+    @Override
+    public PermissionProcessStatus status() {
+        return status;
+    }
+
+    @Override
+    public DataSourceInformation dataSourceInformation() {
+        return new OneNetDataSourceInformation();
+    }
+
+    @Override
+    public ZonedDateTime created() {
+        return created;
+    }
+
+    @Override
+    public LocalDate start() {
+        return dataStart;
+    }
+
+    @Override
+    public LocalDate end() {
+        return dataEnd;
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/persistence/OneNetPermissionEventRepository.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/persistence/OneNetPermissionEventRepository.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.persistence;
+
+import energy.eddie.api.agnostic.process.model.events.PermissionEventRepository;
+import energy.eddie.regionconnector.onenet.permission.events.PersistablePermissionEvent;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OneNetPermissionEventRepository extends PermissionEventRepository, CrudRepository<PersistablePermissionEvent, Long> {
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/persistence/OneNetPermissionRequestRepository.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/persistence/OneNetPermissionRequestRepository.java
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.persistence;
+
+import energy.eddie.api.agnostic.process.model.persistence.PermissionRequestRepository;
+import energy.eddie.regionconnector.onenet.permission.request.OneNetPermissionRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OneNetPermissionRequestRepository
+        extends PermissionRequestRepository<OneNetPermissionRequest>,
+        org.springframework.data.repository.Repository<OneNetPermissionRequest, String> {
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/persistence/PersistenceConfig.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/persistence/PersistenceConfig.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.persistence;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories
+public class PersistenceConfig {
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/service/PermissionCreationService.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/service/PermissionCreationService.java
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.service;
+
+import energy.eddie.api.agnostic.data.needs.DataNeedCalculationService;
+import energy.eddie.api.agnostic.data.needs.DataNeedNotFoundResult;
+import energy.eddie.api.agnostic.data.needs.ValidatedHistoricalDataDataNeedResult;
+import energy.eddie.cim.agnostic.PermissionProcessStatus;
+import energy.eddie.dataneeds.exceptions.DataNeedNotFoundException;
+import energy.eddie.dataneeds.exceptions.UnsupportedDataNeedException;
+import energy.eddie.regionconnector.onenet.dtos.CreatedPermissionRequest;
+import energy.eddie.regionconnector.onenet.dtos.PermissionRequestForCreation;
+import energy.eddie.regionconnector.onenet.permission.events.CreatedEvent;
+import energy.eddie.regionconnector.onenet.permission.events.SimpleEvent;
+import energy.eddie.regionconnector.onenet.permission.events.ValidatedEvent;
+import energy.eddie.regionconnector.shared.event.sourcing.Outbox;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+import static energy.eddie.regionconnector.onenet.OneNetRegionConnectorMetadata.REGION_CONNECTOR_ID;
+
+@Service
+public class PermissionCreationService {
+    private final Outbox outbox;
+    private final DataNeedCalculationService calculationService;
+
+    public PermissionCreationService(Outbox outbox, DataNeedCalculationService calculationService) {
+        this.outbox = outbox;
+        this.calculationService = calculationService;
+    }
+
+    public CreatedPermissionRequest createPermissionRequest(PermissionRequestForCreation creationDto) throws DataNeedNotFoundException, UnsupportedDataNeedException {
+        var permissionId = UUID.randomUUID().toString();
+        var createdEvent = new CreatedEvent(permissionId, creationDto.connectionId(), creationDto.dataNeedId());
+        outbox.commit(createdEvent);
+
+        // TODO: Extend logic required to create a valid connection with onenet
+        switch (calculationService.calculate(createdEvent.dataNeedId(), createdEvent.eventCreated())) {
+            case ValidatedHistoricalDataDataNeedResult res -> {
+                // TODO: Further validation if required
+                outbox.commit(new ValidatedEvent(permissionId,
+                                                 res.granularities().getFirst(),
+                                                 res.energyTimeframe().start(),
+                                                 res.energyTimeframe().end()));
+                // TODO: Refine if needed
+                outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.SENT_TO_PERMISSION_ADMINISTRATOR));
+                outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.ACCEPTED));
+            }
+            case DataNeedNotFoundResult ignored -> {
+                outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.MALFORMED));
+                throw new DataNeedNotFoundException(createdEvent.dataNeedId());
+            }
+            default -> {
+                outbox.commit(new SimpleEvent(permissionId, PermissionProcessStatus.MALFORMED));
+                // TODO: Refine error message
+                throw new UnsupportedDataNeedException(REGION_CONNECTOR_ID,
+                                                       createdEvent.dataNeedId(),
+                                                       "Unsupported data need");
+            }
+        }
+        return new CreatedPermissionRequest(permissionId);
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/web/OneNetWebConfig.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/web/OneNetWebConfig.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+@EnableWebMvc
+public class OneNetWebConfig {
+}

--- a/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/web/PermissionRequestController.java
+++ b/region-connectors/region-connector-onenet/src/main/java/energy/eddie/regionconnector/onenet/web/PermissionRequestController.java
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.onenet.web;
+
+import energy.eddie.dataneeds.exceptions.DataNeedNotFoundException;
+import energy.eddie.dataneeds.exceptions.UnsupportedDataNeedException;
+import energy.eddie.regionconnector.onenet.dtos.CreatedPermissionRequest;
+import energy.eddie.regionconnector.onenet.dtos.PermissionRequestForCreation;
+import energy.eddie.regionconnector.onenet.service.PermissionCreationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import static energy.eddie.regionconnector.shared.web.RestApiPaths.PATH_PERMISSION_REQUEST;
+import static energy.eddie.regionconnector.shared.web.RestApiPaths.connectionStatusMessagesStreamFor;
+
+@Controller
+public class PermissionRequestController {
+
+    private final PermissionCreationService permissionCreationService;
+
+    public PermissionRequestController(PermissionCreationService permissionCreationService) {this.permissionCreationService = permissionCreationService;}
+
+    @PostMapping(PATH_PERMISSION_REQUEST)
+    public ResponseEntity<CreatedPermissionRequest> createPermissionRequest(@RequestBody PermissionRequestForCreation creationDto) throws DataNeedNotFoundException, UnsupportedDataNeedException {
+        var pr = permissionCreationService.createPermissionRequest(creationDto);
+        var location = connectionStatusMessagesStreamFor(pr.permissionId());
+        return ResponseEntity.created(location).body(pr);
+    }
+}

--- a/region-connectors/region-connector-onenet/src/main/resources/db/migration/onenet/V1_0__create_permission_event_table_permission_request_view_and_cds_server.sql
+++ b/region-connectors/region-connector-onenet/src/main/resources/db/migration/onenet/V1_0__create_permission_event_table_permission_request_view_and_cds_server.sql
@@ -1,0 +1,36 @@
+--  SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+--  SPDX-License-Identifier: Apache-2.0
+
+CREATE TABLE onenet.permission_event
+(
+    id            bigserial PRIMARY KEY,
+    dtype         varchar(31) NOT NULL,
+    event_created timestamp(6) WITH TIME ZONE,
+    permission_id varchar(36),
+    status        text,
+    connection_id text,
+    data_need_id  varchar(36),
+    data_start    date,
+    data_end      date,
+    granularity   text
+);
+
+CREATE FUNCTION onenet.coalesce2(anyelement, anyelement) RETURNS anyelement
+    LANGUAGE sql AS
+'SELECT COALESCE($1, $2)';
+
+CREATE AGGREGATE onenet.firstval_agg(anyelement)
+    (SFUNC = onenet.coalesce2, STYPE =anyelement);
+
+CREATE VIEW onenet.permission_request AS
+SELECT DISTINCT ON (permission_id) permission_id,
+                                   onenet.firstval_agg(connection_id) OVER w AS connection_id,
+                                   onenet.firstval_agg(data_need_id) OVER w  AS data_need_id,
+                                   onenet.firstval_agg(status) OVER w        AS status,
+                                   onenet.firstval_agg(data_start) OVER w    AS data_start,
+                                   onenet.firstval_agg(data_end) OVER w      AS data_end,
+                                   onenet.firstval_agg(granularity) OVER w   AS granularity,
+                                   MIN(event_created) OVER w                 AS created
+FROM onenet.permission_event
+WINDOW w AS (PARTITION BY permission_id ORDER BY event_created DESC)
+ORDER BY permission_id, event_created;

--- a/region-connectors/region-connector-onenet/src/main/web/permission-request-form.js
+++ b/region-connectors/region-connector-onenet/src/main/web/permission-request-form.js
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+import { html } from "lit";
+import PermissionRequestFormBase from "../../../../shared/src/main/web/permission-request-form-base.js";
+
+import "https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.15.0/cdn/components/input/input.js";
+import "https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.15.0/cdn/components/button/button.js";
+
+class PermissionRequestForm extends PermissionRequestFormBase {
+  static properties = {
+    connectionId: { attribute: "connection-id" },
+    dataNeedId: { attribute: "data-need-id" },
+    accountingPointId: { attribute: "accounting-point-id" },
+  };
+
+  constructor() {
+    super();
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+
+    // This will be the PermissionRequestForCreation in the region connector
+    const jsonData = {};
+    // TODO: Retrieve data from form fields and put into jsonData
+    jsonData.connectionId = this.connectionId;
+    jsonData.dataNeedId = this.dataNeedId;
+
+    this.createPermissionRequest(jsonData)
+      .then((response) => {
+        // TODO: Do something with the response, or ignore
+      })
+      .catch((error) => {
+        // TODO: Do something with the error if needed
+        this.error(error);
+      });
+  }
+
+  render() {
+    return html`
+      <div>
+        <form id="request-form">
+          <sl-button type="submit" variant="primary"> Create </sl-button>
+        </form>
+        <h1>OneNet Region Connector Element</h1>
+        <h2>TBD</h2>
+        <!-- TODO: Create form to request required data from final customer, such as metering point ID etc-->
+      </div>
+    `;
+  }
+}
+
+export default PermissionRequestForm;

--- a/region-connectors/region-connector-onenet/vite.config.js
+++ b/region-connectors/region-connector-onenet/vite.config.js
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolve } from "path";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    outDir: resolve(
+      __dirname,
+      "src/main/resources/public/region-connectors/onenet"
+    ),
+    assetsDir: "",
+    rollupOptions: {
+      input: resolve(__dirname, "src/main/web/permission-request-form.js"),
+      output: {
+        entryFileNames: "ce.js",
+      },
+      preserveEntrySignatures: "strict",
+    },
+  },
+});

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,3 +50,4 @@ include("examples:new-example-app")
 
 include("data-need-api")
 include("common-types")
+include("region-connectors:region-connector-onenet")


### PR DESCRIPTION
- Creates the database migrations
- Creates the permission request and event classes
- Creates the custom element for the eddie pop-up
- Creates the persistence layer
- Creates the REST endpoint to create permission requests
- Creates the connection status message handler and permission market document handler

<img width="720" height="546" alt="image" src="https://github.com/user-attachments/assets/85b4559f-fa61-435a-b910-d2229dde0655" />
<img width="720" height="517" alt="image" src="https://github.com/user-attachments/assets/426d261a-4e06-4c9b-ad90-aa38736591dd" />


## TODO

- Fix all todos in the code in the region-connector-onenet module
- Implement tests for the onenet region connector
- Update permission administrator name
- Update metering data administrator name