### PR TITLE
 refactor(aiida): Move data tags to dedicated interface for outbound data needs

### DIFF
--- a/aiida/docs/1-running/data-need.md
+++ b/aiida/docs/1-running/data-need.md
@@ -6,23 +6,23 @@ AIIDA supports two types of data needs: inbound and outbound. Outbound data need
 
 ## Fields
 
-| Field                       | Type     | Description                                                                                                                                |
-|-----------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `type`                      | String   | Type of the data need, either `outbound-aiida` or `inbound-aiida`.                                                                         |
-| `id`                        | String   | Unique id that can be used to reference this data need.                                                                                    |
-| `name`                      | String   | Short memorable name of the data need that may be presented to the customer.                                                               |
-| `description`               | String   | Multiline string that describes this data need in a human readable form to be shown in the UI.                                             |
-| `purpose`                   | String   | Multiline string that describes the purpose of this data need.                                                                             |
-| `policyLink`                | URL      | URL to the data policy that applies to this data need.                                                                                     |
-| `enabled`                   | boolean  | Enables or disables a data need.                                                                                                           |
-| `duration`                  | Object   | Describes the timeframe for this data need.                                                                                                |
-| `transmissionSchedule`      | String   | Cron expression that defines how often the data should be sent or received.                                                                |
-| `allowedPermissionCommands` | String[] | Permission commands the EP may send to remotely control transmission. See [Permission Commands](#permission-commands). Default `[]`.       |
-| `acknowledgementRequired`   | boolean  | Whether an acknowledgement is required for the data transmission. See [Acknowledgement](#acknowledgement).                                 |
-| `schemas`                   | String[] | [Schemas](./schemas/schemas.md) that define the structure and format of the data, e.g. standardized schemas such as CIM or custom schemas. |
-| `asset`                     | String   | The asset that the data need is associated with, linking the data to specific physical or logical assets.                                  |
-| `dataTags`                  | String[] | Data tags that further specify the type of data that is expected.                                                                          |
-| `contexts`                  | String[] | Contexts for permission request that AIIDA can use to provide additional functionality, e.g. flexible connection agreements.               |
+| Field                       | Type                | Description                                                                                                                                |
+|-----------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `type`                      | String              | Type of the data need, either `outbound-aiida` or `inbound-aiida`.                                                                         |
+| `id`                        | String              | Unique id that can be used to reference this data need.                                                                                    |
+| `name`                      | String              | Short memorable name of the data need that may be presented to the customer.                                                               |
+| `description`               | String              | Multiline string that describes this data need in a human readable form to be shown in the UI.                                             |
+| `purpose`                   | String              | Multiline string that describes the purpose of this data need.                                                                             |
+| `policyLink`                | URL                 | URL to the data policy that applies to this data need.                                                                                     |
+| `enabled`                   | boolean             | Enables or disables a data need.                                                                                                           |
+| `duration`                  | Object              | Describes the timeframe for this data need.                                                                                                |
+| `transmissionSchedule`      | String              | Cron expression that defines how often the data should be sent or received.                                                                |
+| `allowedPermissionCommands` | String[]            | Permission commands the EP may send to remotely control transmission. See [Permission Commands](#permission-commands). Default `[]`.       |
+| `acknowledgementRequired`   | boolean             | Whether an acknowledgement is required for the data transmission. See [Acknowledgement](#acknowledgement).                                 |
+| `schemas`                   | String[]            | [Schemas](./schemas/schemas.md) that define the structure and format of the data, e.g. standardized schemas such as CIM or custom schemas. |
+| `asset`                     | String              | The asset that the data need is associated with, linking the data to specific physical or logical assets.                                  |
+| `dataTags`                  | String[] (optional) | Data tags further specify the type of data expected. If omitted, it is assumed that all available data is included.                        |
+| `contexts`                  | String[]            | Contexts for permission request that AIIDA can use to provide additional functionality, e.g. flexible connection agreements.               |
 
 ## Outbound
 

--- a/aiida/src/main/java/energy/eddie/aiida/models/permission/dataneed/AiidaLocalDataNeed.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/permission/dataneed/AiidaLocalDataNeed.java
@@ -4,7 +4,9 @@
 package energy.eddie.aiida.models.permission.dataneed;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import energy.eddie.api.agnostic.aiida.*;
+import energy.eddie.api.agnostic.aiida.AiidaAsset;
+import energy.eddie.api.agnostic.aiida.AiidaContext;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
 import energy.eddie.cim.agnostic.PermissionCommand;
 import energy.eddie.dataneeds.needs.aiida.AiidaDataNeed;
 import energy.eddie.dataneeds.needs.aiida.AiidaDataNeedInterface;
@@ -81,13 +83,6 @@ public abstract class AiidaLocalDataNeed implements AiidaDataNeedInterface {
     protected AiidaAsset asset;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "aiida_local_data_need_data_tags", joinColumns = {@JoinColumn(name = "data_need_id", referencedColumnName = "data_need_id")})
-    @Column(name = "data_tag")
-    @Convert(converter = ObisCodeConverter.class)
-    @JsonProperty
-    protected Set<ObisCode> dataTags;
-
-    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "aiida_local_data_need_contexts", joinColumns = @JoinColumn(name = "data_need_id"))
     @Column(name = "context")
     @Enumerated(EnumType.STRING)
@@ -110,7 +105,6 @@ public abstract class AiidaLocalDataNeed implements AiidaDataNeedInterface {
         this.transmissionSchedule = dataNeed.transmissionSchedule();
         this.schemas = dataNeed.schemas();
         this.asset = dataNeed.asset();
-        this.dataTags = Objects.requireNonNullElse(dataNeed.dataTags(), Set.of());
         this.acknowledgementRequired = dataNeed.acknowledgementRequired();
         this.allowedPermissionCommands = Objects.requireNonNullElse(dataNeed.allowedPermissionCommands(), Set.of());
         this.contexts = Objects.requireNonNullElse(dataNeed.contexts(), Set.of());
@@ -118,31 +112,6 @@ public abstract class AiidaLocalDataNeed implements AiidaDataNeedInterface {
 
     public String name() {
         return name;
-    }
-
-    @Override
-    public AiidaAsset asset() {
-        return asset;
-    }
-
-    @Override
-    public UUID dataNeedId() {
-        return dataNeedId;
-    }
-
-    @Override
-    public Set<ObisCode> dataTags() {
-        return dataTags;
-    }
-
-    @Override
-    public Set<AiidaSchema> schemas() {
-        return schemas;
-    }
-
-    @Override
-    public CronExpression transmissionSchedule() {
-        return transmissionSchedule;
     }
 
     @Override
@@ -156,8 +125,28 @@ public abstract class AiidaLocalDataNeed implements AiidaDataNeedInterface {
     }
 
     @Override
+    public AiidaAsset asset() {
+        return asset;
+    }
+
+    @Override
     public Set<AiidaContext> contexts() {
         return contexts;
+    }
+
+    @Override
+    public UUID dataNeedId() {
+        return dataNeedId;
+    }
+
+    @Override
+    public Set<AiidaSchema> schemas() {
+        return schemas;
+    }
+
+    @Override
+    public CronExpression transmissionSchedule() {
+        return transmissionSchedule;
     }
 
     @Override

--- a/aiida/src/main/java/energy/eddie/aiida/models/permission/dataneed/AiidaLocalDataNeedFactory.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/permission/dataneed/AiidaLocalDataNeedFactory.java
@@ -1,17 +1,20 @@
-// SPDX-FileCopyrightText: 2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.aiida.models.permission.dataneed;
 
 import energy.eddie.dataneeds.needs.aiida.AiidaDataNeed;
 import energy.eddie.dataneeds.needs.aiida.InboundAiidaDataNeed;
+import energy.eddie.dataneeds.needs.aiida.OutboundAiidaDataNeed;
 
 public class AiidaLocalDataNeedFactory {
     private AiidaLocalDataNeedFactory() {}
 
     public static AiidaLocalDataNeed create(AiidaDataNeed dataNeed) {
-        return InboundAiidaDataNeed.DISCRIMINATOR_VALUE.equals(dataNeed.type())
-                ? new InboundAiidaLocalDataNeed(dataNeed)
-                : new OutboundAiidaLocalDataNeed(dataNeed);
+        return switch (dataNeed) {
+            case InboundAiidaDataNeed inbound -> new InboundAiidaLocalDataNeed(inbound);
+            case OutboundAiidaDataNeed outbound -> new OutboundAiidaLocalDataNeed(outbound);
+            default -> throw new IllegalArgumentException("Unknown AiidaDataNeed type: " + dataNeed.getClass());
+        };
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/models/permission/dataneed/OutboundAiidaLocalDataNeed.java
+++ b/aiida/src/main/java/energy/eddie/aiida/models/permission/dataneed/OutboundAiidaLocalDataNeed.java
@@ -1,22 +1,40 @@
-// SPDX-FileCopyrightText: 2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.aiida.models.permission.dataneed;
 
-import energy.eddie.dataneeds.needs.aiida.AiidaDataNeed;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import energy.eddie.api.agnostic.aiida.ObisCode;
+import energy.eddie.api.agnostic.aiida.ObisCodeConverter;
 import energy.eddie.dataneeds.needs.aiida.OutboundAiidaDataNeed;
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
+import energy.eddie.dataneeds.needs.aiida.OutboundAiidaDataNeedInterface;
+import jakarta.persistence.*;
+
+import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @DiscriminatorValue(OutboundAiidaDataNeed.DISCRIMINATOR_VALUE)
 @SuppressWarnings("NullAway")
-public class OutboundAiidaLocalDataNeed extends AiidaLocalDataNeed {
+public class OutboundAiidaLocalDataNeed extends AiidaLocalDataNeed implements OutboundAiidaDataNeedInterface {
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "aiida_local_data_need_data_tags", joinColumns = {@JoinColumn(name = "data_need_id", referencedColumnName = "data_need_id")})
+    @Column(name = "data_tag")
+    @Convert(converter = ObisCodeConverter.class)
+    @JsonProperty
+    protected Set<ObisCode> dataTags;
+
     @SuppressWarnings("NullAway.Init")
     protected OutboundAiidaLocalDataNeed() {
     }
 
-    public OutboundAiidaLocalDataNeed(AiidaDataNeed dataNeed) {
+    public OutboundAiidaLocalDataNeed(OutboundAiidaDataNeed dataNeed) {
         super(dataNeed);
+        this.dataTags = Objects.requireNonNullElse(dataNeed.dataTags(), Set.of());
+    }
+
+    @Override
+    public Set<ObisCode> dataTags() {
+        return dataTags;
     }
 }

--- a/aiida/src/main/java/energy/eddie/aiida/streamers/StreamerManager.java
+++ b/aiida/src/main/java/energy/eddie/aiida/streamers/StreamerManager.java
@@ -6,6 +6,7 @@ package energy.eddie.aiida.streamers;
 import energy.eddie.aiida.aggregator.OutboundAggregator;
 import energy.eddie.aiida.models.permission.Permission;
 import energy.eddie.aiida.models.permission.PermissionStatus;
+import energy.eddie.aiida.models.permission.dataneed.OutboundAiidaLocalDataNeed;
 import energy.eddie.aiida.models.record.AiidaRecord;
 import energy.eddie.aiida.models.record.PermissionLatestRecordMap;
 import energy.eddie.aiida.repositories.FailedToSendRepository;
@@ -113,9 +114,14 @@ public class StreamerManager implements AutoCloseable {
 
     /**
      * Applies a new transmission schedule to the streamer of the passed permission by rebuilding its record flux with
-     * the new aggregation cadence.
+     * the new aggregation cadence. No-op for permissions whose data need is not outbound, since only outbound
+     * permissions currently have a record flux to rebuild.
      */
     public void updateSchedule(Permission permission) {
+        if (!(permission.dataNeed() instanceof OutboundAiidaLocalDataNeed)) {
+            return;
+        }
+
         requireStreamer(permission.id())
                 .ifPresent(streamer -> buildFilteredFlux(permission).ifPresent(streamer::updateRecordFlux));
     }
@@ -165,9 +171,9 @@ public class StreamerManager implements AutoCloseable {
     }
 
     /**
-     * Builds the filtered and aggregated record flux for the passed permission. Returns an empty {@link Optional} if a
-     * required field is missing, after logging which one; the caller is responsible for not creating or for closing the
-     * corresponding streamer.
+     * Builds the filtered and aggregated record flux for the passed permission if it was created by an outbound data need.
+     * Returns an empty {@link Optional} if a required field is missing, after logging which one.
+     * The caller is responsible for not creating or for closing the corresponding streamer.
      */
     private Optional<Flux<AiidaRecord>> buildFilteredFlux(Permission permission) {
         try {
@@ -177,7 +183,11 @@ public class StreamerManager implements AutoCloseable {
             var dataSource = Objects.requireNonNull(permission.dataSource(), "data source");
             var schedule = Objects.requireNonNull(permission.effectiveTransmissionSchedule(), "transmission schedule");
 
-            return Optional.of(aggregator.getFilteredFlux(dataNeed.dataTags(),
+            if (!(dataNeed instanceof OutboundAiidaLocalDataNeed outboundDataNeed)) {
+                return Optional.of(Flux.never());
+            }
+
+            return Optional.of(aggregator.getFilteredFlux(outboundDataNeed.dataTags(),
                                                           dataNeed.asset(),
                                                           expirationTime,
                                                           schedule,

--- a/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/PermissionServiceTest.java
@@ -30,7 +30,6 @@ import energy.eddie.api.agnostic.aiida.ObisCode;
 import energy.eddie.api.agnostic.aiida.mqtt.MqttDto;
 import energy.eddie.api.agnostic.process.model.PermissionStateTransitionException;
 import energy.eddie.cim.agnostic.PermissionProcessStatus;
-import energy.eddie.dataneeds.needs.aiida.AiidaDataNeed;
 import energy.eddie.dataneeds.needs.aiida.OutboundAiidaDataNeed;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -99,7 +98,7 @@ class PermissionServiceTest {
     @Mock
     private HandshakeService mockHandshakeService;
     @Mock
-    private AiidaDataNeed mockDataNeed;
+    private OutboundAiidaDataNeed mockDataNeed;
     @Mock
     private InboundAiidaLocalDataNeed mockInboundAiidaLocalDataNeed;
     @Mock
@@ -182,7 +181,12 @@ class PermissionServiceTest {
         // Given
         var expectedStart = ZonedDateTime.of(start, LocalTime.MIN, AIIDA_ZONE_ID).toInstant();
         var expectedEnd = ZonedDateTime.of(end, LocalTime.MAX.withNano(0), AIIDA_ZONE_ID).toInstant();
-        var permissionDetails = new PermissionDetailsDto(permissionId1, connectionId, meterId, start, end, mockDataNeed);
+        var permissionDetails = new PermissionDetailsDto(permissionId1,
+                                                         connectionId,
+                                                         meterId,
+                                                         start,
+                                                         end,
+                                                         mockDataNeed);
         when(mockPermissionRepository.existsById(permissionId1)).thenReturn(false);
         when(mockPermissionRepository.existsById(permissionId2)).thenReturn(false);
         when(mockPermissionRepository.save(any(Permission.class))).then(i -> i.getArgument(0));
@@ -224,8 +228,8 @@ class PermissionServiceTest {
         assertEquals("*/23 * * * * *", dataNeed.transmissionSchedule().toString());
         assertEquals(OutboundAiidaDataNeed.DISCRIMINATOR_VALUE, dataNeed.type());
         assertThat(dataNeed.contexts()).hasSameElementsAs(Set.of(AiidaContext.FLEXIBLE_CONNECTION_AGREEMENT));
-        assertThat(dataNeed.dataTags()).hasSameElementsAs(Set.of(ObisCode.POSITIVE_ACTIVE_ENERGY,
-                                                                 ObisCode.NEGATIVE_ACTIVE_ENERGY));
+        assertThat(((OutboundAiidaLocalDataNeed) dataNeed).dataTags()).hasSameElementsAs(Set.of(ObisCode.POSITIVE_ACTIVE_ENERGY,
+                                                                                                ObisCode.NEGATIVE_ACTIVE_ENERGY));
         assertThat(dataNeed.schemas()).hasSameElementsAs(Set.of(AiidaSchema.SMART_METER_P1_RAW));
     }
 
@@ -234,7 +238,12 @@ class PermissionServiceTest {
         // Given
         var expectedStart = ZonedDateTime.of(start, LocalTime.MIN, AIIDA_ZONE_ID).toInstant();
         var expectedEnd = ZonedDateTime.of(end, LocalTime.MAX.withNano(0), AIIDA_ZONE_ID).toInstant();
-        var permissionDetails = new PermissionDetailsDto(permissionId1, connectionId, meterId, start, end, mockDataNeed);
+        var permissionDetails = new PermissionDetailsDto(permissionId1,
+                                                         connectionId,
+                                                         meterId,
+                                                         start,
+                                                         end,
+                                                         mockDataNeed);
         when(mockPermissionRepository.existsById(permissionId1)).thenReturn(false);
         when(mockPermissionRepository.save(any(Permission.class))).then(i -> i.getArgument(0));
         when(mockHandshakeService.fetchDetailsForPermission(any())).thenReturn(Mono.just(permissionDetails));
@@ -250,7 +259,8 @@ class PermissionServiceTest {
         when(mockDataNeed.schemas()).thenReturn(Set.of(AiidaSchema.SMART_METER_P1_RAW));
 
         // When Then
-        assertThrows(PermissionDataNeedTypeNotSupportedException.class, () -> service.setupNewPermissions(permissionRequests));
+        assertThrows(PermissionDataNeedTypeNotSupportedException.class,
+                     () -> service.setupNewPermissions(permissionRequests));
         verify(mockHandshakeService).fetchDetailsForPermission(argThat(arg -> arg.id().equals(permissionId1)));
         verify(mockPermissionRepository, times(2)).save(permissionCaptor.capture());
 
@@ -270,8 +280,8 @@ class PermissionServiceTest {
         assertEquals(dataNeedId, dataNeed.dataNeedId());
         assertEquals("*/23 * * * * *", dataNeed.transmissionSchedule().toString());
         assertEquals("illegalValue", dataNeed.type());
-        assertThat(dataNeed.dataTags()).hasSameElementsAs(Set.of(ObisCode.POSITIVE_ACTIVE_ENERGY,
-                                                                 ObisCode.NEGATIVE_ACTIVE_ENERGY));
+        assertThat(((OutboundAiidaLocalDataNeed) dataNeed).dataTags()).hasSameElementsAs(Set.of(ObisCode.POSITIVE_ACTIVE_ENERGY,
+                                                                                                ObisCode.NEGATIVE_ACTIVE_ENERGY));
         assertThat(dataNeed.schemas()).hasSameElementsAs(Set.of(AiidaSchema.SMART_METER_P1_RAW));
     }
 
@@ -342,7 +352,12 @@ class PermissionServiceTest {
     @Test
     void givenFcaPermissionWithMeterIdAndActiveDuplicate_setupNewPermissions_marksUnfulfillableAndThrows() throws Exception {
         // Given
-        var permissionDetails = new PermissionDetailsDto(permissionId1, connectionId, meterId, start, end, mockDataNeed);
+        var permissionDetails = new PermissionDetailsDto(permissionId1,
+                                                         connectionId,
+                                                         meterId,
+                                                         start,
+                                                         end,
+                                                         mockDataNeed);
         when(mockPermissionRepository.existsById(permissionId1)).thenReturn(false);
         when(mockPermissionRepository.save(any(Permission.class))).then(i -> i.getArgument(0));
         when(mockHandshakeService.fetchDetailsForPermission(any())).thenReturn(Mono.just(permissionDetails));
@@ -389,7 +404,8 @@ class PermissionServiceTest {
         when(mockPermission.status()).thenReturn(PermissionStatus.FETCHED_DETAILS);
 
         // When, Then
-        assertThrows(DetailFetchingFailedException.class, () -> service.acceptPermission(permissionId1, dataSourceId, null));
+        assertThrows(DetailFetchingFailedException.class,
+                     () -> service.acceptPermission(permissionId1, dataSourceId, null));
     }
 
     @Test
@@ -481,7 +497,8 @@ class PermissionServiceTest {
         when(mockDataSourceService.dataSourceByIdOrThrow(dataSourceId)).thenReturn(mockInboundDataSource);
         when(mockInboundDataSource.userId()).thenReturn(userId);
         when(mockPermission.dataNeed()).thenReturn(mockOutboundAiidaLocalDataNeed);
-        when(mockOutboundAiidaLocalDataNeed.schemas()).thenReturn(Set.of(AiidaSchema.OPAQUE, AiidaSchema.SMART_METER_P1_RAW));
+        when(mockOutboundAiidaLocalDataNeed.schemas()).thenReturn(Set.of(AiidaSchema.OPAQUE,
+                                                                         AiidaSchema.SMART_METER_P1_RAW));
         when(mockInboundDataSource.schemas()).thenReturn(Set.of(AiidaSchema.OPAQUE));
         when(mockHandshakeService.fetchMqttDetails(any())).thenReturn(Mono.just(mockMqttDto));
         when(mockMqttDto.dataTopic()).thenReturn("dataTopic");

--- a/aiida/src/test/java/energy/eddie/aiida/streamers/StreamerManagerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/streamers/StreamerManagerTest.java
@@ -7,7 +7,8 @@ import energy.eddie.aiida.ObjectMapperCreatorUtil;
 import energy.eddie.aiida.aggregator.OutboundAggregator;
 import energy.eddie.aiida.models.datasource.DataSource;
 import energy.eddie.aiida.models.permission.Permission;
-import energy.eddie.aiida.models.permission.dataneed.AiidaLocalDataNeed;
+import energy.eddie.aiida.models.permission.dataneed.InboundAiidaLocalDataNeed;
+import energy.eddie.aiida.models.permission.dataneed.OutboundAiidaLocalDataNeed;
 import energy.eddie.aiida.models.record.PermissionLatestRecordMap;
 import energy.eddie.aiida.repositories.FailedToSendRepository;
 import energy.eddie.aiida.schemas.rtd.SchemaFormatterRegistry;
@@ -61,7 +62,9 @@ class StreamerManagerTest {
     private DataSource mockDataSource;
     private StreamerManager manager;
     @Mock
-    private AiidaLocalDataNeed mockDataNeed;
+    private OutboundAiidaLocalDataNeed mockDataNeed;
+    @Mock
+    private InboundAiidaLocalDataNeed mockInboundDataNeed;
     @Mock
     private AiidaStreamer mockAiidaStreamer;
     @Mock
@@ -166,6 +169,64 @@ class StreamerManagerTest {
             // Then
             verify(mockAiidaStreamer).connect();
         }
+    }
+
+    @Test
+    void givenInboundPermission_createStreamer_neverUsesAggregator() throws MqttException {
+        // Given
+        when(mockPermission.id()).thenReturn(permissionId);
+        when(mockPermission.expirationTime()).thenReturn(expirationTime);
+        when(mockPermission.dataNeed()).thenReturn(mockInboundDataNeed);
+        when(mockPermission.userId()).thenReturn(userId);
+        when(mockPermission.dataSource()).thenReturn(mockDataSource);
+        when(mockPermission.effectiveTransmissionSchedule()).thenReturn(CronExpression.parse("* * * * * *"));
+        try (MockedStatic<StreamerFactory> utilities = Mockito.mockStatic(StreamerFactory.class)) {
+            utilities.when(() -> StreamerFactory.getAiidaStreamer(any(), any(), any()))
+                     .thenReturn(mockAiidaStreamer);
+
+            // When
+            manager.createNewStreamer(mockPermission);
+
+            // Then
+            verify(mockAiidaStreamer).connect();
+            verifyNoInteractions(aggregatorMock);
+        }
+    }
+
+    @Test
+    void givenInboundPermission_updateSchedule_doesNotTouchStreamer() {
+        // Given
+        ReflectionTestUtils.setField(manager, "streamers", mockMap);
+        when(mockPermission.dataNeed()).thenReturn(mockInboundDataNeed);
+
+        // When
+        manager.updateSchedule(mockPermission);
+
+        // Then
+        verifyNoInteractions(mockMap);
+        verifyNoInteractions(aggregatorMock);
+    }
+
+    @Test
+    void givenOutboundPermission_updateSchedule_rebuildsStreamerFlux() {
+        // Given
+        ReflectionTestUtils.setField(manager, "streamers", mockMap);
+        when(aggregatorMock.getFilteredFlux(any(), any(), any(), any(), any(), any())).thenReturn(Flux.empty());
+        when(mockPermission.id()).thenReturn(permissionId);
+        when(mockPermission.dataNeed()).thenReturn(mockDataNeed);
+        when(mockPermission.expirationTime()).thenReturn(expirationTime);
+        when(mockPermission.userId()).thenReturn(userId);
+        when(mockPermission.dataSource()).thenReturn(mockDataSource);
+        when(mockPermission.effectiveTransmissionSchedule()).thenReturn(CronExpression.parse("* * * * * *"));
+        when(mockDataNeed.dataTags()).thenReturn(Set.of(ObisCode.POSITIVE_ACTIVE_ENERGY));
+        when(mockDataNeed.asset()).thenReturn(AiidaAsset.SUBMETER);
+        when(mockMap.get(permissionId)).thenReturn(mockAiidaStreamer);
+
+        // When
+        manager.updateSchedule(mockPermission);
+
+        // Then
+        verify(mockAiidaStreamer).updateRecordFlux(any());
     }
 
     @Test

--- a/data-need-api/src/main/java/energy/eddie/dataneeds/needs/aiida/AiidaDataNeed.java
+++ b/data-need-api/src/main/java/energy/eddie/dataneeds/needs/aiida/AiidaDataNeed.java
@@ -4,7 +4,9 @@
 package energy.eddie.dataneeds.needs.aiida;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import energy.eddie.api.agnostic.aiida.*;
+import energy.eddie.api.agnostic.aiida.AiidaAsset;
+import energy.eddie.api.agnostic.aiida.AiidaContext;
+import energy.eddie.api.agnostic.aiida.AiidaSchema;
 import energy.eddie.cim.agnostic.PermissionCommand;
 import energy.eddie.dataneeds.needs.TimeframedDataNeed;
 import energy.eddie.dataneeds.utils.cron.CronExpressionConverter;
@@ -63,15 +65,6 @@ public abstract class AiidaDataNeed extends TimeframedDataNeed implements AiidaD
     @Enumerated(EnumType.STRING)
     private AiidaAsset asset;
 
-    @Column(name = "data_tag")
-    @ElementCollection
-    @CollectionTable(name = "aiida_data_need_data_tags",
-            joinColumns = @JoinColumn(name = "data_need_id"),
-            schema = "data_needs")
-    @Convert(converter = ObisCodeConverter.class)
-    @JsonProperty
-    private Set<ObisCode> dataTags;
-
     @Schema(description = "Define contexts to be provided to AIIDA ('FLEXIBLE-CONNECTION-AGREEMENT')")
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "aiida_data_need_contexts",
@@ -81,31 +74,6 @@ public abstract class AiidaDataNeed extends TimeframedDataNeed implements AiidaD
     @JsonProperty
     @Enumerated(EnumType.STRING)
     private Set<AiidaContext> contexts;
-
-    @Override
-    public AiidaAsset asset() {
-        return asset;
-    }
-
-    @Override
-    public UUID dataNeedId() {
-        return UUID.fromString(id());
-    }
-
-    @Override
-    public Set<ObisCode> dataTags() {
-        return dataTags;
-    }
-
-    @Override
-    public Set<AiidaSchema> schemas() {
-        return schemas;
-    }
-
-    @Override
-    public CronExpression transmissionSchedule() {
-        return transmissionSchedule;
-    }
 
     @Override
     public boolean acknowledgementRequired() {
@@ -118,8 +86,28 @@ public abstract class AiidaDataNeed extends TimeframedDataNeed implements AiidaD
     }
 
     @Override
+    public AiidaAsset asset() {
+        return asset;
+    }
+
+    @Override
     public Set<AiidaContext> contexts() {
         return contexts;
+    }
+
+    @Override
+    public UUID dataNeedId() {
+        return UUID.fromString(id());
+    }
+
+    @Override
+    public Set<AiidaSchema> schemas() {
+        return schemas;
+    }
+
+    @Override
+    public CronExpression transmissionSchedule() {
+        return transmissionSchedule;
     }
 
     public abstract Set<AiidaSchema> supportedSchemas();

--- a/data-need-api/src/main/java/energy/eddie/dataneeds/needs/aiida/AiidaDataNeedInterface.java
+++ b/data-need-api/src/main/java/energy/eddie/dataneeds/needs/aiida/AiidaDataNeedInterface.java
@@ -6,7 +6,6 @@ package energy.eddie.dataneeds.needs.aiida;
 import energy.eddie.api.agnostic.aiida.AiidaAsset;
 import energy.eddie.api.agnostic.aiida.AiidaContext;
 import energy.eddie.api.agnostic.aiida.AiidaSchema;
-import energy.eddie.api.agnostic.aiida.ObisCode;
 import energy.eddie.cim.agnostic.PermissionCommand;
 import org.springframework.scheduling.support.CronExpression;
 
@@ -15,6 +14,21 @@ import java.util.UUID;
 
 public interface AiidaDataNeedInterface {
     /**
+     * Returns whether the receiving party should acknowledge the reception of the data.
+     * If true, the receiving party is expected to send an acknowledgment envelope back to the sender after receiving the data.
+     * If false, no acknowledgment is expected.
+     */
+    boolean acknowledgementRequired();
+
+    /**
+     * Returns the permission commands the eligible party is explicitly granted to send for this data need.
+     * A command whose action {@link PermissionCommand.Action#requiresExplicitGrant() requires an explicit grant}
+     * (e.g. {@code SET_TRANSMISSION_ENABLED}, {@code UPDATE_TRANSMISSION_SCHEDULE}) is accepted only if its action is contained
+     * in this set; otherwise it is rejected. {@code TERMINATE} is always accepted, regardless of this set.
+     */
+    Set<PermissionCommand.Action> allowedPermissionCommands();
+
+    /**
      * Returns the kind of asset the data is retrieved from
      *
      * @see AiidaAsset
@@ -22,14 +36,15 @@ public interface AiidaDataNeedInterface {
     AiidaAsset asset();
 
     /**
+     * Returns information about the usage context of permissions created from the data need that AIIDA can use to
+     * provide additional functionality specific to that context.
+     */
+    Set<AiidaContext> contexts();
+
+    /**
      * Returns the data need ID
      */
     UUID dataNeedId();
-
-    /**
-     * Returns the set of identifiers for the data that should be shared.
-     */
-    Set<ObisCode> dataTags();
 
     /**
      * Returns the schema for the data
@@ -44,28 +59,7 @@ public interface AiidaDataNeedInterface {
     CronExpression transmissionSchedule();
 
     /**
-     * Returns the permission commands the eligible party is explicitly granted to send for this data need.
-     * A command whose action {@link PermissionCommand.Action#requiresExplicitGrant() requires an explicit grant}
-     * (e.g. {@code SET_TRANSMISSION_ENABLED}, {@code UPDATE_TRANSMISSION_SCHEDULE}) is accepted only if its action is contained
-     * in this set; otherwise it is rejected. {@code TERMINATE} is always accepted, regardless of this set.
-     */
-    Set<PermissionCommand.Action> allowedPermissionCommands();
-
-    /**
-     * Returns whether the receiving party should acknowledge the reception of the data.
-     * If true, the receiving party is expected to send an acknowledgment envelope back to the sender after receiving the data.
-     * If false, no acknowledgment is expected.
-     */
-    boolean acknowledgementRequired();
-
-    /**
      * Returns the type of the Data Need
      */
     String type();
-
-    /**
-     * Returns information about the usage context of permissions created from the data need that AIIDA can use to
-     * provide additional functionality specific to that context.
-     */
-    Set<AiidaContext> contexts();
 }

--- a/data-need-api/src/main/java/energy/eddie/dataneeds/needs/aiida/OutboundAiidaDataNeed.java
+++ b/data-need-api/src/main/java/energy/eddie/dataneeds/needs/aiida/OutboundAiidaDataNeed.java
@@ -3,10 +3,11 @@
 
 package energy.eddie.dataneeds.needs.aiida;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import energy.eddie.api.agnostic.aiida.AiidaSchema;
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import energy.eddie.api.agnostic.aiida.ObisCode;
+import energy.eddie.api.agnostic.aiida.ObisCodeConverter;
+import jakarta.persistence.*;
 
 import java.util.Set;
 
@@ -14,13 +15,22 @@ import java.util.Set;
 @Table(name = "outbound_aiida_data_need", schema = "data_needs")
 @DiscriminatorValue(OutboundAiidaDataNeed.DISCRIMINATOR_VALUE)
 @SuppressWarnings("NullAway")
-public class OutboundAiidaDataNeed extends AiidaDataNeed {
+public class OutboundAiidaDataNeed extends AiidaDataNeed implements OutboundAiidaDataNeedInterface {
     public static final String DISCRIMINATOR_VALUE = "outbound-aiida";
     public static final Set<AiidaSchema> SUPPORTED_SCHEMAS = Set.of(AiidaSchema.SMART_METER_P1_RAW,
-                                                                      AiidaSchema.SMART_METER_P1_CIM_V1_04,
-                                                                      AiidaSchema.SMART_METER_P1_CIM_V1_12,
-                                                                      AiidaSchema.OPAQUE,
-                                                                      AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12);
+                                                                    AiidaSchema.SMART_METER_P1_CIM_V1_04,
+                                                                    AiidaSchema.SMART_METER_P1_CIM_V1_12,
+                                                                    AiidaSchema.OPAQUE,
+                                                                    AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12);
+
+    @Column(name = "data_tag")
+    @ElementCollection
+    @CollectionTable(name = "aiida_data_need_data_tags",
+            joinColumns = @JoinColumn(name = "data_need_id"),
+            schema = "data_needs")
+    @Convert(converter = ObisCodeConverter.class)
+    @JsonProperty
+    private Set<ObisCode> dataTags;
 
     @SuppressWarnings("NullAway.Init")
     public OutboundAiidaDataNeed() {
@@ -30,5 +40,10 @@ public class OutboundAiidaDataNeed extends AiidaDataNeed {
     @Override
     public Set<AiidaSchema> supportedSchemas() {
         return SUPPORTED_SCHEMAS;
+    }
+
+    @Override
+    public Set<ObisCode> dataTags() {
+        return dataTags;
     }
 }

--- a/data-need-api/src/main/java/energy/eddie/dataneeds/needs/aiida/OutboundAiidaDataNeedInterface.java
+++ b/data-need-api/src/main/java/energy/eddie/dataneeds/needs/aiida/OutboundAiidaDataNeedInterface.java
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.dataneeds.needs.aiida;
+
+import energy.eddie.api.agnostic.aiida.ObisCode;
+
+import java.util.Set;
+
+public interface OutboundAiidaDataNeedInterface extends AiidaDataNeedInterface {
+    /**
+     * Returns the set of identifiers for the data that should be shared.
+     */
+    Set<ObisCode> dataTags();
+}


### PR DESCRIPTION
This PR documents that data tags are optional and moves data tags to a dedicated outbound data need interface as it is not used for inbound data needs