### PR TITLE
feat(at-eda): improve Ponton WebSocket health and reconnect handling

### DIFF
--- a/docs/1-running/region-connectors/region-connector-at-eda.md
+++ b/docs/1-running/region-connectors/region-connector-at-eda.md
@@ -33,6 +33,10 @@ depends on the way you deploy the region connector.
 | `region-connector.at.eda.ponton.messenger.folder`                       | Folder that is used to store information that the adapter needs for operating. This folder stores the `id.dat` file that is generated when the region connector first connects to the PontonXP Messenger. This file is used by the messenger to authenticate the adapter, i.e. all subsequent instances of the same adapter (same adapter id) need this file if they want to connect to the messenger.                                                                              |
 | `region-connector.at.eda.ponton.messenger.username`                     | Username that can be used to retrieve a JWT Token from the PontonXP Messengers authentication endpoint. This is needed in order to use some of the authentication protected REST API endpoints. The given user must not be additionally secured by 2FA.                                                                                                                                                                                                                             |
 | `region-connector.at.eda.ponton.messenger.password`                     | Password for the above username. Needed to retrieve a JWT Token from the PontonXP Messengers authentication endpoint. This is needed in order to use some of the authentication protected REST API endpoints.                                                                                                                                                                                                                                                                       |
+| `region-connector.at.eda.ponton.messenger.inbound-connections`          | Expected number of inbound WebSocket connections to the PontonXP Messenger. Must be greater than `0`. Defaults to `1`.                                                                                                                                                                                                                                                                                                                                                              |
+| `region-connector.at.eda.ponton.messenger.outbound-connections`         | Expected number of outbound WebSocket connections to the PontonXP Messenger. Must be greater than `0`. Defaults to `1`.                                                                                                                                                                                                                                                                                                                                                             |
+| `region-connector.at.eda.ponton.messenger.connection-watchdog.interval` | How often the region connector checks the adapter's WebSocket connection state. Must be a positive Spring Boot duration. Defaults to `1m`.                                                                                                                                                                                                                                                                                                                                          |
+| `region-connector.at.eda.ponton.messenger.connection-watchdog.status-timeout` | Maximum time after the adapter starts or reconnects in which the PontonXP Messenger must report its connection status. If no status callback arrives within this period, or the reported inbound or outbound connection count is below the configured expectation, the watchdog reconnects the adapter. Must be a positive Spring Boot duration. Defaults to `2m`.                                                                                                              |
 | `region-connector.at.eda.consumption.records.remove.duplicates.enabled` | Enables the removal of duplicate consumption records that were already received once by EDDIE. If disabled duplicate consumption data for permission requests concerning the same metering point will be emitted to the outbound connector, this is also true if the permission request is already considered fulfilled, since MDA will send updates for the data. If enabled those updates will not be received. To enable set to `true`, disabled otherwise. Disabled by default. |
 | `region-connector.at.eda.ponton.messenger.enabled`                      | Default `true`. If set to true or missing the EDA Region Connector will try to connect to the configured Ponton X/P Messenger instance. If set to `false` it will use a drop-in replacement, which is a simple REST API to manually send Market Messages, should be used for testing and developement only, never in production!                                                                                                                                                    |
 
@@ -53,9 +57,19 @@ region-connector.at.eda.ponton.messenger.api.endpoint=pontonxp.messenger.com/api
 region-connector.at.eda.ponton.messenger.folder=/opt/pontonxp
 region-connector.at.eda.ponton.messenger.username=username
 region-connector.at.eda.ponton.messenger.password=password
