### PR TITLE
feat(aiida): Only data sources with a matching meter ID are displayed for the FCA outbound permission.

### DIFF
--- a/aiida/src/main/java/energy/eddie/aiida/repositories/DataSourceRepository.java
+++ b/aiida/src/main/java/energy/eddie/aiida/repositories/DataSourceRepository.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.aiida.repositories;
@@ -15,6 +15,10 @@ public interface DataSourceRepository extends JpaRepository<DataSource, UUID> {
 
     @Query("select d from DataSource d where d.userId = :userId and not d.type = DataSourceType.INBOUND")
     List<DataSource> findOutboundByUserId(UUID userId);
+
+    @Query("select d from DataSource d where d.userId = :userId and not d.type = DataSourceType.INBOUND "
+            + "and d.meterId = :meterId")
+    List<DataSource> findOutboundByUserIdAndMeterId(UUID userId, String meterId);
 
     List<DataSource> findAllByType(DataSourceType type);
 }

--- a/aiida/src/main/java/energy/eddie/aiida/services/DataSourceService.java
+++ b/aiida/src/main/java/energy/eddie/aiida/services/DataSourceService.java
@@ -120,6 +120,11 @@ public class DataSourceService {
         return repository.findOutboundByUserId(currentUserId);
     }
 
+    public List<DataSource> getOutboundDataSourcesByMeterId(String meterId) throws InvalidUserException {
+        var currentUserId = authService.getCurrentUserId();
+        return repository.findOutboundByUserIdAndMeterId(currentUserId, meterId);
+    }
+
     @Transactional
     public DataSourceSecretsDto addDataSource(DataSourceDto dto) throws InvalidUserException, SinapsiAlfaEmptyConfigException, SecretStoringException {
         var currentUserId = authService.getCurrentUserId();

--- a/aiida/src/main/java/energy/eddie/aiida/web/DataSourceController.java
+++ b/aiida/src/main/java/energy/eddie/aiida/web/DataSourceController.java
@@ -19,6 +19,7 @@ import energy.eddie.aiida.services.DataSourceService;
 import energy.eddie.api.agnostic.EddieApiError;
 import energy.eddie.api.agnostic.aiida.AiidaAsset;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -95,8 +96,12 @@ public class DataSourceController {
                     content = @Content(schema = @Schema(implementation = EddieApiError.class)))
     })
     @GetMapping(path = "/outbound", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<DataSource>> getAllOutboundDataSources() throws InvalidUserException {
-        var dataSources = service.getOutboundDataSources();
+    public ResponseEntity<List<DataSource>> getAllOutboundDataSources(
+            @Parameter(description = "Filter data sources by physical meter ID")
+            @RequestParam(required = false) String meterId) throws InvalidUserException {
+        var dataSources = meterId != null
+                ? service.getOutboundDataSourcesByMeterId(meterId)
+                : service.getOutboundDataSources();
 
         return ResponseEntity.ok(dataSources);
     }

--- a/aiida/src/test/java/energy/eddie/aiida/services/DataSourceServiceTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/services/DataSourceServiceTest.java
@@ -114,6 +114,18 @@ class DataSourceServiceTest {
     }
 
     @Test
+    void shouldReturnOutboundDataSourcesFilteredByMeterId() throws InvalidUserException {
+        var meterId = "e2e-meter";
+        when(authService.getCurrentUserId()).thenReturn(USER_ID);
+        when(repository.findOutboundByUserIdAndMeterId(USER_ID, meterId)).thenReturn(List.of(outboundDataSource));
+
+        var result = dataSourceService.getOutboundDataSourcesByMeterId(meterId);
+
+        assertEquals(List.of(outboundDataSource), result);
+        verify(repository).findOutboundByUserIdAndMeterId(USER_ID, meterId);
+    }
+
+    @Test
     void shouldAddNewDataSource() throws InvalidUserException, SinapsiAlfaEmptyConfigException, SecretStoringException {
         when(authService.getCurrentUserId()).thenReturn(USER_ID);
         when(mqttConfiguration.internalHost()).thenReturn("mqtt://test-broker");

--- a/aiida/src/test/java/energy/eddie/aiida/web/DataSourceControllerTest.java
+++ b/aiida/src/test/java/energy/eddie/aiida/web/DataSourceControllerTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2024-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 package energy.eddie.aiida.web;
@@ -70,6 +70,25 @@ class DataSourceControllerTest {
                .andExpect(jsonPath("$.length()").value(1));
 
         verify(service, times(1)).getOutboundDataSources();
+    }
+
+    @Test
+    @WithMockUser
+    void getAllOutboundDataSources_withMeterId_shouldReturnFilteredListOfDataSources() throws Exception {
+        List<DataSource> dataSources = List.of(DATA_SOURCE);
+        var meterId = "e2e-meter";
+
+        when(service.getOutboundDataSourcesByMeterId(meterId)).thenReturn(dataSources);
+
+        mockMvc.perform(get("/datasources/outbound")
+                                .param("meterId", meterId)
+                                .with(csrf())
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.length()").value(1));
+
+        verify(service, times(1)).getOutboundDataSourcesByMeterId(meterId);
+        verify(service, never()).getOutboundDataSources();
     }
 
     @Test

--- a/aiida/ui/src/api.ts
+++ b/aiida/ui/src/api.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
+// SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
 // SPDX-License-Identifier: Apache-2.0
 
 import useToast from './composables/useToast'
@@ -105,8 +105,9 @@ export function getActiveInboundPermissions(): Promise<AiidaPermission[]> {
   return fetch('/permissions/inbound/active')
 }
 
-export function getDataSources(): Promise<AiidaDataSource[]> {
-  return fetch('/datasources/outbound')
+export function getDataSources(meterId?: string): Promise<AiidaDataSource[]> {
+  const query = meterId ? `?${new URLSearchParams({ meterId })}` : ''
+  return fetch(`/datasources/outbound${query}`)
 }
 
 export function getDataSourceTypes(): Promise<AiidaDataSourceType[]> {

--- a/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
+++ b/aiida/ui/src/components/Modals/UpdatePermissionModal.vue
@@ -1,7 +1,5 @@
-<!--
-SPDX-FileCopyrightText: 2025 The EDDIE Developers <eddie.developers@fh-hagenberg.at>
-SPDX-License-Identifier: Apache-2.0
--->
+<!-- SPDX-FileCopyrightText: 2025-2026 The EDDIE Developers <eddie.developers@fh-hagenberg.at> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <script setup lang="ts">
 import ModalDialog from '@/components/ModalDialog.vue'
@@ -9,11 +7,15 @@ import ModalDialog from '@/components/ModalDialog.vue'
 import Button from '@/components/Button.vue'
 import { computed, ref, watch } from 'vue'
 import PermissionDetails from '@/components/PermissionDetails.vue'
-import { acceptPermission, getActiveInboundPermissions, rejectPermission } from '@/api'
+import {
+  acceptPermission,
+  getActiveInboundPermissions,
+  getDataSources,
+  rejectPermission,
+} from '@/api'
 import { usePermissionDialog } from '@/composables/permission-dialog'
 import CustomSelect from '../CustomSelect.vue'
-import { dataSources, fetchDataSources } from '@/stores/dataSources'
-import type { AiidaPermission, AiidaSchema } from '@/types'
+import type { AiidaDataSource, AiidaPermission, AiidaSchema } from '@/types'
 import { useI18n } from 'vue-i18n'
 
 const inboundSchemas: Set<AiidaSchema> = new Set(['MIN-MAX-ENVELOPE-CIM-V1-12', 'OPAQUE'])
@@ -24,6 +26,7 @@ const modal = ref<HTMLDialogElement>()
 const loading = ref(false)
 const selectedDataSource = ref<string>('')
 const inboundPermissions = ref<AiidaPermission[]>([])
+const outboundDataSources = ref<AiidaDataSource[]>([])
 const emit = defineEmits(['update'])
 
 watch([open], async () => {
@@ -31,8 +34,12 @@ watch([open], async () => {
     selectedDataSource.value = ''
     modal.value?.showModal()
 
-    await fetchDataSources()
+    outboundDataSources.value = await getDataSources(permission.value?.meterId)
     inboundPermissions.value = await getActiveInboundPermissions()
+
+    if (dataSourceOptions.value.length === 1) {
+      selectedDataSource.value = dataSourceOptions.value[0].value
+    }
   }
 })
 
@@ -55,6 +62,7 @@ const handleModalClose = () => {
 
 const dataSourceOptions = computed(() => {
   const requestedSchemas = permission.value?.dataNeed.schemas ?? []
+  const permissionMeterId = permission.value?.meterId
   const matches: { label: string; value: string }[] = []
 
   // Request includes inbound schemas
@@ -62,7 +70,8 @@ const dataSourceOptions = computed(() => {
     for (const { dataSource } of inboundPermissions.value) {
       if (
         dataSource && // For TypeScript, even though it should always be set here
-        requestedSchemas.some((requestedSchema) => dataSource.schemas?.includes(requestedSchema))
+        requestedSchemas.some((requestedSchema) => dataSource.schemas?.includes(requestedSchema)) &&
+        (!permissionMeterId || dataSource.meterId === permissionMeterId)
       ) {
         matches.push({ label: dataSource.name, value: dataSource.id })
       }
@@ -72,7 +81,7 @@ const dataSourceOptions = computed(() => {
   // Request includes outbound schemas
   if (requestedSchemas.some((requestedSchema) => !inboundSchemas.has(requestedSchema))) {
     matches.push(
-      ...dataSources.value.map(({ id, name }) => ({
+      ...outboundDataSources.value.map(({ id, name }) => ({
         label: name,
         value: id,
       })),

--- a/e2e-tests/src/test/java/energy/eddie/e2etests/aiida/AiidaUiTests.java
+++ b/e2e-tests/src/test/java/energy/eddie/e2etests/aiida/AiidaUiTests.java
@@ -166,26 +166,21 @@ class AiidaUiTests {
     @Test
     void fcaPermissionFlow() {
         var dataSource = "E2E FCA Data Source";
+        var otherDataSource = "E2E FCA Other Data Source";
         var fcaOutboundDataNeed = "FCA Outbound";
         var meterId = "e2e-meter";
+        var otherMeterId = "e2e-meter-other";
 
-        // Create a data source to use for the FCA permission
-        page.getByRole(AriaRole.LINK).getByText("Data Sources").click();
-        page.getByRole(AriaRole.BUTTON).getByText("Add Data Source").click();
-        page.getByLabel("Name").fill(dataSource);
-        page.getByRole(AriaRole.LISTBOX).getByText("Asset Type").click();
-        page.getByRole(AriaRole.OPTION).getByText("CONNECTION-AGREEMENT-POINT").click();
-        page.getByRole(AriaRole.LISTBOX).getByText("Data Source Type").click();
-        page.getByRole(AriaRole.OPTION).getByText("Simulation").click();
-        page.getByRole(AriaRole.LISTBOX).getByText("Country").click();
-        page.getByRole(AriaRole.OPTION).getByText("Austria").click();
-        page.getByLabel("Polling Interval").fill("120");
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Meter")).click();
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add").setExact(true)).click();
+        // Create a data source matching the FCA meter ID, and one that doesn't match
+        createSimulationDataSource(dataSource, meterId);
+        createSimulationDataSource(otherDataSource, otherMeterId);
 
         // Accept an FCA outbound permission tied to the meter ID
+        // The data source with a different meter ID is not shown
+        // The matching data source with the same meter ID gets pre-selected
         var aiidaCode = aiidaCodeForDataNeedWithMeterId(fcaOutboundDataNeed, meterId);
-        var permissionId = acceptOutboundPermissionRequest(aiidaCode, dataSource);
+        var permissionId =
+                acceptOutboundPermissionRequestWithPreselectedDataSource(aiidaCode, dataSource, otherDataSource);
 
         // Attempting a second FCA outbound permission for the same meter ID must fail
         var duplicateAiidaCode = aiidaCodeForDataNeedWithMeterId(fcaOutboundDataNeed, meterId);
@@ -208,6 +203,7 @@ class AiidaUiTests {
         // Clean up
         revokePermission(permission);
         deleteDataSource(dataSource);
+        deleteDataSource(otherDataSource);
     }
 
     @Test
@@ -268,6 +264,44 @@ class AiidaUiTests {
         dialog.getByRole(AriaRole.BUTTON).getByText("Accept").click();
 
         return id;
+    }
+
+    private String acceptOutboundPermissionRequestWithPreselectedDataSource(
+            String aiidaCode, String expectedDataSource, String excludedDataSource) {
+        addPermission(aiidaCode);
+
+        var dialog = page.getByRole(AriaRole.DIALOG);
+        var id = dialog.locator(":text('Permission ID') + dd").textContent();
+        var listbox = dialog.getByRole(AriaRole.LISTBOX);
+
+        // The one data source that matches the meter ID is pre-selected
+        assertThat(listbox).containsText(expectedDataSource);
+
+        // The data source with a different meter ID is not displayed
+        listbox.click();
+        assertThat(dialog.getByRole(AriaRole.OPTION).getByText(excludedDataSource)).hasCount(0);
+        listbox.click();
+
+        assertThat(dialog.getByRole(AriaRole.BUTTON).getByText("Accept")).isEnabled();
+        dialog.getByRole(AriaRole.BUTTON).getByText("Accept").click();
+
+        return id;
+    }
+
+    private void createSimulationDataSource(String name, String meterId) {
+        page.getByRole(AriaRole.LINK).getByText("Data Sources").click();
+        page.getByRole(AriaRole.BUTTON).getByText("Add Data Source").click();
+        page.getByLabel("Name").fill(name);
+        page.getByRole(AriaRole.LISTBOX).getByText("Asset Type").click();
+        page.getByRole(AriaRole.OPTION).getByText("CONNECTION-AGREEMENT-POINT").click();
+        page.getByRole(AriaRole.LISTBOX).getByText("Data Source Type").click();
+        page.getByRole(AriaRole.OPTION).getByText("Simulation").click();
+        page.getByRole(AriaRole.LISTBOX).getByText("Country").click();
+        page.getByRole(AriaRole.OPTION).getByText("Austria").click();
+        page.getByLabel("Polling Interval").fill("120");
+        page.getByLabel("Physical Meter ID").fill(meterId);
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Meter")).click();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add").setExact(true)).click();
     }
 
     private void revokeInboundPermission(String name) {


### PR DESCRIPTION
This PR adds an optional request parameter to filter outbound data sources by their physical meter ID.
This is relevant in the context of FCAs in order to display the user the relevant data sources matching the physical meter ID.
If there is only one matching result, the data source is pre-selected.