### PR TITLE
test(e2e): Harden data source select against preselect

### DIFF
--- a/e2e-tests/src/test/java/energy/eddie/e2etests/aiida/AiidaUiTests.java
+++ b/e2e-tests/src/test/java/energy/eddie/e2etests/aiida/AiidaUiTests.java
@@ -260,7 +260,7 @@ class AiidaUiTests {
         var dialog = page.getByRole(AriaRole.DIALOG);
         var id = dialog.locator(":text('Permission ID') + dd").textContent();
 
-        dialog.getByRole(AriaRole.LISTBOX).getByText("Select Data Source").click();
+        dialog.getByRole(AriaRole.LISTBOX).click();
         dialog.getByRole(AriaRole.OPTION).getByText(dataSource).first().click();
 
         dialog.getByRole(AriaRole.BUTTON).getByText("Accept").click();


### PR DESCRIPTION
Fixes a regression in our AIIDA E2E tests where the UI fails due to not being able to select the right data source if it was preselected as the only applicable data source.