### PR TITLE
fix(aiida): handle CIM timestamps with bracketed zone IDs

### DIFF
--- a/aiida/build.gradle.kts
+++ b/aiida/build.gradle.kts
@@ -17,7 +17,7 @@ version = "1.0.0"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(24))
     }
 }
 

--- a/aiida/src/main/java/energy/eddie/aiida/services/record/transform/MinMaxEnvelopeOpenAdr3Transformer.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/record/transform/MinMaxEnvelopeOpenAdr3Transformer.java
@@ -14,7 +14,6 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.math.BigDecimal;
 import java.time.Duration;
-import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -26,6 +25,9 @@ public class MinMaxEnvelopeOpenAdr3Transformer implements InboundPayloadTransfor
     private static final String IMPORT_CAPACITY_LIMIT = "IMPORT_CAPACITY_LIMIT";
     private static final String EXPORT_CAPACITY_LIMIT = "EXPORT_CAPACITY_LIMIT";
     private static final String CAPACITY_LIMIT_UNIT = "W";
+    private static final String PERIOD_TIME_INTERVAL = "marketDocument.period.timeInterval";
+    private static final String PERIOD_TIME_INTERVAL_START = PERIOD_TIME_INTERVAL + ".start";
+    private static final String PERIOD_TIME_INTERVAL_END = PERIOD_TIME_INTERVAL + ".end";
     private static final BigDecimal WATT_PER_KILO_WATT = BigDecimal.valueOf(1000);
     private static final List<EventPayloadDescriptor> PAYLOAD_DESCRIPTORS = List.of(
             new EventPayloadDescriptor(EVENT_PAYLOAD_DESCRIPTOR, IMPORT_CAPACITY_LIMIT, CAPACITY_LIMIT_UNIT),
@@ -84,14 +86,18 @@ public class MinMaxEnvelopeOpenAdr3Transformer implements InboundPayloadTransfor
     }
 
     private Duration duration(RECMMOEMarketDocument marketDocument) {
-        var interval = requireNonNull(marketDocument.getPeriodTimeInterval(), "marketDocument.period.timeInterval");
-        return Duration.between(OffsetDateTime.parse(interval.getStart()), OffsetDateTime.parse(interval.getEnd()));
+        var interval = requireNonNull(marketDocument.getPeriodTimeInterval(), PERIOD_TIME_INTERVAL);
+        return Duration.between(
+                parseCimDateTime(interval.getStart(), PERIOD_TIME_INTERVAL_START),
+                parseCimDateTime(interval.getEnd(), PERIOD_TIME_INTERVAL_END)
+        );
     }
 
     private IntervalPeriod intervalPeriod(RECMMOEMarketDocument marketDocument, SeriesPeriod period) {
-        var interval = requireNonNull(marketDocument.getPeriodTimeInterval(), "marketDocument.period.timeInterval");
-        var start = requireNonBlank(interval.getStart(), "marketDocument.period.timeInterval.start");
-        var normalizedStart = OffsetDateTime.parse(start).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        var interval = requireNonNull(marketDocument.getPeriodTimeInterval(), PERIOD_TIME_INTERVAL);
+        var start = requireNonBlank(interval.getStart(), PERIOD_TIME_INTERVAL_START);
+        var normalizedStart = parseCimDateTime(start, PERIOD_TIME_INTERVAL_START)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         var resolution = requireNonNull(period.getResolution(), "period.resolution");
 
         return new IntervalPeriod(normalizedStart, resolution);
@@ -159,6 +165,10 @@ public class MinMaxEnvelopeOpenAdr3Transformer implements InboundPayloadTransfor
 
     private @Nullable String dateTimeOrNull(@Nullable ZonedDateTime value) {
         return value == null ? null : value.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    private ZonedDateTime parseCimDateTime(String value, String fieldName) {
+        return ZonedDateTime.parse(requireNonBlank(value, fieldName));
     }
 
     private @Nullable String notBlankOrNull(@Nullable String value) {

--- a/aiida/src/test/java/energy/eddie/aiida/services/record/InboundPayloadTransformationServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/record/InboundPayloadTransformationServiceTest.java
@@ -90,6 +90,27 @@ class InboundPayloadTransformationServiceTest {
         assertEquals(mapper.readTree(expected), mapper.readTree(transformed));
     }
 
+    @Test
+    void transform_shouldMapMinMaxEnvelopeWithBracketedZoneIdToOpenAdr3Event() throws IOException, UnsupportedInboundRecordTransformationException {
+        var mapper = ObjectMapperCreatorUtil.mapper();
+        var dataSource = mock(InboundDataSource.class);
+        var payload = readResource("record/transform/min-max-envelope-openadr3-input.json")
+                .replace("2026-06-01T00:00:00Z", "2026-08-13T07:00Z[GMT]")
+                .replace("2026-06-01T00:30:00Z", "2026-08-13T07:30Z[GMT]");
+        var inboundRecord = new InboundRecord(
+                Instant.parse("2024-01-15T10:30:00Z"),
+                dataSource,
+                AiidaSchema.MIN_MAX_ENVELOPE_CIM_V1_12,
+                payload
+        );
+
+        var transformed = inboundPayloadTransformationService.transform(inboundRecord, InboundMessageFormat.OPENADR_3_1);
+        var expected = readResource("record/transform/min-max-envelope-openadr3-expected.json")
+                .replace("2026-06-01T00:00:00Z", "2026-08-13T07:00:00Z");
+
+        assertEquals(mapper.readTree(expected), mapper.readTree(transformed));
+    }
+
     private String readResource(String path) throws IOException {
         return new ClassPathResource(path).getContentAsString(StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
## Summary

- Parse MinMaxEnvelope CIM interval timestamps with `ZonedDateTime` so bracketed zone IDs such as `2026-08-13T07:00Z[GMT]` are accepted.
- Normalize OpenADR 3.1 interval timestamps back to offset-only ISO format.
- Add regression coverage for bracketed-zone CIM timestamps.
- Update the `aiida` Gradle toolchain to Java 24 so it can resolve Java 24 project dependencies.

## Root cause

`MinMaxEnvelopeOpenAdr3Transformer` parsed CIM interval boundaries with `OffsetDateTime.parse(...)`. That parser accepts offset-only timestamps, but rejects timestamps containing bracketed zone IDs.

## Validation

- Attempted `./gradlew :aiida:test --tests energy.eddie.aiida.services.record.InboundPayloadTransformationServiceTest`.
- The previous `aiida` Java 21 vs dependency Java 24 variant-resolution blocker is resolved.
- The run is still blocked in `:api:compileJava` because Error Prone 2.23.0 is incompatible with JDK 24 javac internals (`TypeTag UNKNOWN`).

Fixes https://github.com/eddie-energy/eddie/issues/2579