+region-connector.at.eda.ponton.messenger.inbound-connections=1
+region-connector.at.eda.ponton.messenger.outbound-connections=1
+region-connector.at.eda.ponton.messenger.connection-watchdog.interval=1m
+region-connector.at.eda.ponton.messenger.connection-watchdog.status-timeout=2m
 region-connector.at.eda.consumption.records.remove.duplicates.enabled=false
 region-connector.at.eda.ponton.messenger.enabled=true
 ```
+
+The duration values use Spring Boot's duration format. For example, `30s`, `1m`, and `2m` mean 30 seconds, one minute,
+and two minutes respectively.
+
+The connection count and watchdog values configure the connection watchdog for the PontonXP Messenger WebSocket
+connection.
 
 ## Running the Region Connector via EDDIE
 

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapter.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapter.java
@@ -24,6 +24,7 @@ import energy.eddie.regionconnector.at.eda.requests.CPRequestResult;
 import energy.eddie.regionconnector.at.eda.services.IdentifiableConsumptionRecordService;
 import energy.eddie.regionconnector.at.eda.services.IdentifiableMasterDataService;
 import energy.eddie.regionconnector.at.eda.tasks.IdentifyECMPListTask;
+import jakarta.annotation.Nullable;
 import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 
 import static de.ponton.xp.adapter.api.domainvalues.OutboundStatusEnum.*;
 
@@ -57,6 +59,8 @@ public class PontonXPAdapter implements EdaAdapter {
     private final IdentifiableMasterDataService identifiableMasterDataService;
     private final IdentifyECMPListTask identifyECMPListTask;
     private final TaskScheduler scheduler;
+    @Nullable
+    private ScheduledFuture<?> connectionWatchdogTask;
     /**
      * Set of conversationIds for CPRequests that have been sent to Ponton. Used to distinguish between CPRequests and CMRequests in the OutboundMessageStatusUpdateHandler.
      */
@@ -90,6 +94,10 @@ public class PontonXPAdapter implements EdaAdapter {
         masterDataSink.tryEmitComplete();
         cmRevokeSink.tryEmitComplete();
         cpRequestResultSink.tryEmitComplete();
+        if (connectionWatchdogTask != null) {
+            connectionWatchdogTask.cancel(false);
+            connectionWatchdogTask = null;
+        }
         pontonMessengerConnection.close();
     }
 
@@ -168,6 +176,7 @@ public class PontonXPAdapter implements EdaAdapter {
     public void start() throws TransmissionException {
         try {
             pontonMessengerConnection.start();
+            scheduleConnectionWatchdog();
             LOGGER.info("Ponton XP adapter started.");
         } catch (de.ponton.xp.adapter.api.TransmissionException e) {
             throw new TransmissionException(e);
@@ -382,5 +391,23 @@ public class PontonXPAdapter implements EdaAdapter {
                 () -> pontonMessengerConnection.resendFailedMessage(date, messageId),
                 Instant.now().plusSeconds(30)
         );
+    }
+
+    private void scheduleConnectionWatchdog() {
+        if (connectionWatchdogTask != null && !connectionWatchdogTask.isCancelled() && !connectionWatchdogTask.isDone()) {
+            return;
+        }
+        connectionWatchdogTask = scheduler.scheduleAtFixedRate(
+                this::reconnectIfConnectionStale,
+                pontonMessengerConnection.connectionWatchdogInterval()
+        );
+    }
+
+    private void reconnectIfConnectionStale() {
+        try {
+            pontonMessengerConnection.reconnectIfConnectionStale();
+        } catch (Exception e) {
+            LOGGER.error("Error while checking or restarting Ponton XP adapter WebSocket connection", e);
+        }
     }
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterConfiguration.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterConfiguration.java
@@ -3,9 +3,13 @@
 
 package energy.eddie.regionconnector.at.eda.ponton;
 
+import jakarta.validation.constraints.Positive;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.boot.context.properties.bind.Name;
+import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
 
@@ -24,10 +28,10 @@ import java.time.Duration;
  * @param password       Password for the given username.
  * @param inboundConnections Expected amount of inbound WebSocket connections to the Ponton XP Messenger.
  * @param outboundConnections Expected amount of outbound WebSocket connections to the Ponton XP Messenger.
- * @param archiveConnections Expected amount of archive WebSocket connections to the Ponton XP Messenger.
  * @param connectionWatchdogInterval How often the Ponton XP Messenger adapter WebSocket connection is checked.
  * @param connectionStatusTimeout Maximum time after start or reconnect until a connection-status callback must be received.
  */
+@Validated
 @ConfigurationProperties("region-connector.at.eda.ponton.messenger")
 public record PontonXPAdapterConfiguration(
         @Name("adapter.id") String adapterId,
@@ -38,55 +42,16 @@ public record PontonXPAdapterConfiguration(
         @Name("folder") String workFolder,
         @Name("username") String username,
         @Name("password") String password,
-        @Name("inbound-connections") int inboundConnections,
-        @Name("outbound-connections") int outboundConnections,
-        @Name("archive-connections") int archiveConnections,
-        @Name("connection-watchdog.interval") Duration connectionWatchdogInterval,
-        @Name("connection-watchdog.status-timeout") Duration connectionStatusTimeout
+        @Name("inbound-connections") @Positive @DefaultValue("1") int inboundConnections,
+        @Name("outbound-connections") @Positive @DefaultValue("1") int outboundConnections,
+        @Name("connection-watchdog.interval")
+        @DurationMin(nanos = 1)
+        @DefaultValue("1m") Duration connectionWatchdogInterval,
+        @Name("connection-watchdog.status-timeout")
+        @DurationMin(nanos = 1)
+        @DefaultValue("2m") Duration connectionStatusTimeout
 ) {
-    private static final int DEFAULT_INBOUND_CONNECTIONS = 1;
-    private static final int DEFAULT_OUTBOUND_CONNECTIONS = 1;
-    private static final int DEFAULT_ARCHIVE_CONNECTIONS = 0;
-    private static final Duration DEFAULT_CONNECTION_WATCHDOG_INTERVAL = Duration.ofMinutes(1);
-    private static final Duration DEFAULT_CONNECTION_STATUS_TIMEOUT = Duration.ofMinutes(2);
-
     @ConstructorBinding
     public PontonXPAdapterConfiguration {
-        inboundConnections = inboundConnections <= 0 ? DEFAULT_INBOUND_CONNECTIONS : inboundConnections;
-        outboundConnections = outboundConnections <= 0 ? DEFAULT_OUTBOUND_CONNECTIONS : outboundConnections;
-        archiveConnections = Math.max(archiveConnections, DEFAULT_ARCHIVE_CONNECTIONS);
-        connectionWatchdogInterval = connectionWatchdogInterval == null
-                ? DEFAULT_CONNECTION_WATCHDOG_INTERVAL
-                : connectionWatchdogInterval;
-        connectionStatusTimeout = connectionStatusTimeout == null
-                ? DEFAULT_CONNECTION_STATUS_TIMEOUT
-                : connectionStatusTimeout;
-    }
-
-    public PontonXPAdapterConfiguration(
-            String adapterId,
-            String adapterVersion,
-            String hostname,
-            int port,
-            String apiEndpoint,
-            String workFolder,
-            String username,
-            String password
-    ) {
-        this(
-                adapterId,
-                adapterVersion,
-                hostname,
-                port,
-                apiEndpoint,
-                workFolder,
-                username,
-                password,
-                DEFAULT_INBOUND_CONNECTIONS,
-                DEFAULT_OUTBOUND_CONNECTIONS,
-                DEFAULT_ARCHIVE_CONNECTIONS,
-                DEFAULT_CONNECTION_WATCHDOG_INTERVAL,
-                DEFAULT_CONNECTION_STATUS_TIMEOUT
-        );
     }
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterConfiguration.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterConfiguration.java
@@ -4,7 +4,10 @@
 package energy.eddie.regionconnector.at.eda.ponton;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.Name;
+
+import java.time.Duration;
 
 /**
  * This record defines all information needed for a PontonXPAdapter to establish a connection to a Ponton XP Messenger.
@@ -19,6 +22,11 @@ import org.springframework.boot.context.properties.bind.Name;
  * @param username       Username for the Ponton XP Messenger to use REST API endpoints that require authentication.
  *                       Needs to be a user without 2FA activated.
  * @param password       Password for the given username.
+ * @param inboundConnections Expected amount of inbound WebSocket connections to the Ponton XP Messenger.
+ * @param outboundConnections Expected amount of outbound WebSocket connections to the Ponton XP Messenger.
+ * @param archiveConnections Expected amount of archive WebSocket connections to the Ponton XP Messenger.
+ * @param connectionWatchdogInterval How often the Ponton XP Messenger adapter WebSocket connection is checked.
+ * @param connectionStatusTimeout Maximum time after start or reconnect until a connection-status callback must be received.
  */
 @ConfigurationProperties("region-connector.at.eda.ponton.messenger")
 public record PontonXPAdapterConfiguration(
@@ -29,5 +37,56 @@ public record PontonXPAdapterConfiguration(
         @Name("api.endpoint") String apiEndpoint,
         @Name("folder") String workFolder,
         @Name("username") String username,
-        @Name("password") String password
-) {}
+        @Name("password") String password,
+        @Name("inbound-connections") int inboundConnections,
+        @Name("outbound-connections") int outboundConnections,
+        @Name("archive-connections") int archiveConnections,
+        @Name("connection-watchdog.interval") Duration connectionWatchdogInterval,
+        @Name("connection-watchdog.status-timeout") Duration connectionStatusTimeout
+) {
+    private static final int DEFAULT_INBOUND_CONNECTIONS = 1;
+    private static final int DEFAULT_OUTBOUND_CONNECTIONS = 1;
+    private static final int DEFAULT_ARCHIVE_CONNECTIONS = 0;
+    private static final Duration DEFAULT_CONNECTION_WATCHDOG_INTERVAL = Duration.ofMinutes(1);
+    private static final Duration DEFAULT_CONNECTION_STATUS_TIMEOUT = Duration.ofMinutes(2);
+
+    @ConstructorBinding
+    public PontonXPAdapterConfiguration {
+        inboundConnections = inboundConnections <= 0 ? DEFAULT_INBOUND_CONNECTIONS : inboundConnections;
+        outboundConnections = outboundConnections <= 0 ? DEFAULT_OUTBOUND_CONNECTIONS : outboundConnections;
+        archiveConnections = Math.max(archiveConnections, DEFAULT_ARCHIVE_CONNECTIONS);
+        connectionWatchdogInterval = connectionWatchdogInterval == null
+                ? DEFAULT_CONNECTION_WATCHDOG_INTERVAL
+                : connectionWatchdogInterval;
+        connectionStatusTimeout = connectionStatusTimeout == null
+                ? DEFAULT_CONNECTION_STATUS_TIMEOUT
+                : connectionStatusTimeout;
+    }
+
+    public PontonXPAdapterConfiguration(
+            String adapterId,
+            String adapterVersion,
+            String hostname,
+            int port,
+            String apiEndpoint,
+            String workFolder,
+            String username,
+            String password
+    ) {
+        this(
+                adapterId,
+                adapterVersion,
+                hostname,
+                port,
+                apiEndpoint,
+                workFolder,
+                username,
+                password,
+                DEFAULT_INBOUND_CONNECTIONS,
+                DEFAULT_OUTBOUND_CONNECTIONS,
+                DEFAULT_ARCHIVE_CONNECTIONS,
+                DEFAULT_CONNECTION_WATCHDOG_INTERVAL,
+                DEFAULT_CONNECTION_STATUS_TIMEOUT
+        );
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterConfiguration.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterConfiguration.java
@@ -6,7 +6,6 @@ package energy.eddie.regionconnector.at.eda.ponton;
 import jakarta.validation.constraints.Positive;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.bind.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.boot.context.properties.bind.Name;
 import org.springframework.validation.annotation.Validated;
@@ -51,7 +50,4 @@ public record PontonXPAdapterConfiguration(
         @DurationMin(nanos = 1)
         @DefaultValue("2m") Duration connectionStatusTimeout
 ) {
-    @ConstructorBinding
-    public PontonXPAdapterConfiguration {
-    }
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnection.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnection.java
@@ -10,6 +10,8 @@ import energy.eddie.regionconnector.at.eda.requests.CCMORequest;
 import energy.eddie.regionconnector.at.eda.requests.CCMORevoke;
 import energy.eddie.regionconnector.at.eda.requests.CPRequestCR;
 
+import java.time.Duration;
+
 public interface PontonMessengerConnection extends MessengerHealth, MessengerMonitor {
     static PontonMessengerConnectionBuilder newBuilder() {
         return new PontonMessengerConnectionBuilder();
@@ -18,6 +20,10 @@ public interface PontonMessengerConnection extends MessengerHealth, MessengerMon
     void close();
 
     void start() throws TransmissionException;
+
+    void reconnectIfConnectionStale() throws TransmissionException, ConnectionException;
+
+    Duration connectionWatchdogInterval();
 
     void sendCMRevoke(CCMORevoke ccmoRevoke) throws TransmissionException, ConnectionException;
 

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionBuilder.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionBuilder.java
@@ -11,6 +11,7 @@ import jakarta.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Clock;
 
 import static java.util.Objects.requireNonNull;
 
@@ -75,7 +76,10 @@ public class PontonMessengerConnectionBuilder {
                 inboundMessageFactoryCollection,
                 outboundMessageFactoryCollection,
                 healthApi,
-                messengerMonitor
+                messengerMonitor,
+                // Keep UTC as the production time source while allowing the implementation to receive a deterministic
+                // Clock in tests. Hard-coding this clock inside the implementation would prevent timeout testing.
+                Clock.systemUTC()
         );
     }
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImpl.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImpl.java
@@ -32,7 +32,10 @@ import org.springframework.oxm.XmlMappingException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMessengerConnection {
@@ -40,10 +43,13 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     private final InboundMessageFactoryCollection inboundMessageFactoryCollection;
     private final OutboundMessageFactoryCollection outboundMessageFactoryCollection;
     private final MessengerConnection.MessengerConnectionBuilder messengerConnectionBuilder;
+    private final PontonXPAdapterConfiguration config;
     private final MessengerHealth healthApi;
     private final MessengerMonitor messengerMonitor;
     private final ReentrantLock lock = new ReentrantLock();
     private final PontonRetryableStrategy retryStrategy;
+    private final PontonWebSocketConnectionState webSocketConnectionState = new PontonWebSocketConnectionState();
+    private boolean closed;
     @Nullable
     private OutboundMessageStatusUpdateHandler outboundMessageStatusUpdateHandler;
     @Nullable
@@ -68,6 +74,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
             MessengerHealth healthApi,
             MessengerMonitor messengerMonitor
     ) throws ConnectionException {
+        this.config = config;
         this.inboundMessageFactoryCollection = inboundMessageFactoryCollection;
         this.outboundMessageFactoryCollection = outboundMessageFactoryCollection;
         this.healthApi = healthApi;
@@ -80,12 +87,28 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
 
     @Override
     public void close() {
-        messengerConnection.close();
+        lock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            messengerConnection.close();
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
     public void start() throws TransmissionException {
-        messengerConnection.startReception();
+        lock.lock();
+        try {
+            ensureOpen();
+            webSocketConnectionState.markReceptionStarted(Instant.now());
+            messengerConnection.startReception();
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
@@ -148,30 +171,81 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     public void sendMessage(
             OutboundMessage outboundMessage
     ) throws de.ponton.xp.adapter.api.TransmissionException, ConnectionException {
+        lock.lock();
         try {
+            ensureOpen();
             messengerConnection.sendMessage(outboundMessage);
+        } catch (IllegalStateException closedException) {
+            throw new ConnectionException("Ponton XP adapter WebSocket connection is closed.", closedException);
         } catch (Exception sendException) {
             LOGGER.error("Error while sending message to Ponton XP Messenger", sendException);
-            // check if the exception is retryable and no other thread is already trying to restart the connection
-            if (!(retryStrategy.isRetryable(sendException) && lock.tryLock())) {
+            if (!retryStrategy.isRetryable(sendException)) {
                 throw new ConnectionException("Error while sending message to Ponton XP Messenger", sendException);
             }
-            LOGGER.info("Restarting Ponton XP adapter messengerConnection.");
-            try {
-                messengerConnection.close();
-                messengerConnection = messengerConnectionBuilder.build();
-                messengerConnection.startReception();
-                LOGGER.info("Ponton XP adapter messengerConnection restarted.");
-                messengerConnection.sendMessage(outboundMessage);
-            } finally {
-                lock.unlock();
-            }
+            reconnect("send failed with retryable exception: " + sendException.getMessage());
+            messengerConnection.sendMessage(outboundMessage);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public MessengerStatus messengerStatus() {
-        return healthApi.messengerStatus();
+        var messengerStatus = healthApi.messengerStatus();
+        var healthChecks = new HashMap<>(messengerStatus.healthChecks());
+        var adapterConnectionHealthCheck = webSocketConnectionState.healthCheck(
+                config.outboundConnections(),
+                config.inboundConnections(),
+                config.archiveConnections(),
+                config.connectionStatusTimeout(),
+                Instant.now()
+        );
+        healthChecks.put(adapterConnectionHealthCheck.name(), adapterConnectionHealthCheck);
+        return new MessengerStatus(healthChecks, messengerStatus.ok() && adapterConnectionHealthCheck.ok());
+    }
+
+    @Override
+    public void reconnectIfConnectionStale() throws TransmissionException, ConnectionException {
+        if (!webSocketConnectionState.needsReconnect(
+                config.outboundConnections(),
+                config.inboundConnections(),
+                config.archiveConnections(),
+                config.connectionStatusTimeout(),
+                Instant.now()
+        )) {
+            return;
+        }
+        if (!lock.tryLock()) {
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn(
+                        "Skipping Ponton XP adapter WebSocket reconnect because another reconnect is already running. State: {}",
+                        webSocketConnectionState.describe()
+                );
+            }
+            return;
+        }
+        try {
+            if (closed) {
+                return;
+            }
+            if (!webSocketConnectionState.needsReconnect(
+                    config.outboundConnections(),
+                    config.inboundConnections(),
+                    config.archiveConnections(),
+                    config.connectionStatusTimeout(),
+                    Instant.now()
+            )) {
+                return;
+            }
+            reconnect("stale or insufficient WebSocket connection state: " + webSocketConnectionState.describe());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Duration connectionWatchdogInterval() {
+        return config.connectionWatchdogInterval();
     }
 
     @Override
@@ -196,15 +270,62 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
                 .newBuilder()
                 .setWorkFolder(workFolder)
                 .setAdapterInfo(adapterInfo)
-                .addMessengerInstance(MessengerInstance.create(config.hostname(), config.port()))
-                .onAdapterStatusRequest(() -> config.adapterId() + " " + config.adapterVersion() + " is running on.")
+                .addMessengerInstance(MessengerInstance.create(
+                        config.hostname(),
+                        config.port(),
+                        config.inboundConnections(),
+                        config.outboundConnections(),
+                        config.archiveConnections()
+                ))
+                .onAdapterStatusRequest(this::handleAdapterStatusRequest)
                 .onMessageStatusUpdate(outboundMessageStatusUpdate -> {
                     if (outboundMessageStatusUpdateHandler != null) {
                         outboundMessageStatusUpdateHandler.onOutboundMessageStatusUpdate(outboundMessageStatusUpdate);
                     }
                 })
-                .onAdapterStatusRequest(() -> config.adapterId() + " " + config.adapterVersion() + " is running on.")
+                .onConnectionStatusChanged(this::handleConnectionStatusChanged)
                 .onMessageReceive(this::inboundMessageHandler);
+    }
+
+    private String handleAdapterStatusRequest() {
+        webSocketConnectionState.markAdapterStatusRequested(Instant.now());
+        return config.adapterId() + " " + config.adapterVersion() + " is running. " + webSocketConnectionState.describe();
+    }
+
+    private void handleConnectionStatusChanged(
+            MessengerInstance messengerInstance,
+            int outboundConnectionCount,
+            int inboundConnectionCount,
+            int archiveConnectionCount
+    ) {
+        webSocketConnectionState.updateConnectionCounts(
+                outboundConnectionCount,
+                inboundConnectionCount,
+                archiveConnectionCount,
+                Instant.now()
+        );
+        if (outboundConnectionCount < config.outboundConnections() ||
+            inboundConnectionCount < config.inboundConnections() ||
+            archiveConnectionCount < config.archiveConnections()) {
+            LOGGER.warn(
+                    "Ponton XP adapter WebSocket connection count below expected for '{}': outbound {}/{}, inbound {}/{}, archive {}/{}",
+                    messengerInstance,
+                    outboundConnectionCount,
+                    config.outboundConnections(),
+                    inboundConnectionCount,
+                    config.inboundConnections(),
+                    archiveConnectionCount,
+                    config.archiveConnections()
+            );
+        } else {
+            LOGGER.info(
+                    "Ponton XP adapter WebSocket connection count changed for '{}': outbound {}, inbound {}, archive {}",
+                    messengerInstance,
+                    outboundConnectionCount,
+                    inboundConnectionCount,
+                    archiveConnectionCount
+            );
+        }
     }
 
     private InboundMessageStatusUpdate inboundMessageHandler(InboundMessage inboundMessage) {
@@ -368,5 +489,24 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
                 .activeCMRevokeFactory()
                 .parseInputStream(inputStream);
         return cmRevokeHandler.handle(cmRevoke);
+    }
+
+    private void reconnect(String reason) throws ConnectionException, TransmissionException {
+        if (closed) {
+            LOGGER.info("Skipping Ponton XP adapter WebSocket reconnect because connection is closed.");
+            return;
+        }
+        LOGGER.warn("Restarting Ponton XP adapter WebSocket connection because {}.", reason);
+        messengerConnection.close();
+        messengerConnection = messengerConnectionBuilder.build();
+        webSocketConnectionState.markRestarted(Instant.now());
+        messengerConnection.startReception();
+        LOGGER.info("Ponton XP adapter WebSocket connection restarted.");
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("Ponton XP adapter WebSocket connection is closed.");
+        }
     }
 }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImpl.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImpl.java
@@ -45,14 +45,11 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     private final OutboundMessageFactoryCollection outboundMessageFactoryCollection;
     private final MessengerConnection.MessengerConnectionBuilder messengerConnectionBuilder;
     private final PontonXPAdapterConfiguration config;
-    // The clock is injected instead of calling Instant.now(Clock.systemUTC()) directly. Production still supplies the
-    // suggested UTC clock, while tests can supply a fixed clock to verify timeout behavior without relying on wall time.
-    private final Clock clock;
     private final MessengerHealth healthApi;
     private final MessengerMonitor messengerMonitor;
     private final ReentrantLock lock = new ReentrantLock();
     private final PontonRetryableStrategy retryStrategy;
-    private final PontonWebSocketConnectionState webSocketConnectionState = new PontonWebSocketConnectionState();
+    private final PontonWebSocketConnectionState webSocketConnectionState;
     private volatile boolean closed;
     @Nullable
     private OutboundMessageStatusUpdateHandler outboundMessageStatusUpdateHandler;
@@ -80,7 +77,9 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
             Clock clock
     ) throws ConnectionException {
         this.config = config;
-        this.clock = clock;
+        // The state owns the injected clock instead of calling Instant.now() directly. Production supplies the suggested
+        // UTC clock, while tests can supply a fixed clock to verify timeout behavior without relying on wall time.
+        this.webSocketConnectionState = new PontonWebSocketConnectionState(config, clock);
         this.inboundMessageFactoryCollection = inboundMessageFactoryCollection;
         this.outboundMessageFactoryCollection = outboundMessageFactoryCollection;
         this.healthApi = healthApi;
@@ -110,7 +109,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
         lock.lock();
         try {
             ensureOpen();
-            webSocketConnectionState.markReceptionStarted(clock.instant());
+            webSocketConnectionState.markReceptionStarted();
             messengerConnection.startReception();
         } finally {
             lock.unlock();
@@ -199,7 +198,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     public MessengerStatus messengerStatus() {
         var messengerStatus = healthApi.messengerStatus();
         var healthChecks = new HashMap<>(messengerStatus.healthChecks());
-        var adapterConnectionHealthCheck = webSocketConnectionState.healthCheck(config, clock.instant());
+        var adapterConnectionHealthCheck = webSocketConnectionState.healthCheck();
         healthChecks.put(adapterConnectionHealthCheck.name(), adapterConnectionHealthCheck);
         return new MessengerStatus(healthChecks, messengerStatus.ok() && adapterConnectionHealthCheck.ok());
     }
@@ -207,28 +206,29 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     @Override
     public void reconnectIfConnectionStale() throws TransmissionException, ConnectionException {
         // Keep the common healthy/closed path lock-free so the watchdog never waits behind sends or shutdown.
-        if (closed || !webSocketConnectionState.needsReconnect(config, clock.instant())) {
+        if (shouldSkipReconnect()) {
             return;
         }
         if (!lock.tryLock()) {
             LOGGER.atWarn()
                   .addArgument(webSocketConnectionState::describe)
-                  .log("Skipping Ponton XP adapter WebSocket reconnect because another reconnect is already running. State: {}");
+                  .log("Skipping Ponton XP adapter WebSocket reconnect because another connection operation is running. State: {}");
             return;
         }
         try {
-            if (closed) {
-                return;
-            }
             // Connection-status callbacks can update the state while this thread waits for the lock. Rechecking after
             // acquiring it prevents reconnecting a connection that recovered after the initial lock-free fast-path check.
-            if (!webSocketConnectionState.needsReconnect(config, clock.instant())) {
+            if (shouldSkipReconnect()) {
                 return;
             }
             reconnect("stale or insufficient WebSocket connection state: " + webSocketConnectionState.describe());
         } finally {
             lock.unlock();
         }
+    }
+
+    private boolean shouldSkipReconnect() {
+        return closed || !webSocketConnectionState.needsReconnect();
     }
 
     @Override
@@ -276,7 +276,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     }
 
     private String handleAdapterStatusRequest() {
-        webSocketConnectionState.markAdapterStatusRequested(clock.instant());
+        webSocketConnectionState.markAdapterStatusRequested();
         return config.adapterId() + " " + config.adapterVersion() + " is running. " + webSocketConnectionState.describe();
     }
 
@@ -288,8 +288,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     ) {
         webSocketConnectionState.updateConnectionCounts(
                 outboundConnectionCount,
-                inboundConnectionCount,
-                clock.instant()
+                inboundConnectionCount
         );
         if (outboundConnectionCount < config.outboundConnections() ||
             inboundConnectionCount < config.inboundConnections()) {
@@ -484,7 +483,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
         LOGGER.warn("Restarting Ponton XP adapter WebSocket connection because {}.", reason);
         messengerConnection.close();
         messengerConnection = messengerConnectionBuilder.build();
-        webSocketConnectionState.markRestarted(clock.instant());
+        webSocketConnectionState.markRestarted();
         messengerConnection.startReception();
         LOGGER.info("Ponton XP adapter WebSocket connection restarted.");
     }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImpl.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImpl.java
@@ -32,24 +32,28 @@ import org.springframework.oxm.XmlMappingException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMessengerConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(PontonMessengerConnectionImpl.class);
+    private static final int ARCHIVE_CONNECTIONS = 0;
     private final InboundMessageFactoryCollection inboundMessageFactoryCollection;
     private final OutboundMessageFactoryCollection outboundMessageFactoryCollection;
     private final MessengerConnection.MessengerConnectionBuilder messengerConnectionBuilder;
     private final PontonXPAdapterConfiguration config;
+    // The clock is injected instead of calling Instant.now(Clock.systemUTC()) directly. Production still supplies the
+    // suggested UTC clock, while tests can supply a fixed clock to verify timeout behavior without relying on wall time.
+    private final Clock clock;
     private final MessengerHealth healthApi;
     private final MessengerMonitor messengerMonitor;
     private final ReentrantLock lock = new ReentrantLock();
     private final PontonRetryableStrategy retryStrategy;
     private final PontonWebSocketConnectionState webSocketConnectionState = new PontonWebSocketConnectionState();
-    private boolean closed;
+    private volatile boolean closed;
     @Nullable
     private OutboundMessageStatusUpdateHandler outboundMessageStatusUpdateHandler;
     @Nullable
@@ -72,9 +76,11 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
             InboundMessageFactoryCollection inboundMessageFactoryCollection,
             OutboundMessageFactoryCollection outboundMessageFactoryCollection,
             MessengerHealth healthApi,
-            MessengerMonitor messengerMonitor
+            MessengerMonitor messengerMonitor,
+            Clock clock
     ) throws ConnectionException {
         this.config = config;
+        this.clock = clock;
         this.inboundMessageFactoryCollection = inboundMessageFactoryCollection;
         this.outboundMessageFactoryCollection = outboundMessageFactoryCollection;
         this.healthApi = healthApi;
@@ -104,7 +110,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
         lock.lock();
         try {
             ensureOpen();
-            webSocketConnectionState.markReceptionStarted(Instant.now());
+            webSocketConnectionState.markReceptionStarted(clock.instant());
             messengerConnection.startReception();
         } finally {
             lock.unlock();
@@ -193,48 +199,30 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     public MessengerStatus messengerStatus() {
         var messengerStatus = healthApi.messengerStatus();
         var healthChecks = new HashMap<>(messengerStatus.healthChecks());
-        var adapterConnectionHealthCheck = webSocketConnectionState.healthCheck(
-                config.outboundConnections(),
-                config.inboundConnections(),
-                config.archiveConnections(),
-                config.connectionStatusTimeout(),
-                Instant.now()
-        );
+        var adapterConnectionHealthCheck = webSocketConnectionState.healthCheck(config, clock.instant());
         healthChecks.put(adapterConnectionHealthCheck.name(), adapterConnectionHealthCheck);
         return new MessengerStatus(healthChecks, messengerStatus.ok() && adapterConnectionHealthCheck.ok());
     }
 
     @Override
     public void reconnectIfConnectionStale() throws TransmissionException, ConnectionException {
-        if (!webSocketConnectionState.needsReconnect(
-                config.outboundConnections(),
-                config.inboundConnections(),
-                config.archiveConnections(),
-                config.connectionStatusTimeout(),
-                Instant.now()
-        )) {
+        // Keep the common healthy/closed path lock-free so the watchdog never waits behind sends or shutdown.
+        if (closed || !webSocketConnectionState.needsReconnect(config, clock.instant())) {
             return;
         }
         if (!lock.tryLock()) {
-            if (LOGGER.isWarnEnabled()) {
-                LOGGER.warn(
-                        "Skipping Ponton XP adapter WebSocket reconnect because another reconnect is already running. State: {}",
-                        webSocketConnectionState.describe()
-                );
-            }
+            LOGGER.atWarn()
+                  .addArgument(webSocketConnectionState::describe)
+                  .log("Skipping Ponton XP adapter WebSocket reconnect because another reconnect is already running. State: {}");
             return;
         }
         try {
             if (closed) {
                 return;
             }
-            if (!webSocketConnectionState.needsReconnect(
-                    config.outboundConnections(),
-                    config.inboundConnections(),
-                    config.archiveConnections(),
-                    config.connectionStatusTimeout(),
-                    Instant.now()
-            )) {
+            // Connection-status callbacks can update the state while this thread waits for the lock. Rechecking after
+            // acquiring it prevents reconnecting a connection that recovered after the initial lock-free fast-path check.
+            if (!webSocketConnectionState.needsReconnect(config, clock.instant())) {
                 return;
             }
             reconnect("stale or insufficient WebSocket connection state: " + webSocketConnectionState.describe());
@@ -275,7 +263,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
                         config.port(),
                         config.inboundConnections(),
                         config.outboundConnections(),
-                        config.archiveConnections()
+                        ARCHIVE_CONNECTIONS
                 ))
                 .onAdapterStatusRequest(this::handleAdapterStatusRequest)
                 .onMessageStatusUpdate(outboundMessageStatusUpdate -> {
@@ -288,7 +276,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
     }
 
     private String handleAdapterStatusRequest() {
-        webSocketConnectionState.markAdapterStatusRequested(Instant.now());
+        webSocketConnectionState.markAdapterStatusRequested(clock.instant());
         return config.adapterId() + " " + config.adapterVersion() + " is running. " + webSocketConnectionState.describe();
     }
 
@@ -301,21 +289,18 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
         webSocketConnectionState.updateConnectionCounts(
                 outboundConnectionCount,
                 inboundConnectionCount,
-                archiveConnectionCount,
-                Instant.now()
+                clock.instant()
         );
         if (outboundConnectionCount < config.outboundConnections() ||
-            inboundConnectionCount < config.inboundConnections() ||
-            archiveConnectionCount < config.archiveConnections()) {
+            inboundConnectionCount < config.inboundConnections()) {
             LOGGER.warn(
-                    "Ponton XP adapter WebSocket connection count below expected for '{}': outbound {}/{}, inbound {}/{}, archive {}/{}",
+                    "Ponton XP adapter WebSocket connection count below expected for '{}': outbound {}/{}, inbound {}/{}, archive {}",
                     messengerInstance,
                     outboundConnectionCount,
                     config.outboundConnections(),
                     inboundConnectionCount,
                     config.inboundConnections(),
-                    archiveConnectionCount,
-                    config.archiveConnections()
+                    archiveConnectionCount
             );
         } else {
             LOGGER.info(
@@ -499,7 +484,7 @@ public class PontonMessengerConnectionImpl implements AutoCloseable, PontonMesse
         LOGGER.warn("Restarting Ponton XP adapter WebSocket connection because {}.", reason);
         messengerConnection.close();
         messengerConnection = messengerConnectionBuilder.build();
-        webSocketConnectionState.markRestarted(Instant.now());
+        webSocketConnectionState.markRestarted(clock.instant());
         messengerConnection.startReception();
         LOGGER.info("Ponton XP adapter WebSocket connection restarted.");
     }

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionState.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionState.java
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.at.eda.ponton.messenger;
+
+import jakarta.annotation.Nullable;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Tracks the local adapter-side WebSocket connection state reported by the PONTON X/P Adapter API.
+ * <p>
+ * The PONTON REST health endpoint only says whether the Messenger process is reachable. It does not prove that this
+ * adapter still has usable WebSocket connections for inbound and outbound processing. The PONTON X/P Adapter API exposes
+ * {@code onConnectionStatusChanged}, which reports the active WebSocket connection counts for each processing direction.
+ * This class stores those callback values and turns them into a reconnect decision.
+ * <p>
+ * A connection is considered bad when reception has been started and either no initial connection status was reported
+ * within the configured timeout, or one of the observed connection counts is below the configured expected count.
+ */
+final class PontonWebSocketConnectionState {
+    private boolean receptionStarted;
+    @Nullable
+    private Instant lastStartAt;
+    @Nullable
+    private Instant lastRestartAt;
+    @Nullable
+    private Instant lastConnectionStatusChangedAt;
+    @Nullable
+    private Instant lastAdapterStatusRequestAt;
+    private int outboundConnectionCount;
+    private int inboundConnectionCount;
+    private int archiveConnectionCount;
+
+    /**
+     * Marks that {@code startReception()} was called and the adapter now expects connection-status callbacks.
+     */
+    synchronized void markReceptionStarted(Instant now) {
+        receptionStarted = true;
+        lastStartAt = now;
+    }
+
+    /**
+     * Resets the observed connection counts after rebuilding the Messenger connection.
+     */
+    synchronized void markRestarted(Instant now) {
+        lastRestartAt = now;
+        lastStartAt = now;
+        lastConnectionStatusChangedAt = null;
+        outboundConnectionCount = 0;
+        inboundConnectionCount = 0;
+        archiveConnectionCount = 0;
+    }
+
+    synchronized void markAdapterStatusRequested(Instant now) {
+        lastAdapterStatusRequestAt = now;
+    }
+
+    /**
+     * Stores the current active WebSocket connection counts reported by the Adapter API.
+     */
+    synchronized void updateConnectionCounts(
+            int outboundConnectionCount,
+            int inboundConnectionCount,
+            int archiveConnectionCount,
+            Instant now
+    ) {
+        this.outboundConnectionCount = outboundConnectionCount;
+        this.inboundConnectionCount = inboundConnectionCount;
+        this.archiveConnectionCount = archiveConnectionCount;
+        lastConnectionStatusChangedAt = now;
+    }
+
+    synchronized boolean needsReconnect(
+            int expectedOutboundConnections,
+            int expectedInboundConnections,
+            int expectedArchiveConnections,
+            Duration connectionStatusTimeout,
+            Instant now
+    ) {
+        if (!receptionStarted) {
+            return false;
+        }
+        if (lastConnectionStatusChangedAt == null) {
+            return lastStartAt != null && lastStartAt.plus(connectionStatusTimeout).isBefore(now);
+        }
+        return outboundConnectionCount < expectedOutboundConnections ||
+               inboundConnectionCount < expectedInboundConnections ||
+               archiveConnectionCount < expectedArchiveConnections;
+    }
+
+    synchronized HealthCheck healthCheck(
+            int expectedOutboundConnections,
+            int expectedInboundConnections,
+            int expectedArchiveConnections,
+            Duration connectionStatusTimeout,
+            Instant now
+    ) {
+        var ok = !needsReconnect(
+                expectedOutboundConnections,
+                expectedInboundConnections,
+                expectedArchiveConnections,
+                connectionStatusTimeout,
+                now
+        );
+        return new HealthCheck("adapterWebSocketConnection", ok, describe());
+    }
+
+    synchronized String describe() {
+        return "started=%s, outbound=%d, inbound=%d, archive=%d, lastStartAt=%s, lastRestartAt=%s, lastConnectionStatusChangedAt=%s, lastAdapterStatusRequestAt=%s"
+                .formatted(
+                        receptionStarted,
+                        outboundConnectionCount,
+                        inboundConnectionCount,
+                        archiveConnectionCount,
+                        lastStartAt,
+                        lastRestartAt,
+                        lastConnectionStatusChangedAt,
+                        lastAdapterStatusRequestAt
+                );
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionState.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionState.java
@@ -6,6 +6,7 @@ package energy.eddie.regionconnector.at.eda.ponton.messenger;
 import energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapterConfiguration;
 import jakarta.annotation.Nullable;
 
+import java.time.Clock;
 import java.time.Instant;
 
 /**
@@ -20,6 +21,8 @@ import java.time.Instant;
  * within the configured timeout, or one of the observed connection counts is below the configured expected count.
  */
 final class PontonWebSocketConnectionState {
+    private final PontonXPAdapterConfiguration config;
+    private final Clock clock;
     private boolean receptionStarted;
     @Nullable
     private Instant lastStartAt;
@@ -32,18 +35,24 @@ final class PontonWebSocketConnectionState {
     private int outboundConnectionCount;
     private int inboundConnectionCount;
 
+    PontonWebSocketConnectionState(PontonXPAdapterConfiguration config, Clock clock) {
+        this.config = config;
+        this.clock = clock;
+    }
+
     /**
      * Marks that {@code startReception()} was called and the adapter now expects connection-status callbacks.
      */
-    synchronized void markReceptionStarted(Instant now) {
+    synchronized void markReceptionStarted() {
         receptionStarted = true;
-        lastStartAt = now;
+        lastStartAt = clock.instant();
     }
 
     /**
      * Resets the observed connection counts after rebuilding the Messenger connection.
      */
-    synchronized void markRestarted(Instant now) {
+    synchronized void markRestarted() {
+        var now = clock.instant();
         lastRestartAt = now;
         lastStartAt = now;
         lastConnectionStatusChangedAt = null;
@@ -51,8 +60,8 @@ final class PontonWebSocketConnectionState {
         inboundConnectionCount = 0;
     }
 
-    synchronized void markAdapterStatusRequested(Instant now) {
-        lastAdapterStatusRequestAt = now;
+    synchronized void markAdapterStatusRequested() {
+        lastAdapterStatusRequestAt = clock.instant();
     }
 
     /**
@@ -60,33 +69,26 @@ final class PontonWebSocketConnectionState {
      */
     synchronized void updateConnectionCounts(
             int outboundConnectionCount,
-            int inboundConnectionCount,
-            Instant now
+            int inboundConnectionCount
     ) {
         this.outboundConnectionCount = outboundConnectionCount;
         this.inboundConnectionCount = inboundConnectionCount;
-        lastConnectionStatusChangedAt = now;
+        lastConnectionStatusChangedAt = clock.instant();
     }
 
-    synchronized boolean needsReconnect(
-            PontonXPAdapterConfiguration config,
-            Instant now
-    ) {
+    synchronized boolean needsReconnect() {
         if (!receptionStarted) {
             return false;
         }
         if (lastConnectionStatusChangedAt == null) {
-            return lastStartAt != null && lastStartAt.plus(config.connectionStatusTimeout()).isBefore(now);
+            return lastStartAt != null && lastStartAt.plus(config.connectionStatusTimeout()).isBefore(clock.instant());
         }
         return outboundConnectionCount < config.outboundConnections() ||
                inboundConnectionCount < config.inboundConnections();
     }
 
-    synchronized HealthCheck healthCheck(
-            PontonXPAdapterConfiguration config,
-            Instant now
-    ) {
-        var ok = !needsReconnect(config, now);
+    synchronized HealthCheck healthCheck() {
+        var ok = !needsReconnect();
         return new HealthCheck("adapterWebSocketConnection", ok, describe());
     }
 

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionState.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionState.java
@@ -3,9 +3,9 @@
 
 package energy.eddie.regionconnector.at.eda.ponton.messenger;
 
+import energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapterConfiguration;
 import jakarta.annotation.Nullable;
 
-import java.time.Duration;
 import java.time.Instant;
 
 /**
@@ -31,7 +31,6 @@ final class PontonWebSocketConnectionState {
     private Instant lastAdapterStatusRequestAt;
     private int outboundConnectionCount;
     private int inboundConnectionCount;
-    private int archiveConnectionCount;
 
     /**
      * Marks that {@code startReception()} was called and the adapter now expects connection-status callbacks.
@@ -50,7 +49,6 @@ final class PontonWebSocketConnectionState {
         lastConnectionStatusChangedAt = null;
         outboundConnectionCount = 0;
         inboundConnectionCount = 0;
-        archiveConnectionCount = 0;
     }
 
     synchronized void markAdapterStatusRequested(Instant now) {
@@ -63,57 +61,41 @@ final class PontonWebSocketConnectionState {
     synchronized void updateConnectionCounts(
             int outboundConnectionCount,
             int inboundConnectionCount,
-            int archiveConnectionCount,
             Instant now
     ) {
         this.outboundConnectionCount = outboundConnectionCount;
         this.inboundConnectionCount = inboundConnectionCount;
-        this.archiveConnectionCount = archiveConnectionCount;
         lastConnectionStatusChangedAt = now;
     }
 
     synchronized boolean needsReconnect(
-            int expectedOutboundConnections,
-            int expectedInboundConnections,
-            int expectedArchiveConnections,
-            Duration connectionStatusTimeout,
+            PontonXPAdapterConfiguration config,
             Instant now
     ) {
         if (!receptionStarted) {
             return false;
         }
         if (lastConnectionStatusChangedAt == null) {
-            return lastStartAt != null && lastStartAt.plus(connectionStatusTimeout).isBefore(now);
+            return lastStartAt != null && lastStartAt.plus(config.connectionStatusTimeout()).isBefore(now);
         }
-        return outboundConnectionCount < expectedOutboundConnections ||
-               inboundConnectionCount < expectedInboundConnections ||
-               archiveConnectionCount < expectedArchiveConnections;
+        return outboundConnectionCount < config.outboundConnections() ||
+               inboundConnectionCount < config.inboundConnections();
     }
 
     synchronized HealthCheck healthCheck(
-            int expectedOutboundConnections,
-            int expectedInboundConnections,
-            int expectedArchiveConnections,
-            Duration connectionStatusTimeout,
+            PontonXPAdapterConfiguration config,
             Instant now
     ) {
-        var ok = !needsReconnect(
-                expectedOutboundConnections,
-                expectedInboundConnections,
-                expectedArchiveConnections,
-                connectionStatusTimeout,
-                now
-        );
+        var ok = !needsReconnect(config, now);
         return new HealthCheck("adapterWebSocketConnection", ok, describe());
     }
 
     synchronized String describe() {
-        return "started=%s, outbound=%d, inbound=%d, archive=%d, lastStartAt=%s, lastRestartAt=%s, lastConnectionStatusChangedAt=%s, lastAdapterStatusRequestAt=%s"
+        return "started=%s, outbound=%d, inbound=%d, lastStartAt=%s, lastRestartAt=%s, lastConnectionStatusChangedAt=%s, lastAdapterStatusRequestAt=%s"
                 .formatted(
                         receptionStarted,
                         outboundConnectionCount,
                         inboundConnectionCount,
-                        archiveConnectionCount,
                         lastStartAt,
                         lastRestartAt,
                         lastConnectionStatusChangedAt,

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionState.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionState.java
@@ -23,9 +23,8 @@ import java.time.Instant;
 final class PontonWebSocketConnectionState {
     private final PontonXPAdapterConfiguration config;
     private final Clock clock;
-    private boolean receptionStarted;
     @Nullable
-    private Instant lastStartAt;
+    private Instant lastReceptionStartAt;
     @Nullable
     private Instant lastRestartAt;
     @Nullable
@@ -44,8 +43,7 @@ final class PontonWebSocketConnectionState {
      * Marks that {@code startReception()} was called and the adapter now expects connection-status callbacks.
      */
     synchronized void markReceptionStarted() {
-        receptionStarted = true;
-        lastStartAt = clock.instant();
+        lastReceptionStartAt = clock.instant();
     }
 
     /**
@@ -54,7 +52,7 @@ final class PontonWebSocketConnectionState {
     synchronized void markRestarted() {
         var now = clock.instant();
         lastRestartAt = now;
-        lastStartAt = now;
+        lastReceptionStartAt = now;
         lastConnectionStatusChangedAt = null;
         outboundConnectionCount = 0;
         inboundConnectionCount = 0;
@@ -77,11 +75,11 @@ final class PontonWebSocketConnectionState {
     }
 
     synchronized boolean needsReconnect() {
-        if (!receptionStarted) {
+        if (lastReceptionStartAt == null) {
             return false;
         }
         if (lastConnectionStatusChangedAt == null) {
-            return lastStartAt != null && lastStartAt.plus(config.connectionStatusTimeout()).isBefore(clock.instant());
+            return lastReceptionStartAt.plus(config.connectionStatusTimeout()).isBefore(clock.instant());
         }
         return outboundConnectionCount < config.outboundConnections() ||
                inboundConnectionCount < config.inboundConnections();
@@ -93,12 +91,12 @@ final class PontonWebSocketConnectionState {
     }
 
     synchronized String describe() {
-        return "started=%s, outbound=%d, inbound=%d, lastStartAt=%s, lastRestartAt=%s, lastConnectionStatusChangedAt=%s, lastAdapterStatusRequestAt=%s"
+        return "started=%s, outbound=%d, inbound=%d, lastReceptionStartAt=%s, lastRestartAt=%s, lastConnectionStatusChangedAt=%s, lastAdapterStatusRequestAt=%s"
                 .formatted(
-                        receptionStarted,
+                        lastReceptionStartAt != null,
                         outboundConnectionCount,
                         inboundConnectionCount,
-                        lastStartAt,
+                        lastReceptionStartAt,
                         lastRestartAt,
                         lastConnectionStatusChangedAt,
                         lastAdapterStatusRequestAt

--- a/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/web/WebPontonConnectionController.java
+++ b/region-connectors/region-connector-at-eda/src/main/java/energy/eddie/regionconnector/at/eda/web/WebPontonConnectionController.java
@@ -35,6 +35,7 @@ import reactor.core.publisher.Sinks;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
@@ -326,6 +327,16 @@ public class WebPontonConnectionController implements PontonMessengerConnection 
     @Override
     public void start() throws TransmissionException {
         LOGGER.info("Starting WebPonton Connection");
+    }
+
+    @Override
+    public void reconnectIfConnectionStale() {
+        // No WebSocket connection exists in the development REST replacement.
+    }
+
+    @Override
+    public Duration connectionWatchdogInterval() {
+        return Duration.ofMinutes(1);
     }
 
     @Override

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterConfigurationTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterConfigurationTest.java
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.at.eda.ponton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PontonXPAdapterConfigurationTest {
+    private static final String PREFIX = "region-connector.at.eda.ponton.messenger.";
+    private static final String[] REQUIRED_PROPERTIES = {
+            PREFIX + "adapter.id=adapter-id",
+            PREFIX + "adapter.version=adapter-version",
+            PREFIX + "hostname=localhost",
+            PREFIX + "port=2600",
+            PREFIX + "folder=work-folder"
+    };
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(EnableConfig.class)
+            .withPropertyValues(REQUIRED_PROPERTIES);
+
+    @Configuration
+    @EnableConfigurationProperties(PontonXPAdapterConfiguration.class)
+    static class EnableConfig {
+    }
+
+    @Test
+    void omittedConnectionSettings_useDefaults() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            var config = context.getBean(PontonXPAdapterConfiguration.class);
+            assertThat(config.inboundConnections()).isEqualTo(1);
+            assertThat(config.outboundConnections()).isEqualTo(1);
+            assertThat(config.connectionWatchdogInterval()).isEqualTo(Duration.ofMinutes(1));
+            assertThat(config.connectionStatusTimeout()).isEqualTo(Duration.ofMinutes(2));
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-1"})
+    void invalidInboundConnectionCount_failsBinding(String value) {
+        contextRunner
+                .withPropertyValues(PREFIX + "inbound-connections=" + value)
+                .run(context -> assertThat(context).hasFailed());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-1"})
+    void invalidOutboundConnectionCount_failsBinding(String value) {
+        contextRunner
+                .withPropertyValues(PREFIX + "outbound-connections=" + value)
+                .run(context -> assertThat(context).hasFailed());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0s", "-1s"})
+    void invalidWatchdogInterval_failsBinding(String value) {
+        contextRunner
+                .withPropertyValues(PREFIX + "connection-watchdog.interval=" + value)
+                .run(context -> assertThat(context).hasFailed());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0s", "-1s"})
+    void invalidConnectionStatusTimeout_failsBinding(String value) {
+        contextRunner
+                .withPropertyValues(PREFIX + "connection-watchdog.status-timeout=" + value)
+                .run(context -> assertThat(context).hasFailed());
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -47,11 +48,15 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -78,6 +83,8 @@ class PontonXPAdapterTest {
     @Mock
     @SuppressWarnings("unused")
     private TaskScheduler taskScheduler;
+    @Mock
+    private ScheduledFuture<Object> connectionWatchdogTask;
 
     @InjectMocks
     private PontonXPAdapter pontonXPAdapter;
@@ -561,6 +568,53 @@ class PontonXPAdapterTest {
         // Then
         verify(pontonMessengerConnection).start();
         pontonXPAdapter.close();
+    }
+
+    @Test
+    void start_schedulesConnectionWatchdog() throws TransmissionException {
+        // Given
+        doReturn(connectionWatchdogTask)
+                .when(taskScheduler)
+                .scheduleAtFixedRate(any(Runnable.class), eq(Duration.ofMinutes(1)));
+
+        // When
+        pontonXPAdapter.start();
+
+        // Then
+        verify(taskScheduler).scheduleAtFixedRate(any(Runnable.class), eq(Duration.ofMinutes(1)));
+        pontonXPAdapter.close();
+    }
+
+    @Test
+    void scheduledConnectionWatchdog_reconnectsWhenConnectionIsStale() throws TransmissionException {
+        // Given
+        var taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        doReturn(connectionWatchdogTask)
+                .when(taskScheduler)
+                .scheduleAtFixedRate(taskCaptor.capture(), eq(Duration.ofMinutes(1)));
+        pontonXPAdapter.start();
+
+        // When
+        taskCaptor.getValue().run();
+
+        // Then
+        assertEquals(1, pontonMessengerConnection.reconnectIfConnectionStaleCalls());
+        pontonXPAdapter.close();
+    }
+
+    @Test
+    void close_cancelsConnectionWatchdog() throws TransmissionException {
+        // Given
+        doReturn(connectionWatchdogTask)
+                .when(taskScheduler)
+                .scheduleAtFixedRate(any(Runnable.class), eq(Duration.ofMinutes(1)));
+        pontonXPAdapter.start();
+
+        // When
+        pontonXPAdapter.close();
+
+        // Then
+        verify(connectionWatchdogTask).cancel(false);
     }
 
     public static EdaECMPList createECMPList() {

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/PontonXPAdapterTest.java
@@ -603,6 +603,22 @@ class PontonXPAdapterTest {
     }
 
     @Test
+    void scheduledConnectionWatchdog_keepsRunningWhenReconnectFails() throws TransmissionException {
+        // Given
+        var taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        doReturn(connectionWatchdogTask)
+                .when(taskScheduler)
+                .scheduleAtFixedRate(taskCaptor.capture(), eq(Duration.ofMinutes(1)));
+        pontonXPAdapter.start();
+        pontonMessengerConnection.setThrowTransmissionException(true);
+
+        // When & Then
+        assertDoesNotThrow(() -> taskCaptor.getValue().run());
+        assertEquals(1, pontonMessengerConnection.reconnectIfConnectionStaleCalls());
+        pontonXPAdapter.close();
+    }
+
+    @Test
     void close_cancelsConnectionWatchdog() throws TransmissionException {
         // Given
         doReturn(connectionWatchdogTask)

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
@@ -4,15 +4,19 @@
 package energy.eddie.regionconnector.at.eda.ponton.messenger;
 
 import de.ponton.xp.adapter.api.ConnectionException;
+import de.ponton.xp.adapter.api.AdapterStatusRequestHandler;
+import de.ponton.xp.adapter.api.ConnectionStatusChangeHandler;
 import de.ponton.xp.adapter.api.MessengerConnection;
 import de.ponton.xp.adapter.api.TransmissionException;
 import de.ponton.xp.adapter.api.messages.OutboundMessage;
+import de.ponton.xp.adapter.api.domainvalues.MessengerInstance;
 import energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapterConfiguration;
 import energy.eddie.regionconnector.at.eda.ponton.messages.InboundMessageFactoryCollection;
 import energy.eddie.regionconnector.at.eda.ponton.messages.OutboundMessageFactoryCollection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -218,6 +222,31 @@ class PontonMessengerConnectionImplTest {
             connection.resendFailedMessage(date, "message-id");
 
             verify(monitor).resendFailedMessage(date, "message-id");
+        }
+    }
+
+    @Test
+    void registeredStatusCallbacks_updateAndReportWebSocketState() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            when(builder.build()).thenReturn(mock(MessengerConnection.class));
+            var connectionStatusHandler = ArgumentCaptor.forClass(ConnectionStatusChangeHandler.class);
+            var adapterStatusHandler = ArgumentCaptor.forClass(AdapterStatusRequestHandler.class);
+            connection();
+            verify(builder).onConnectionStatusChanged(connectionStatusHandler.capture());
+            verify(builder).onAdapterStatusRequest(adapterStatusHandler.capture());
+            var messengerInstance = mock(MessengerInstance.class);
+
+            connectionStatusHandler.getValue().connectionCountChanged(messengerInstance, 0, 0, 0);
+            connectionStatusHandler.getValue().connectionCountChanged(messengerInstance, 1, 1, 0);
+            var adapterStatus = adapterStatusHandler.getValue().onAdapterStatusRequest();
+
+            assertThat(adapterStatus).contains(
+                    CONFIG.adapterId(),
+                    CONFIG.adapterVersion(),
+                    "outbound=1",
+                    "inbound=1"
+            );
         }
     }
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.at.eda.ponton.messenger;
+
+import de.ponton.xp.adapter.api.ConnectionException;
+import de.ponton.xp.adapter.api.MessengerConnection;
+import de.ponton.xp.adapter.api.TransmissionException;
+import de.ponton.xp.adapter.api.messages.OutboundMessage;
+import energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapterConfiguration;
+import energy.eddie.regionconnector.at.eda.ponton.messages.InboundMessageFactoryCollection;
+import energy.eddie.regionconnector.at.eda.ponton.messages.OutboundMessageFactoryCollection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class PontonMessengerConnectionImplTest {
+    private static final PontonXPAdapterConfiguration CONFIG = new PontonXPAdapterConfiguration(
+            "adapter-id",
+            "adapter-version",
+            "localhost",
+            8080,
+            "http://localhost:8081",
+            "work",
+            "user",
+            "password"
+    );
+
+    @TempDir
+    private Path workFolder;
+
+    @Test
+    void close_closesCurrentMessengerConnectionOnlyOnce() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            var messengerConnection = mock(MessengerConnection.class);
+            when(builder.build()).thenReturn(messengerConnection);
+            var connection = connection();
+
+            connection.close();
+            connection.close();
+
+            verify(messengerConnection).close();
+            verify(builder).build();
+        }
+    }
+
+    @Test
+    void sendMessage_afterCloseThrowsAndDoesNotReconnect() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            var messengerConnection = mock(MessengerConnection.class);
+            when(builder.build()).thenReturn(messengerConnection);
+            var connection = connection();
+            connection.close();
+
+            assertThrows(ConnectionException.class, () -> connection.sendMessage(mock(OutboundMessage.class)));
+
+            verify(messengerConnection).close();
+            verify(messengerConnection, never()).startReception();
+            verify(builder).build();
+        }
+    }
+
+    @Test
+    void sendMessage_reconnectsAndRetriesWhenOpenAndSendFailsWithRetryableException() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            var firstMessengerConnection = mock(MessengerConnection.class);
+            var secondMessengerConnection = mock(MessengerConnection.class);
+            var outboundMessage = mock(OutboundMessage.class);
+            when(builder.build()).thenReturn(firstMessengerConnection, secondMessengerConnection);
+            doThrow(new TransmissionException("send failed", new IOException("socket closed")))
+                    .when(firstMessengerConnection)
+                    .sendMessage(outboundMessage);
+            var connection = connection();
+
+            connection.sendMessage(outboundMessage);
+
+            verify(firstMessengerConnection).close();
+            verify(secondMessengerConnection).startReception();
+            verify(secondMessengerConnection).sendMessage(outboundMessage);
+            verify(builder, times(2)).build();
+        }
+    }
+
+    private PontonMessengerConnectionImpl connection() throws Exception {
+        return new PontonMessengerConnectionImpl(
+                CONFIG,
+                workFolder.toFile(),
+                mock(InboundMessageFactoryCollection.class),
+                mock(OutboundMessageFactoryCollection.class),
+                () -> new MessengerStatus(Map.of(), true),
+                mock(MessengerMonitor.class)
+        );
+    }
+
+    private MessengerConnection.MessengerConnectionBuilder messengerConnectionBuilderReturning(
+            org.mockito.MockedStatic<MessengerConnection> messengerConnectionFactory
+    ) {
+        var builder = mock(MessengerConnection.MessengerConnectionBuilder.class, Answers.RETURNS_SELF);
+        messengerConnectionFactory.when(MessengerConnection::newBuilder).thenReturn(builder);
+        return builder;
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
@@ -17,11 +17,15 @@ import org.mockito.Answers;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 class PontonMessengerConnectionImplTest {
@@ -99,15 +103,145 @@ class PontonMessengerConnectionImplTest {
         }
     }
 
+    @Test
+    void start_startsReceptionAndExposesConfiguredWatchdogInterval() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            var messengerConnection = mock(MessengerConnection.class);
+            when(builder.build()).thenReturn(messengerConnection);
+            var connection = connection();
+
+            connection.start();
+
+            verify(messengerConnection).startReception();
+            assertThat(connection.connectionWatchdogInterval()).isEqualTo(CONFIG.connectionWatchdogInterval());
+        }
+    }
+
+    @Test
+    void sendMessage_sendsWithoutReconnectWhenFirstAttemptSucceeds() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            var messengerConnection = mock(MessengerConnection.class);
+            var outboundMessage = mock(OutboundMessage.class);
+            when(builder.build()).thenReturn(messengerConnection);
+            var connection = connection();
+
+            connection.sendMessage(outboundMessage);
+
+            verify(messengerConnection).sendMessage(outboundMessage);
+            verify(messengerConnection, never()).close();
+            verify(builder).build();
+        }
+    }
+
+    @Test
+    void sendMessage_wrapsNonRetryableFailureWithoutReconnect() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            var messengerConnection = mock(MessengerConnection.class);
+            var outboundMessage = mock(OutboundMessage.class);
+            when(builder.build()).thenReturn(messengerConnection);
+            doThrow(new IllegalArgumentException("invalid message"))
+                    .when(messengerConnection)
+                    .sendMessage(outboundMessage);
+            var connection = connection();
+
+            assertThrows(ConnectionException.class, () -> connection.sendMessage(outboundMessage));
+
+            verify(messengerConnection, never()).close();
+            verify(builder).build();
+        }
+    }
+
+    @Test
+    void messengerStatus_combinesMessengerAndWebSocketHealth() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            when(builder.build()).thenReturn(mock(MessengerConnection.class));
+            var healthApi = mock(MessengerHealth.class);
+            when(healthApi.messengerStatus()).thenReturn(new MessengerStatus(Map.of(), true));
+            var connection = connection(healthApi, mock(MessengerMonitor.class), CLOCK);
+
+            var status = connection.messengerStatus();
+
+            assertThat(status.ok()).isTrue();
+            assertThat(status.healthChecks()).containsKey("adapterWebSocketConnection");
+        }
+    }
+
+    @Test
+    void reconnectIfConnectionStale_rebuildsAndStartsConnectionAfterTimeout() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            var firstMessengerConnection = mock(MessengerConnection.class);
+            var secondMessengerConnection = mock(MessengerConnection.class);
+            when(builder.build()).thenReturn(firstMessengerConnection, secondMessengerConnection);
+            var clock = new MutableClock(CLOCK.instant());
+            var connection = connection(mock(MessengerHealth.class), mock(MessengerMonitor.class), clock);
+            connection.start();
+            clock.advance(CONFIG.connectionStatusTimeout().plusSeconds(1));
+
+            connection.reconnectIfConnectionStale();
+
+            verify(firstMessengerConnection).close();
+            verify(secondMessengerConnection).startReception();
+            verify(builder, times(2)).build();
+        }
+    }
+
+    @Test
+    void reconnectIfConnectionStale_doesNothingAfterClose() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            var messengerConnection = mock(MessengerConnection.class);
+            when(builder.build()).thenReturn(messengerConnection);
+            var connection = connection();
+            connection.close();
+
+            connection.reconnectIfConnectionStale();
+
+            verify(messengerConnection).close();
+            verify(builder).build();
+        }
+    }
+
+    @Test
+    void resendFailedMessage_delegatesToMonitor() throws Exception {
+        try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
+            var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
+            when(builder.build()).thenReturn(mock(MessengerConnection.class));
+            var monitor = mock(MessengerMonitor.class);
+            var connection = connection(mock(MessengerHealth.class), monitor, CLOCK);
+            var date = ZonedDateTime.parse("2026-08-13T12:00:00Z");
+
+            connection.resendFailedMessage(date, "message-id");
+
+            verify(monitor).resendFailedMessage(date, "message-id");
+        }
+    }
+
     private PontonMessengerConnectionImpl connection() throws Exception {
+        return connection(
+                () -> new MessengerStatus(Map.of(), true),
+                mock(MessengerMonitor.class),
+                CLOCK
+        );
+    }
+
+    private PontonMessengerConnectionImpl connection(
+            MessengerHealth healthApi,
+            MessengerMonitor monitor,
+            Clock clock
+    ) throws Exception {
         return new PontonMessengerConnectionImpl(
                 CONFIG,
                 workFolder.toFile(),
                 mock(InboundMessageFactoryCollection.class),
                 mock(OutboundMessageFactoryCollection.class),
-                () -> new MessengerStatus(Map.of(), true),
-                mock(MessengerMonitor.class),
-                CLOCK
+                healthApi,
+                monitor,
+                clock
         );
     }
 
@@ -117,5 +251,32 @@ class PontonMessengerConnectionImplTest {
         var builder = mock(MessengerConnection.MessengerConnectionBuilder.class, Answers.RETURNS_SELF);
         messengerConnectionFactory.when(MessengerConnection::newBuilder).thenReturn(builder);
         return builder;
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
     }
 }

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
@@ -16,12 +16,16 @@ import org.mockito.Answers;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 class PontonMessengerConnectionImplTest {
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-13T10:00:00Z"), ZoneOffset.UTC);
     private static final PontonXPAdapterConfiguration CONFIG = new PontonXPAdapterConfiguration(
             "adapter-id",
             "adapter-version",
@@ -30,7 +34,11 @@ class PontonMessengerConnectionImplTest {
             "http://localhost:8081",
             "work",
             "user",
-            "password"
+            "password",
+            1,
+            1,
+            java.time.Duration.ofMinutes(1),
+            java.time.Duration.ofMinutes(2)
     );
 
     @TempDir
@@ -98,7 +106,8 @@ class PontonMessengerConnectionImplTest {
                 mock(InboundMessageFactoryCollection.class),
                 mock(OutboundMessageFactoryCollection.class),
                 () -> new MessengerStatus(Map.of(), true),
-                mock(MessengerMonitor.class)
+                mock(MessengerMonitor.class),
+                CLOCK
         );
     }
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionImplTest.java
@@ -3,20 +3,20 @@
 
 package energy.eddie.regionconnector.at.eda.ponton.messenger;
 
-import de.ponton.xp.adapter.api.ConnectionException;
 import de.ponton.xp.adapter.api.AdapterStatusRequestHandler;
+import de.ponton.xp.adapter.api.ConnectionException;
 import de.ponton.xp.adapter.api.ConnectionStatusChangeHandler;
 import de.ponton.xp.adapter.api.MessengerConnection;
 import de.ponton.xp.adapter.api.TransmissionException;
-import de.ponton.xp.adapter.api.messages.OutboundMessage;
 import de.ponton.xp.adapter.api.domainvalues.MessengerInstance;
+import de.ponton.xp.adapter.api.messages.OutboundMessage;
 import energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapterConfiguration;
 import energy.eddie.regionconnector.at.eda.ponton.messages.InboundMessageFactoryCollection;
 import energy.eddie.regionconnector.at.eda.ponton.messages.OutboundMessageFactoryCollection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Answers;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -28,8 +28,8 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 class PontonMessengerConnectionImplTest {
@@ -45,8 +45,8 @@ class PontonMessengerConnectionImplTest {
             "password",
             1,
             1,
-            java.time.Duration.ofMinutes(1),
-            java.time.Duration.ofMinutes(2)
+            Duration.ofMinutes(1),
+            Duration.ofMinutes(2)
     );
 
     @TempDir
@@ -162,7 +162,8 @@ class PontonMessengerConnectionImplTest {
     void messengerStatus_combinesMessengerAndWebSocketHealth() throws Exception {
         try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
             var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
-            when(builder.build()).thenReturn(mock(MessengerConnection.class));
+            var messengerConnection = mock(MessengerConnection.class);
+            when(builder.build()).thenReturn(messengerConnection);
             var healthApi = mock(MessengerHealth.class);
             when(healthApi.messengerStatus()).thenReturn(new MessengerStatus(Map.of(), true));
             var connection = connection(healthApi, mock(MessengerMonitor.class), CLOCK);
@@ -214,7 +215,8 @@ class PontonMessengerConnectionImplTest {
     void resendFailedMessage_delegatesToMonitor() throws Exception {
         try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
             var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
-            when(builder.build()).thenReturn(mock(MessengerConnection.class));
+            var messengerConnection = mock(MessengerConnection.class);
+            when(builder.build()).thenReturn(messengerConnection);
             var monitor = mock(MessengerMonitor.class);
             var connection = connection(mock(MessengerHealth.class), monitor, CLOCK);
             var date = ZonedDateTime.parse("2026-08-13T12:00:00Z");
@@ -229,7 +231,8 @@ class PontonMessengerConnectionImplTest {
     void registeredStatusCallbacks_updateAndReportWebSocketState() throws Exception {
         try (var messengerConnectionFactory = mockStatic(MessengerConnection.class)) {
             var builder = messengerConnectionBuilderReturning(messengerConnectionFactory);
-            when(builder.build()).thenReturn(mock(MessengerConnection.class));
+            var messengerConnection = mock(MessengerConnection.class);
+            when(builder.build()).thenReturn(messengerConnection);
             var connectionStatusHandler = ArgumentCaptor.forClass(ConnectionStatusChangeHandler.class);
             var adapterStatusHandler = ArgumentCaptor.forClass(AdapterStatusRequestHandler.class);
             connection();

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionTestImpl.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonMessengerConnectionTestImpl.java
@@ -10,6 +10,7 @@ import energy.eddie.regionconnector.at.eda.requests.CCMORequest;
 import energy.eddie.regionconnector.at.eda.requests.CCMORevoke;
 import energy.eddie.regionconnector.at.eda.requests.CPRequestCR;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
@@ -25,6 +26,7 @@ public class PontonMessengerConnectionTestImpl implements PontonMessengerConnect
 
     private boolean throwTransmissionException = false;
     private boolean throwConnectionException = false;
+    private int reconnectIfConnectionStaleCalls;
     public ECMPListHandler ecmpListHandler;
 
     public void setThrowTransmissionException(boolean throwTransmissionException) {
@@ -50,6 +52,23 @@ public class PontonMessengerConnectionTestImpl implements PontonMessengerConnect
         if (throwTransmissionException) {
             throw new TransmissionException("TransmissionException");
         }
+    }
+
+    @Override
+    public void reconnectIfConnectionStale() throws TransmissionException {
+        reconnectIfConnectionStaleCalls++;
+        if (throwTransmissionException) {
+            throw new TransmissionException("TransmissionException");
+        }
+    }
+
+    public int reconnectIfConnectionStaleCalls() {
+        return reconnectIfConnectionStaleCalls;
+    }
+
+    @Override
+    public Duration connectionWatchdogInterval() {
+        return Duration.ofMinutes(1);
     }
 
     @Override

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
@@ -28,6 +28,10 @@ class PontonWebSocketConnectionStateTest {
         var state = new PontonWebSocketConnectionState(CONFIG, clock);
 
         assertThat(state.needsReconnect()).isFalse();
+        assertThat(state.describe()).contains(
+                "started=false",
+                "lastReceptionStartAt=null"
+        );
     }
 
     @Test
@@ -97,6 +101,7 @@ class PontonWebSocketConnectionStateTest {
         assertThat(state.describe()).contains(
                 "outbound=0",
                 "inbound=0",
+                "lastReceptionStartAt=" + restartedAt,
                 "lastRestartAt=" + restartedAt,
                 "lastConnectionStatusChangedAt=null"
         );

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
@@ -55,4 +55,59 @@ class PontonWebSocketConnectionStateTest {
         assertThat(state.needsReconnect(CONFIG, START.plusSeconds(2)))
                 .isFalse();
     }
+
+    @Test
+    void needsReconnect_returnsTrueWhenOutboundConnectionCountIsBelowExpected() {
+        var state = new PontonWebSocketConnectionState();
+        state.markReceptionStarted(START);
+        state.updateConnectionCounts(0, 1, START.plusSeconds(1));
+
+        assertThat(state.needsReconnect(CONFIG, START.plusSeconds(2)))
+                .isTrue();
+    }
+
+    @Test
+    void needsReconnect_returnsFalseAtStatusTimeoutBoundary() {
+        var state = new PontonWebSocketConnectionState();
+        state.markReceptionStarted(START);
+
+        assertThat(state.needsReconnect(CONFIG, START.plus(STATUS_TIMEOUT)))
+                .isFalse();
+    }
+
+    @Test
+    void markRestarted_resetsConnectionCountsAndStartsStatusTimeoutAgain() {
+        var state = new PontonWebSocketConnectionState();
+        state.markReceptionStarted(START);
+        state.updateConnectionCounts(1, 1, START.plusSeconds(1));
+        var restartedAt = START.plusSeconds(10);
+
+        state.markRestarted(restartedAt);
+
+        assertThat(state.needsReconnect(CONFIG, restartedAt.plus(STATUS_TIMEOUT).plusSeconds(1)))
+                .isTrue();
+        assertThat(state.describe()).contains(
+                "outbound=0",
+                "inbound=0",
+                "lastRestartAt=" + restartedAt,
+                "lastConnectionStatusChangedAt=null"
+        );
+    }
+
+    @Test
+    void healthCheck_reportsWebSocketState() {
+        var state = new PontonWebSocketConnectionState();
+        state.markReceptionStarted(START);
+        state.markAdapterStatusRequested(START.plusSeconds(1));
+        state.updateConnectionCounts(1, 1, START.plusSeconds(2));
+
+        var healthCheck = state.healthCheck(CONFIG, START.plusSeconds(3));
+
+        assertThat(healthCheck.name()).isEqualTo("adapterWebSocketConnection");
+        assertThat(healthCheck.ok()).isTrue();
+        assertThat(healthCheck.content()).contains(
+                "started=true",
+                "lastAdapterStatusRequestAt=" + START.plusSeconds(1)
+        );
+    }
 }

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
@@ -6,9 +6,9 @@ package energy.eddie.regionconnector.at.eda.ponton.messenger;
 import energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapterConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.Clock;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 
@@ -28,6 +28,12 @@ class PontonWebSocketConnectionStateTest {
         var state = new PontonWebSocketConnectionState(CONFIG, clock);
 
         assertThat(state.needsReconnect()).isFalse();
+    }
+
+    @Test
+    void describe_reportsNotStartedWithoutReceptionStartTimestamp() {
+        var state = new PontonWebSocketConnectionState(CONFIG, new MutableClock(START));
+
         assertThat(state.describe()).contains(
                 "started=false",
                 "lastReceptionStartAt=null"
@@ -86,10 +92,9 @@ class PontonWebSocketConnectionStateTest {
     }
 
     @Test
-    void markRestarted_resetsConnectionCountsAndStartsStatusTimeoutAgain() {
+    void markRestarted_setsReceptionStartTimestampAndStartsStatusTimeout() {
         var clock = new MutableClock(START);
         var state = new PontonWebSocketConnectionState(CONFIG, clock);
-        state.markReceptionStarted();
         state.updateConnectionCounts(1, 1);
         var restartedAt = START.plusSeconds(10);
         clock.set(restartedAt);

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
@@ -3,6 +3,7 @@
 
 package energy.eddie.regionconnector.at.eda.ponton.messenger;
 
+import energy.eddie.regionconnector.at.eda.ponton.PontonXPAdapterConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -13,12 +14,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PontonWebSocketConnectionStateTest {
     private static final Duration STATUS_TIMEOUT = Duration.ofMinutes(2);
     private static final Instant START = Instant.parse("2026-08-02T10:00:00Z");
+    private static final PontonXPAdapterConfiguration CONFIG = new PontonXPAdapterConfiguration(
+            "adapter-id", "adapter-version", "localhost", 8080, "api-endpoint", "work-folder", "username", "password",
+            1, 1, Duration.ofMinutes(1), STATUS_TIMEOUT
+    );
 
     @Test
     void needsReconnect_returnsFalseBeforeReceptionStarted() {
         var state = new PontonWebSocketConnectionState();
 
-        assertThat(state.needsReconnect(1, 1, 0, STATUS_TIMEOUT, START.plus(STATUS_TIMEOUT).plusSeconds(1)))
+        assertThat(state.needsReconnect(CONFIG, START.plus(STATUS_TIMEOUT).plusSeconds(1)))
                 .isFalse();
     }
 
@@ -27,7 +32,7 @@ class PontonWebSocketConnectionStateTest {
         var state = new PontonWebSocketConnectionState();
         state.markReceptionStarted(START);
 
-        assertThat(state.needsReconnect(1, 1, 0, STATUS_TIMEOUT, START.plus(STATUS_TIMEOUT).plusSeconds(1)))
+        assertThat(state.needsReconnect(CONFIG, START.plus(STATUS_TIMEOUT).plusSeconds(1)))
                 .isTrue();
     }
 
@@ -35,9 +40,9 @@ class PontonWebSocketConnectionStateTest {
     void needsReconnect_returnsTrueWhenInboundConnectionCountIsBelowExpected() {
         var state = new PontonWebSocketConnectionState();
         state.markReceptionStarted(START);
-        state.updateConnectionCounts(1, 0, 0, START.plusSeconds(1));
+        state.updateConnectionCounts(1, 0, START.plusSeconds(1));
 
-        assertThat(state.needsReconnect(1, 1, 0, STATUS_TIMEOUT, START.plusSeconds(2)))
+        assertThat(state.needsReconnect(CONFIG, START.plusSeconds(2)))
                 .isTrue();
     }
 
@@ -45,9 +50,9 @@ class PontonWebSocketConnectionStateTest {
     void needsReconnect_returnsFalseWhenConnectionCountsMatchExpectedCounts() {
         var state = new PontonWebSocketConnectionState();
         state.markReceptionStarted(START);
-        state.updateConnectionCounts(1, 1, 0, START.plusSeconds(1));
+        state.updateConnectionCounts(1, 1, START.plusSeconds(1));
 
-        assertThat(state.needsReconnect(1, 1, 0, STATUS_TIMEOUT, START.plusSeconds(2)))
+        assertThat(state.needsReconnect(CONFIG, START.plusSeconds(2)))
                 .isFalse();
     }
 }

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,71 +24,76 @@ class PontonWebSocketConnectionStateTest {
 
     @Test
     void needsReconnect_returnsFalseBeforeReceptionStarted() {
-        var state = new PontonWebSocketConnectionState();
+        var clock = new MutableClock(START.plus(STATUS_TIMEOUT).plusSeconds(1));
+        var state = new PontonWebSocketConnectionState(CONFIG, clock);
 
-        assertThat(state.needsReconnect(CONFIG, START.plus(STATUS_TIMEOUT).plusSeconds(1)))
-                .isFalse();
+        assertThat(state.needsReconnect()).isFalse();
     }
 
     @Test
     void needsReconnect_returnsTrueWhenInitialConnectionStatusCallbackIsStale() {
-        var state = new PontonWebSocketConnectionState();
-        state.markReceptionStarted(START);
+        var clock = new MutableClock(START);
+        var state = new PontonWebSocketConnectionState(CONFIG, clock);
+        state.markReceptionStarted();
+        clock.set(START.plus(STATUS_TIMEOUT).plusSeconds(1));
 
-        assertThat(state.needsReconnect(CONFIG, START.plus(STATUS_TIMEOUT).plusSeconds(1)))
-                .isTrue();
+        assertThat(state.needsReconnect()).isTrue();
     }
 
     @Test
     void needsReconnect_returnsTrueWhenInboundConnectionCountIsBelowExpected() {
-        var state = new PontonWebSocketConnectionState();
-        state.markReceptionStarted(START);
-        state.updateConnectionCounts(1, 0, START.plusSeconds(1));
+        var clock = new MutableClock(START);
+        var state = new PontonWebSocketConnectionState(CONFIG, clock);
+        state.markReceptionStarted();
+        clock.set(START.plusSeconds(1));
+        state.updateConnectionCounts(1, 0);
 
-        assertThat(state.needsReconnect(CONFIG, START.plusSeconds(2)))
-                .isTrue();
+        assertThat(state.needsReconnect()).isTrue();
     }
 
     @Test
     void needsReconnect_returnsFalseWhenConnectionCountsMatchExpectedCounts() {
-        var state = new PontonWebSocketConnectionState();
-        state.markReceptionStarted(START);
-        state.updateConnectionCounts(1, 1, START.plusSeconds(1));
+        var clock = new MutableClock(START);
+        var state = new PontonWebSocketConnectionState(CONFIG, clock);
+        state.markReceptionStarted();
+        state.updateConnectionCounts(1, 1);
 
-        assertThat(state.needsReconnect(CONFIG, START.plusSeconds(2)))
-                .isFalse();
+        assertThat(state.needsReconnect()).isFalse();
     }
 
     @Test
     void needsReconnect_returnsTrueWhenOutboundConnectionCountIsBelowExpected() {
-        var state = new PontonWebSocketConnectionState();
-        state.markReceptionStarted(START);
-        state.updateConnectionCounts(0, 1, START.plusSeconds(1));
+        var clock = new MutableClock(START);
+        var state = new PontonWebSocketConnectionState(CONFIG, clock);
+        state.markReceptionStarted();
+        state.updateConnectionCounts(0, 1);
 
-        assertThat(state.needsReconnect(CONFIG, START.plusSeconds(2)))
-                .isTrue();
+        assertThat(state.needsReconnect()).isTrue();
     }
 
     @Test
     void needsReconnect_returnsFalseAtStatusTimeoutBoundary() {
-        var state = new PontonWebSocketConnectionState();
-        state.markReceptionStarted(START);
+        var clock = new MutableClock(START);
+        var state = new PontonWebSocketConnectionState(CONFIG, clock);
+        state.markReceptionStarted();
+        clock.set(START.plus(STATUS_TIMEOUT));
 
-        assertThat(state.needsReconnect(CONFIG, START.plus(STATUS_TIMEOUT)))
-                .isFalse();
+        assertThat(state.needsReconnect()).isFalse();
     }
 
     @Test
     void markRestarted_resetsConnectionCountsAndStartsStatusTimeoutAgain() {
-        var state = new PontonWebSocketConnectionState();
-        state.markReceptionStarted(START);
-        state.updateConnectionCounts(1, 1, START.plusSeconds(1));
+        var clock = new MutableClock(START);
+        var state = new PontonWebSocketConnectionState(CONFIG, clock);
+        state.markReceptionStarted();
+        state.updateConnectionCounts(1, 1);
         var restartedAt = START.plusSeconds(10);
+        clock.set(restartedAt);
 
-        state.markRestarted(restartedAt);
+        state.markRestarted();
+        clock.set(restartedAt.plus(STATUS_TIMEOUT).plusSeconds(1));
 
-        assertThat(state.needsReconnect(CONFIG, restartedAt.plus(STATUS_TIMEOUT).plusSeconds(1)))
-                .isTrue();
+        assertThat(state.needsReconnect()).isTrue();
         assertThat(state.describe()).contains(
                 "outbound=0",
                 "inbound=0",
@@ -96,12 +104,15 @@ class PontonWebSocketConnectionStateTest {
 
     @Test
     void healthCheck_reportsWebSocketState() {
-        var state = new PontonWebSocketConnectionState();
-        state.markReceptionStarted(START);
-        state.markAdapterStatusRequested(START.plusSeconds(1));
-        state.updateConnectionCounts(1, 1, START.plusSeconds(2));
+        var clock = new MutableClock(START);
+        var state = new PontonWebSocketConnectionState(CONFIG, clock);
+        state.markReceptionStarted();
+        clock.set(START.plusSeconds(1));
+        state.markAdapterStatusRequested();
+        clock.set(START.plusSeconds(2));
+        state.updateConnectionCounts(1, 1);
 
-        var healthCheck = state.healthCheck(CONFIG, START.plusSeconds(3));
+        var healthCheck = state.healthCheck();
 
         assertThat(healthCheck.name()).isEqualTo("adapterWebSocketConnection");
         assertThat(healthCheck.ok()).isTrue();
@@ -109,5 +120,32 @@ class PontonWebSocketConnectionStateTest {
                 "started=true",
                 "lastAdapterStatusRequestAt=" + START.plusSeconds(1)
         );
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void set(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
     }
 }

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/PontonWebSocketConnectionStateTest.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-License-Identifier: Apache-2.0
+
+package energy.eddie.regionconnector.at.eda.ponton.messenger;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PontonWebSocketConnectionStateTest {
+    private static final Duration STATUS_TIMEOUT = Duration.ofMinutes(2);
+    private static final Instant START = Instant.parse("2026-08-02T10:00:00Z");
+
+    @Test
+    void needsReconnect_returnsFalseBeforeReceptionStarted() {
+        var state = new PontonWebSocketConnectionState();
+
+        assertThat(state.needsReconnect(1, 1, 0, STATUS_TIMEOUT, START.plus(STATUS_TIMEOUT).plusSeconds(1)))
+                .isFalse();
+    }
+
+    @Test
+    void needsReconnect_returnsTrueWhenInitialConnectionStatusCallbackIsStale() {
+        var state = new PontonWebSocketConnectionState();
+        state.markReceptionStarted(START);
+
+        assertThat(state.needsReconnect(1, 1, 0, STATUS_TIMEOUT, START.plus(STATUS_TIMEOUT).plusSeconds(1)))
+                .isTrue();
+    }
+
+    @Test
+    void needsReconnect_returnsTrueWhenInboundConnectionCountIsBelowExpected() {
+        var state = new PontonWebSocketConnectionState();
+        state.markReceptionStarted(START);
+        state.updateConnectionCounts(1, 0, 0, START.plusSeconds(1));
+
+        assertThat(state.needsReconnect(1, 1, 0, STATUS_TIMEOUT, START.plusSeconds(2)))
+                .isTrue();
+    }
+
+    @Test
+    void needsReconnect_returnsFalseWhenConnectionCountsMatchExpectedCounts() {
+        var state = new PontonWebSocketConnectionState();
+        state.markReceptionStarted(START);
+        state.updateConnectionCounts(1, 1, 0, START.plusSeconds(1));
+
+        assertThat(state.needsReconnect(1, 1, 0, STATUS_TIMEOUT, START.plusSeconds(2)))
+                .isFalse();
+    }
+}

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientMessengerHealthTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientMessengerHealthTest.java
@@ -37,7 +37,11 @@ class WebClientMessengerHealthTest {
                 "http://localhost:" + mockBackEnd.getPort(),
                 "folder",
                 "username",
-                "password"
+                "password",
+                1,
+                1,
+                java.time.Duration.ofMinutes(1),
+                java.time.Duration.ofMinutes(2)
         );
     }
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientMessengerHealthTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientMessengerHealthTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,8 +41,8 @@ class WebClientMessengerHealthTest {
                 "password",
                 1,
                 1,
-                java.time.Duration.ofMinutes(1),
-                java.time.Duration.ofMinutes(2)
+                Duration.ofMinutes(1),
+                Duration.ofMinutes(2)
         );
     }
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientMessengerMonitorTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientMessengerMonitorTest.java
@@ -52,7 +52,11 @@ class WebClientMessengerMonitorTest {
                 "http://localhost:" + mockBackEnd.getPort(),
                 "folder",
                 "username",
-                "password"
+                "password",
+                1,
+                1,
+                java.time.Duration.ofMinutes(1),
+                java.time.Duration.ofMinutes(2)
         );
     }
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientPontonTokenProviderTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientPontonTokenProviderTest.java
@@ -52,7 +52,11 @@ class WebClientPontonTokenProviderTest {
                 "http://localhost:" + mockBackEnd.getPort(),
                 "folder",
                 "user",
-                "password"
+                "password",
+                1,
+                1,
+                java.time.Duration.ofMinutes(1),
+                java.time.Duration.ofMinutes(2)
         );
     }
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientPontonTokenProviderTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/WebClientPontonTokenProviderTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,8 +56,8 @@ class WebClientPontonTokenProviderTest {
                 "password",
                 1,
                 1,
-                java.time.Duration.ofMinutes(1),
-                java.time.Duration.ofMinutes(2)
+                Duration.ofMinutes(1),
+                Duration.ofMinutes(2)
         );
     }
 

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/client/FindMessagesClientTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/client/FindMessagesClientTest.java
@@ -37,7 +37,11 @@ class FindMessagesClientTest {
             SERVER.url("/api").toString(),
             "/",
             "admin",
-            "admin"
+            "admin",
+            1,
+            1,
+            java.time.Duration.ofMinutes(1),
+            java.time.Duration.ofMinutes(2)
     );
     @Mock
     private PontonTokenProvider tokenProvider;

--- a/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/otel/PontonQueueGaugeTest.java
+++ b/region-connectors/region-connector-at-eda/src/test/java/energy/eddie/regionconnector/at/eda/ponton/messenger/otel/PontonQueueGaugeTest.java
@@ -33,7 +33,11 @@ class PontonQueueGaugeTest {
             "https://localhost:8080/api",
             "/",
             "admin",
-            "password"
+            "password",
+            1,
+            1,
+            java.time.Duration.ofMinutes(1),
+            java.time.Duration.ofMinutes(2)
     );
     @Mock
     private FindMessagesClient client;


### PR DESCRIPTION
## What changed

- track adapter-side Ponton WebSocket connection counts and expose them through health checks
- add a configurable watchdog that detects stale or insufficient connections and reconnects safely
- serialize send, reconnect, and shutdown operations to avoid reconnect races
- preserve retry behavior for retryable send failures and prevent reconnects after shutdown
- add focused tests for watchdog scheduling, connection-state evaluation, retries, reconnects, and idempotent shutdown

## Why

The existing health endpoint only showed whether the Ponton Messenger process was reachable. It did not detect stale adapter WebSocket connections, and concurrent send, reconnect, and shutdown paths could race with one another.

This change uses the Ponton Adapter API connection-status callback to monitor the actual inbound, outbound, and archive WebSocket connections and recover them when they become unhealthy.

## Impact

AT EDA connections can recover automatically from stale WebSocket sessions. Existing installations retain compatible defaults: one inbound connection, one outbound connection, no archive connection, a one-minute watchdog interval, and a two-minute initial status timeout.

## Validation

- focused watchdog, connection-state, retry, reconnect, and shutdown tests
- AT EDA Java compilation
- JaCoCo coverage verification
- staged diff whitespace validation
